### PR TITLE
fix(content): allow long S3 keys in FileDetails.file (varchar 100 → 512)

### DIFF
--- a/acbc_app/content/migrations/0009_alter_filedetails_file_alter_filesuggestion_file.py
+++ b/acbc_app/content/migrations/0009_alter_filedetails_file_alter_filesuggestion_file.py
@@ -1,0 +1,32 @@
+# Generated manually: FileField default max_length=100 was too short for S3 keys
+
+import content.models
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('content', '0008_rename_content_file_content_58ff3f_idx_content_fil_content_32a911_idx_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='filedetails',
+            name='file',
+            field=models.FileField(
+                blank=True,
+                max_length=512,
+                null=True,
+                upload_to=content.models.content_file_upload_path,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='filesuggestion',
+            name='file',
+            field=models.FileField(
+                max_length=512,
+                upload_to=content.models.file_suggestion_upload_path,
+            ),
+        ),
+    ]

--- a/acbc_app/content/models.py
+++ b/acbc_app/content/models.py
@@ -191,7 +191,12 @@ def file_suggestion_upload_path(instance, filename):
 class FileDetails(models.Model):
     """Handles file storage and content analysis"""
     content = models.OneToOneField(Content, on_delete=models.CASCADE, related_name='file_details')
-    file = models.FileField(upload_to=content_file_upload_path, blank=True, null=True)  # Optional for URL content
+    file = models.FileField(
+        upload_to=content_file_upload_path,
+        blank=True,
+        null=True,
+        max_length=512,
+    )  # Optional for URL content; path includes S3 key (uuid + long filename)
     file_size = models.PositiveBigIntegerField(blank=True, null=True)  # BigInteger for files > 2GB
     
     # Text analysis (for text-based content)
@@ -374,7 +379,7 @@ class FileSuggestion(models.Model):
         User, on_delete=models.SET_NULL, null=True, blank=True, related_name='reviewed_file_suggestions'
     )
 
-    file = models.FileField(upload_to=file_suggestion_upload_path)
+    file = models.FileField(upload_to=file_suggestion_upload_path, max_length=512)
     file_size = models.PositiveBigIntegerField(blank=True, null=True)
     message = models.TextField(blank=True, null=True)
     rejection_reason = models.TextField(blank=True, null=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Confirm upload after S3 PUT failed with `value too long for type character varying(100)`. The presigned key (e.g. `content/document/2/{uuid}_Very_Long_Filename.pdf`) can exceed 100 characters while Django `FileField` defaults to `max_length=100`.

## Change
- Set `max_length=512` on `FileDetails.file` and `FileSuggestion.file`.
- Migration `0009_alter_filedetails_file_alter_filesuggestion_file`.

## Deploy
Run migrations in production after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76abb892-d00b-4a61-b014-46d21c7e1a7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76abb892-d00b-4a61-b014-46d21c7e1a7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

