### PR TITLE
Mitigar pantalla blanca en Telegram bloqueando la ruta raíz

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -73,6 +73,51 @@ const ContentIdRedirect = () => {
   return <Navigate to={`/content/${contentId}/library`} replace />;
 };
 
+const isTelegramInAppBrowser = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const ua = navigator.userAgent || '';
+  return Boolean(
+    window.TelegramWebview ||
+    window.TelegramWebviewProxy ||
+    window.TelegramWebviewProxyProto ||
+    /Telegram/i.test(ua)
+  );
+};
+
+const TelegramNotSupportedMessage = () => (
+  <main
+    style={{
+      minHeight: '70vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '24px',
+    }}
+  >
+    <section
+      style={{
+        maxWidth: '640px',
+        width: '100%',
+        border: '1px solid #d9d9d9',
+        borderRadius: '12px',
+        padding: '24px',
+        background: '#fff',
+        boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)',
+      }}
+    >
+      <h1 style={{ marginTop: 0, marginBottom: '12px' }}>
+        Esta app no está disponible en el navegador de Telegram
+      </h1>
+      <p style={{ margin: 0, lineHeight: 1.5 }}>
+        Para continuar, abre este enlace en tu navegador externo (Safari, Chrome u otro).
+      </p>
+    </section>
+  </main>
+);
+
 const AppContent = () => {
   const { theme } = useThemeMode();
   
@@ -83,7 +128,10 @@ const AppContent = () => {
         <AuthProvider>
           <Routes>
           <Route element={<MainLayout />}>
-            <Route path="/" element={<Home />} />
+            <Route
+              path="/"
+              element={isTelegramInAppBrowser() ? <TelegramNotSupportedMessage /> : <Home />}
+            />
             <Route path="unirme" element={<NewsletterSubscribe />} />
             <Route path="profiles">
               <Route path="login" element={

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -112,7 +112,7 @@ const TelegramNotSupportedMessage = () => (
         Esta app no está disponible en el navegador de Telegram
       </h1>
       <p style={{ margin: 0, lineHeight: 1.5 }}>
-        Para continuar, abre este enlace en tu navegador externo (Safari, Chrome u otro).
+        Por favor, ábrela en tu navegador externo (Safari, Chrome u otro).
       </p>
     </section>
   </main>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen
Este cambio añade una mitigación en la ruta raíz (`/`) para evitar la experiencia de pantalla blanca dentro del navegador embebido de Telegram.

## Qué se cambió
- Se agregó una detección de entorno Telegram in-app browser en `frontend/src/App.jsx`.
- Se creó un componente de mensaje informativo (`TelegramNotSupportedMessage`).
- La ruta `/` ahora renderiza:
  - el mensaje informativo si se detecta Telegram,
  - `Home` en cualquier otro navegador.

## Alcance
- Solo afecta la ruta `/`.
- No modifica el comportamiento de otras rutas ni flujos de autenticación en esta iteración.

## Nota de validación
- No se pudo ejecutar `vite build` en este entorno porque falta `vite` en PATH (`sh: 1: vite: not found`).
- El cambio es acotado y compilable a nivel sintáctico en el archivo modificado, pero queda pendiente validación CI/local con dependencias instaladas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee781e0a-5fe1-4d75-be52-caef08157c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee781e0a-5fe1-4d75-be52-caef08157c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

