### PR TITLE
fix: redirect url login

### DIFF
--- a/acbc_app/academia_blockchain/settings.py
+++ b/acbc_app/academia_blockchain/settings.py
@@ -227,7 +227,7 @@ SOCIALACCOUNT_PROVIDERS = {
 # Other config
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 LOGIN_URL = "profile_register"
-LOGIN_REDIRECT_URL = "set_jwt_token"
+LOGIN_REDIRECT_URL = "profiles:set_jwt_token"
 LOGOUT_REDIRECT_URL = "event_index"
 LANGUAGE_CODE = "en-us"
 SEND_EMAILS = False

--- a/acbc_app/academia_blockchain/urls.py
+++ b/acbc_app/academia_blockchain/urls.py
@@ -21,7 +21,7 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('accounts/', include('allauth.urls')),
+    path('api/accounts/', include('allauth.urls')),
     path('api/profiles/', include('profiles.urls', namespace='profiles')),
     path('api/content/', include('content.urls', namespace='content')),
     path('api/events/', include('events.urls', namespace='events')),


### PR DESCRIPTION
- Change the redirect URL for the login to point to `profiles:set_jwt_token` instead of the previous URL.
- Move the Django Allauth URLs to the `api/accounts/` namespace.