### PR TITLE
fix(auth): long-lived sessions (refresh cookie max_age, checkAuth refresh, JWT lifetimes)

### DIFF
--- a/acbc_app/academia_blockchain/settings.py
+++ b/acbc_app/academia_blockchain/settings.py
@@ -522,8 +522,10 @@ ACCOUNT_USER_MODEL_USERNAME_FIELD = 'username'
 ACCOUNT_EMAIL_SUBJECT_PREFIX = 'Academia Blockchain - '
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=15),  # 15 minutes
-    'REFRESH_TOKEN_LIFETIME': timedelta(days=30),    # 30 days
+    # Short-lived access token; session length is governed by the refresh cookie + lifetime below.
+    'ACCESS_TOKEN_LIFETIME': timedelta(hours=24),
+    # Refresh cookie max_age matches this; users stay signed in until logout or expiry (~1 month).
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=30),
     'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': True,
     'ALGORITHM': 'HS256',

--- a/acbc_app/profiles/tests.py
+++ b/acbc_app/profiles/tests.py
@@ -463,6 +463,21 @@ class AuthenticationTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('acbc_refresh_token', response.cookies)
 
+    def test_login_sets_refresh_cookie_max_age(self):
+        """Refresh cookie must use max_age so the browser keeps it across restarts (not a session cookie)."""
+        cache.delete('login_attempts_127.0.0.1')
+        url = reverse('profiles:login')
+        response = self.client.post(
+            url,
+            {'username': self.user_data['username'], 'password': self.user_data['password']},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cookie = response.cookies.get(settings.SIMPLE_JWT['REFRESH_COOKIE'])
+        self.assertIsNotNone(cookie)
+        expected = int(settings.SIMPLE_JWT['REFRESH_TOKEN_LIFETIME'].total_seconds())
+        self.assertEqual(int(cookie.get('max-age')), expected)
+
     def test_check_auth_unauthenticated(self):
         """Test authentication check for unauthenticated user."""
         url = reverse('profiles:check_auth')

--- a/acbc_app/profiles/views.py
+++ b/acbc_app/profiles/views.py
@@ -47,6 +47,25 @@ from django.db.models import Count
 logger = logging.getLogger(__name__)
 
 
+def set_refresh_token_cookie(response, refresh_token: str) -> None:
+    """
+    Persist the refresh token in a browser cookie with max_age aligned to SIMPLE_JWT.
+
+    Without max_age, browsers treat the cookie as a session cookie and drop it when
+    the browser closes, which makes logins feel short-lived despite a long JWT lifetime.
+    """
+    max_age = int(settings.SIMPLE_JWT['REFRESH_TOKEN_LIFETIME'].total_seconds())
+    response.set_cookie(
+        settings.SIMPLE_JWT['REFRESH_COOKIE'],
+        refresh_token,
+        max_age=max_age,
+        httponly=True,
+        secure=settings.SIMPLE_JWT['AUTH_COOKIE_SECURE'],
+        samesite=settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE'],
+        path=settings.SIMPLE_JWT['AUTH_COOKIE_PATH'],
+    )
+
+
 class NewsletterSubscriptionForm(forms.Form):
     email = forms.EmailField(
         label="Email",
@@ -609,15 +628,7 @@ class LoginView(APIView):
 
                 response = Response(response_data)
 
-                # Set refresh token in HTTP-only cookie
-                response.set_cookie(
-                    settings.SIMPLE_JWT['REFRESH_COOKIE'],
-                    refresh_token,
-                    httponly=True,
-                    secure=settings.SIMPLE_JWT['AUTH_COOKIE_SECURE'],
-                    samesite=settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE'],
-                    path=settings.SIMPLE_JWT['AUTH_COOKIE_PATH'],
-                )
+                set_refresh_token_cookie(response, refresh_token)
 
                 return response
             except Exception as e:
@@ -749,15 +760,7 @@ class RegisterView(APIView):
 
                 response = Response(response_data, status=status.HTTP_201_CREATED)
 
-                # Set refresh token in HTTP-only cookie (same as login endpoint)
-                response.set_cookie(
-                    settings.SIMPLE_JWT['REFRESH_COOKIE'],
-                    refresh_token,
-                    httponly=True,
-                    secure=settings.SIMPLE_JWT['AUTH_COOKIE_SECURE'],
-                    samesite=settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE'],
-                    path=settings.SIMPLE_JWT['AUTH_COOKIE_PATH'],
-                )
+                set_refresh_token_cookie(response, refresh_token)
                 # TODO: Implement email activation sending here if needed
                 return response
             except Exception as e:
@@ -821,14 +824,7 @@ class RefreshTokenView(APIView):
                         refresh.blacklist()
                     except Exception:
                         logger.debug("Refresh token blacklist skipped (blacklist app may be disabled)")
-                response.set_cookie(
-                    settings.SIMPLE_JWT['REFRESH_COOKIE'],
-                    str(new_refresh),
-                    httponly=True,
-                    secure=settings.SIMPLE_JWT['AUTH_COOKIE_SECURE'],
-                    samesite=settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE'],
-                    path=settings.SIMPLE_JWT['AUTH_COOKIE_PATH'],
-                )
+                set_refresh_token_cookie(response, str(new_refresh))
             return response
 
         except TokenError as e:
@@ -849,6 +845,8 @@ class GoogleLoginView(SocialLoginView):
     """
     Handles Google OAuth authentication and JWT token generation.
     """
+    permission_classes = [AllowAny]
+    authentication_classes = []
     adapter_class = GoogleOAuth2Adapter
     client_class = OAuth2Client
     callback_url = None
@@ -1050,15 +1048,7 @@ class GoogleLoginView(SocialLoginView):
 
             response = Response(response_data)
 
-            # Set refresh token in HTTP-only cookie
-            response.set_cookie(
-                settings.SIMPLE_JWT['REFRESH_COOKIE'],
-                refresh_token,
-                httponly=True,
-                secure=settings.SIMPLE_JWT['AUTH_COOKIE_SECURE'],
-                samesite=settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE'],
-                path=settings.SIMPLE_JWT['AUTH_COOKIE_PATH'],
-            )
+            set_refresh_token_cookie(response, refresh_token)
             logger.info(f"Successfully completed Google login process for user {request.user.username if request.user.is_authenticated else 'anonymous'}")
             return response
         except Exception as e:

--- a/frontend/src/api/axiosConfig.js
+++ b/frontend/src/api/axiosConfig.js
@@ -60,13 +60,12 @@ axiosInstance.interceptors.response.use(
     // 2. The request has already been retried
     // 3. The request is for the refresh token endpoint
     // 4. The request is for the logout endpoint
-    // 5. The request is for the check_auth endpoint (to avoid infinite loops)
+    // 5. (check_auth is not excluded: a stale Bearer must refresh so startup auth can recover.)
     if (error.response?.status !== 401 || 
         !accessToken ||
         originalRequest._retry || 
         originalRequest.url === '/profiles/refresh_token/' ||
-        originalRequest.url === '/profiles/logout/' ||
-        originalRequest.url === '/profiles/check_auth/') {
+        originalRequest.url === '/profiles/logout/') {
       return Promise.reject(error);
     }
 

--- a/frontend/src/api/profilesApi.js
+++ b/frontend/src/api/profilesApi.js
@@ -12,12 +12,26 @@ const checkAuth = async () => {
     }
 
     const response = await axiosInstance.get('/profiles/check_auth/');
-    
+
     if (response.status === 200) {
-      return response.data.is_authenticated === true;
+      if (response.data.is_authenticated === true) {
+        return true;
+      }
+      // Access token missing/expired but HTTP-only refresh cookie still present: mint a new access token.
+      if (response.data.reason === 'refresh_token_present_requires_refresh') {
+        const refreshResponse = await axiosInstance.post('/profiles/refresh_token/');
+        const { access_token } = refreshResponse.data;
+        if (access_token) {
+          localStorage.setItem('access_token', access_token);
+          axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${access_token}`;
+        }
+        const retry = await axiosInstance.get('/profiles/check_auth/');
+        return retry.status === 200 && retry.data.is_authenticated === true;
+      }
+      return false;
     }
     return false;
-  } catch(error) {
+  } catch (error) {
     return false;
   }
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why “automatic refresh” did not feel automatic

1. **`/profiles/check_auth/` was excluded from the axios 401 retry path.** After the access token expired, `check_auth` returned **401** (invalid Bearer). The interceptor bailed out without calling `/profiles/refresh_token/`, so startup auth never recovered from an expired access token alone.

2. **Refresh cookies had no `max_age`.** Browsers then treat them as **session cookies**: they disappear when the user closes the browser, regardless of the JWT’s 30-day lifetime. That makes every new browser session look like “I have to log in again”.

3. **Optional gap:** If `localStorage` had no `access_token` but the refresh cookie was still valid, `checkAuth` never called refresh. The client now refreshes when the API returns `reason: refresh_token_present_requires_refresh`.

## Changes

- **`set_refresh_token_cookie`**: set `max_age` to `REFRESH_TOKEN_LIFETIME` seconds for login, register, refresh rotation, and Google login.
- **`SIMPLE_JWT`**: `ACCESS_TOKEN_LIFETIME` **24 hours** (fewer rotations); `REFRESH_TOKEN_LIFETIME` remains **30 days** (~1 month without re-entering credentials while the cookie survives).
- **`axiosConfig.js`**: stop excluding `check_auth` from the 401 → refresh → retry flow.
- **`profilesApi.checkAuth`**: if the backend reports a refresh cookie without an active access session, POST `refresh_token` then re-check.
- **`GoogleLoginView`**: `AllowAny` + empty `authentication_classes` (same fix as the Google 401 issue when a stale Bearer is sent).

## Tests

- `python3 manage.py test profiles.tests.AuthenticationTests profiles.tests.TokenRefreshTest`

## Note

True “stay logged in for a month” requires the **refresh cookie** to remain (same browser profile, no manual cookie clear, `SameSite`/cross-site rules respected). Access tokens can still be rotated silently without asking the user for a password.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bc38e08-8df0-428b-890d-5ef86035bed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bc38e08-8df0-428b-890d-5ef86035bed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

