### PR TITLE
fix(content): widen FileDetails.file for long S3 keys

### DIFF
--- a/acbc_app/content/migrations/0009_alter_filedetails_file_max_length.py
+++ b/acbc_app/content/migrations/0009_alter_filedetails_file_max_length.py
@@ -1,0 +1,24 @@
+# Generated manually: widen FileDetails.file for full S3 keys (default was varchar(100))
+
+import content.models
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('content', '0008_rename_content_file_content_58ff3f_idx_content_fil_content_32a911_idx_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='filedetails',
+            name='file',
+            field=models.FileField(
+                blank=True,
+                max_length=512,
+                null=True,
+                upload_to=content.models.content_file_upload_path,
+            ),
+        ),
+    ]

--- a/acbc_app/content/models.py
+++ b/acbc_app/content/models.py
@@ -191,7 +191,12 @@ def file_suggestion_upload_path(instance, filename):
 class FileDetails(models.Model):
     """Handles file storage and content analysis"""
     content = models.OneToOneField(Content, on_delete=models.CASCADE, related_name='file_details')
-    file = models.FileField(upload_to=content_file_upload_path, blank=True, null=True)  # Optional for URL content
+    file = models.FileField(
+        upload_to=content_file_upload_path,
+        blank=True,
+        null=True,
+        max_length=512,
+    )  # Optional for URL content; S3 keys exceed Django's default 100 chars
     file_size = models.PositiveBigIntegerField(blank=True, null=True)  # BigInteger for files > 2GB
     
     # Text analysis (for text-based content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Set `FileDetails.file` `max_length` to **512** so full S3 object keys (presign flow) fit in the database. Django’s `FileField` default is 100 characters, which caused `value too long for type character varying(100)` on `POST /api/content/upload-content/confirm/`.
- Added migration `0009_alter_filedetails_file_max_length`.

## Deploy notes
Run migrations in production: `python manage.py migrate content` (or full `migrate`).

## Testing
- Not run (Django not installed in this agent environment). Migration file matches the model change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-296f74ec-ef7b-402b-88d8-9e8c22c73675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-296f74ec-ef7b-402b-88d8-9e8c22c73675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

