### PR TITLE
Fix intermittent SSL mismatch on www domain

### DIFF
--- a/DEPLOYMENT_QUICK_START.md
+++ b/DEPLOYMENT_QUICK_START.md
@@ -72,6 +72,7 @@
    ```bash
    # 1) Set ALLOWED_HOSTS in acbc_app/.env (yourdomain.com,www.yourdomain.com,...)
    # 2) Get certificate and generate SSL config (gitignored)
+   #    If you pass your apex domain, it also includes www automatically.
    ./scripts/setup-ssl.sh yourdomain.com
    # 3) One rebuild
    ./scripts/deploy.sh
@@ -155,6 +156,7 @@ To serve the app at a custom URL (e.g. `https://academia.yourdomain.com`):
 **4. HTTPS (recommended)**
 
 - Certificates are from **Let's Encrypt** (free; https://letsencrypt.org). The script **does not change any tracked file**: it generates **nginx/nginx-ssl.conf** (gitignored) on the server.
+- The certificate includes SANs for the hostname passed plus related apex/`www` variant (e.g., passing `yourdomain.com` includes `www.yourdomain.com`; passing `www.yourdomain.com` includes `yourdomain.com`).
 - After DNS points to the droplet, set **ALLOWED_HOSTS** in `acbc_app/.env`, then run setup-ssl, then deploy once (one rebuild):
 
   ```bash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -96,6 +96,11 @@ chmod +x scripts/setup-ssl.sh
 ./scripts/setup-ssl.sh yourdomain.com [email@example.com]
 ```
 
+**Domain coverage behavior:**
+- If you pass an apex domain (e.g. `yourdomain.com`), the certificate includes both `yourdomain.com` and `www.yourdomain.com`.
+- If you pass a `www` domain (e.g. `www.yourdomain.com`), the certificate also includes the apex `yourdomain.com`.
+- If you pass a subdomain (e.g. `api.yourdomain.com`), only that hostname is included.
+
 **What it does:**
 - Installs Certbot if needed
 - Generates SSL certificate for your domain

--- a/scripts/setup-ssl.sh
+++ b/scripts/setup-ssl.sh
@@ -14,15 +14,36 @@ echo "🔒 Setting up SSL with Let's Encrypt..."
 
 if [ -z "$1" ]; then
     echo "Usage: ./scripts/setup-ssl.sh <your-domain.com> [email]"
-    echo "Example: ./scripts/setup-ssl.sh academia.example.com admin@example.com"
+    echo "Example: ./scripts/setup-ssl.sh academiablockchain.com admin@academiablockchain.com"
     exit 1
 fi
 
 DOMAIN=$1
 EMAIL=${2:-"admin@${DOMAIN}"}
+DOT_COUNT=$(awk -F'.' '{print NF-1}' <<< "$DOMAIN")
+
+# Build certificate SANs:
+# - If apex domain is provided (example.com), include www.example.com automatically.
+# - If www domain is provided, include the apex domain too.
+DOMAINS=("$DOMAIN")
+if [[ "$DOMAIN" == www.* ]]; then
+    APEX_DOMAIN="${DOMAIN#www.}"
+    DOMAINS+=("$APEX_DOMAIN")
+elif [ "$DOT_COUNT" -eq 1 ]; then
+    DOMAINS+=("www.$DOMAIN")
+fi
+
+# Deduplicate in case values overlap
+UNIQUE_DOMAINS=()
+for d in "${DOMAINS[@]}"; do
+    if [[ ! " ${UNIQUE_DOMAINS[*]} " =~ " $d " ]]; then
+        UNIQUE_DOMAINS+=("$d")
+    fi
+done
 
 echo "Domain: $DOMAIN"
 echo "Email: $EMAIL"
+echo "Certificate domains (SAN): ${UNIQUE_DOMAINS[*]}"
 echo "Certificate: Let's Encrypt (free, from https://letsencrypt.org)"
 
 if ! command -v certbot &> /dev/null; then
@@ -35,8 +56,13 @@ echo "Stopping nginx briefly for certificate issuance..."
 docker compose -f docker-compose.prod.yml stop nginx 2>/dev/null || true
 
 echo "Obtaining certificate (certbot standalone)..."
+CERTBOT_DOMAIN_ARGS=()
+for d in "${UNIQUE_DOMAINS[@]}"; do
+    CERTBOT_DOMAIN_ARGS+=("-d" "$d")
+done
+
 sudo certbot certonly --standalone \
-    -d "$DOMAIN" \
+    "${CERTBOT_DOMAIN_ARGS[@]}" \
     --email "$EMAIL" \
     --agree-tos \
     --non-interactive


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes SSL issuance so `scripts/setup-ssl.sh` requests certificates with SANs for both apex and `www` when appropriate.
- If you run with `academiablockchain.com`, the script now requests both:
  - `academiablockchain.com`
  - `www.academiablockchain.com`
- If you run with `www.example.com`, it also includes `example.com`.
- Updates deployment docs to explicitly mention this behavior.

## Root cause
The previous SSL flow requested a certificate for only one hostname (`-d <domain>`). If users visited the alternate host (especially `www`), browsers validated against a cert without that SAN and showed `NET::ERR_CERT_COMMON_NAME_INVALID`.

## Files changed
- `scripts/setup-ssl.sh`
- `scripts/README.md`
- `DEPLOYMENT_QUICK_START.md`

## Validation
- Confirmed live certificate for `academiablockchain.com` currently includes only `academiablockchain.com` SAN and fails hostname verification on `www.academiablockchain.com`.
- Lint/syntax check: `bash -n scripts/setup-ssl.sh` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64e322fd-8dea-4b2a-b673-41ef93fcdb4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64e322fd-8dea-4b2a-b673-41ef93fcdb4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

