### PR TITLE
Log URL preview HTTP errors as warning (reduce Sentry noise)

### DIFF
--- a/acbc_app/content/views.py
+++ b/acbc_app/content/views.py
@@ -2494,7 +2494,7 @@ class URLPreviewView(APIView):
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError as e:
-                logger.error(
+                logger.warning(
                     f"URL preview HTTP error: {str(e)}",
                     extra={
                         'user_id': user_id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When a remote URL returns a non-success status (e.g. 418 from Invidious), the preview endpoint already responds with HTTP 400 to the client. Logging that case at ERROR caused Sentry to open an issue for every such URL.

This change logs those handled HTTP failures at WARNING so they still appear in application logs and Sentry breadcrumbs (INFO+) without creating ERROR-level events.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f480bee6-dd12-4fc0-b586-81d9c2292238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f480bee6-dd12-4fc0-b586-81d9c2292238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

