### PR TITLE
fix(auth): Google login 401 when Bearer token present from failed login

### DIFF
--- a/acbc_app/profiles/views.py
+++ b/acbc_app/profiles/views.py
@@ -849,6 +849,8 @@ class GoogleLoginView(SocialLoginView):
     """
     Handles Google OAuth authentication and JWT token generation.
     """
+    permission_classes = [AllowAny]
+    authentication_classes = []
     adapter_class = GoogleOAuth2Adapter
     client_class = OAuth2Client
     callback_url = None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After a failed username/password login, Google sign-in could return **401** with axios’s generic message (`Request failed with status code 401`).

## Root cause

`REST_FRAMEWORK` defaults to `JWTAuthentication` + `IsAuthenticated`. `GoogleLoginView` did not override permissions, so any request that still carried `Authorization: Bearer <token>` from `localStorage` (e.g. an expired session from a previous visit) was authenticated by JWT first; an invalid/expired token yields **401** before the Google login handler runs.

Failed password login does not clear `access_token`, so the stale header stayed on the next request to `/api/rest-auth/google/login/`.

## Fix

Set `permission_classes = [AllowAny]` and `authentication_classes = []` on `GoogleLoginView`, matching the existing pattern on `LoginView` for `/profiles/login/`.

## Testing

- `python3 manage.py test profiles.tests` was run; 5 failures appear unrelated (suggestion email mocks). No new failures attributable to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bc38e08-8df0-428b-890d-5ef86035bed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bc38e08-8df0-428b-890d-5ef86035bed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

