### PR TITLE
Paginación en la biblioteca de contenido del usuario

### DIFF
--- a/acbc_app/content/tests.py
+++ b/acbc_app/content/tests.py
@@ -728,6 +728,77 @@ class ContentAPITests(APITestCase):
         content_count = Content.objects.filter(url=url).count()
         self.assertEqual(content_count, 2)
 
+
+class UserLibraryWithDetailsAPITests(APITestCase):
+    """Tests for paginated GET /api/content/user-content-with-details/."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='libraryowner',
+            email='library@example.com',
+            password='testpass123',
+        )
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse('content:user-content-with-details')
+
+    def test_pagination_shape_and_page_size(self):
+        for i in range(15):
+            c = Content.objects.create(
+                uploaded_by=self.user,
+                media_type='IMAGE',
+                original_title=f'Img {i}',
+            )
+            ContentProfile.objects.create(
+                content=c,
+                user=self.user,
+                title=f'Title {i}',
+            )
+        r = self.client.get(self.url, {'page': 1, 'page_size': 5})
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(r.data['count'], 15)
+        self.assertEqual(r.data['current_page'], 1)
+        self.assertEqual(r.data['total_pages'], 3)
+        self.assertEqual(len(r.data['results']), 5)
+
+        r2 = self.client.get(self.url, {'page': 2, 'page_size': 5})
+        self.assertEqual(r2.status_code, status.HTTP_200_OK)
+        self.assertEqual(r2.data['current_page'], 2)
+        self.assertEqual(len(r2.data['results']), 5)
+
+    def test_media_type_filter(self):
+        c_img = Content.objects.create(
+            uploaded_by=self.user,
+            media_type='IMAGE',
+            original_title='A',
+        )
+        c_vid = Content.objects.create(
+            uploaded_by=self.user,
+            media_type='VIDEO',
+            original_title='B',
+        )
+        ContentProfile.objects.create(content=c_img, user=self.user, title='p1')
+        ContentProfile.objects.create(content=c_vid, user=self.user, title='p2')
+        r = self.client.get(self.url, {'media_type': 'VIDEO'})
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(r.data['count'], 1)
+        self.assertEqual(r.data['results'][0]['content']['media_type'], 'VIDEO')
+
+    def test_search_query(self):
+        c = Content.objects.create(
+            uploaded_by=self.user,
+            media_type='TEXT',
+            original_title='UniqueOriginalXYZ',
+        )
+        ContentProfile.objects.create(
+            content=c,
+            user=self.user,
+            title='Other',
+        )
+        r = self.client.get(self.url, {'search': 'UniqueOriginalXYZ'})
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(r.data['count'], 1)
+
+
 class LibraryAPITests(APITestCase):
     """Test suite for Library API endpoints"""
     

--- a/acbc_app/content/views.py
+++ b/acbc_app/content/views.py
@@ -1,5 +1,6 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.pagination import PageNumberPagination
 from rest_framework import status
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated, AllowAny
@@ -931,34 +932,64 @@ class UserContentListView(APIView):
             )
 
 
+class UserLibraryPagination(PageNumberPagination):
+    """Paginated user library list (aligned with search API shape for the frontend)."""
+    page_size = 12
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+
+    def get_paginated_response(self, data):
+        return Response({
+            'count': self.page.paginator.count,
+            'current_page': self.page.number,
+            'total_pages': self.page.paginator.num_pages,
+            'results': data,
+        })
+
+
 class UserContentWithDetailsView(APIView):
-    """API view to retrieve all content profiles owned by a user with file details for card mode display."""
+    """Paginated list of the current user's content profiles with file details for library display."""
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
         try:
-            content_profiles = ContentProfile.objects.filter(user=request.user)\
-                .select_related('content', 'content__file_details')\
-                .order_by('-created_at')
-            
-            # Serialize each profile individually to handle errors gracefully
+            queryset = ContentProfile.objects.filter(user=request.user).select_related(
+                'content', 'content__file_details'
+            ).order_by('-created_at')
+
+            media_type = (request.query_params.get('media_type') or 'ALL').upper()
+            if media_type != 'ALL':
+                queryset = queryset.filter(content__media_type=media_type)
+
+            search = (request.query_params.get('search') or '').strip()
+            if search:
+                queryset = queryset.filter(
+                    Q(title__icontains=search)
+                    | Q(author__icontains=search)
+                    | Q(personal_note__icontains=search)
+                    | Q(content__original_title__icontains=search)
+                    | Q(content__media_type__icontains=search)
+                )
+
+            paginator = UserLibraryPagination()
+            page = paginator.paginate_queryset(queryset, request)
+
             response_data = []
-            for profile in content_profiles:
+            for profile in page:
                 try:
                     serializer = ContentProfileSerializer(
-                        profile, 
-                        context={'request': request}
+                        profile,
+                        context={'request': request},
                     )
                     response_data.append(serializer.data)
-                except Exception as e:
-                    # Skip this profile instead of failing the entire request
+                except Exception:
                     continue
-            
-            return Response(response_data, status=status.HTTP_200_OK)
-        except Exception as e:
+
+            return paginator.get_paginated_response(response_data)
+        except Exception:
             return Response(
-                {'error': 'Ocurrio un error al obtener el contenido'}, 
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                {'error': 'Ocurrio un error al obtener el contenido'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
 

--- a/frontend/src/api/contentApi.js
+++ b/frontend/src/api/contentApi.js
@@ -14,9 +14,21 @@ const contentApi = {
         }
     },
 
-    getUserContentWithDetails: async () => {
+    getUserContentWithDetails: async (params = {}) => {
         try {
-            const response = await axiosInstance.get('/content/user-content-with-details/');
+            const query = {
+                page: params.page ?? 1,
+                page_size: params.page_size ?? 12,
+            };
+            if (params.media_type && params.media_type !== 'ALL') {
+                query.media_type = params.media_type;
+            }
+            if (params.search) {
+                query.search = params.search;
+            }
+            const response = await axiosInstance.get('/content/user-content-with-details/', {
+                params: query,
+            });
             return response.data;
         } catch (error) {
             console.error('Error fetching user content with details:', error);

--- a/frontend/src/content/LibraryUser.jsx
+++ b/frontend/src/content/LibraryUser.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, useMemo } from "react";
+import React, { useState, useEffect, useContext, useCallback } from "react";
 import {
   Box,
   Typography,
@@ -8,6 +8,7 @@ import {
   Button,
   TextField,
   InputAdornment,
+  TablePagination,
 } from "@mui/material";
 import NoteIcon from "@mui/icons-material/Note";
 import SearchIcon from "@mui/icons-material/Search";
@@ -18,10 +19,7 @@ import { resolveMediaUrl } from "../utils/fileUtils";
 import { AuthContext } from "../context/AuthContext";
 import ContentDisplay from "./ContentDisplay";
 
-const fetchUserContentWithDetails = async () => {
-  const data = await contentApi.getUserContentWithDetails();
-  return Array.isArray(data) ? data.filter((item) => item && item.content) : [];
-};
+const DEFAULT_PAGE_SIZE = 12;
 
 const LibraryUser = () => {
   const [userContent, setUserContent] = useState([]);
@@ -29,97 +27,95 @@ const LibraryUser = () => {
   const [error, setError] = useState(null);
   const [mediaFilter, setMediaFilter] = useState("ALL");
   const [searchQuery, setSearchQuery] = useState("");
+  const [searchDebounced, setSearchDebounced] = useState("");
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_PAGE_SIZE);
+  const [totalCount, setTotalCount] = useState(0);
   const navigate = useNavigate();
   const { authState } = useContext(AuthContext);
   const currentUser = authState.user;
   const isAuthenticated = authState.isAuthenticated;
 
   useEffect(() => {
-    const loadContent = async () => {
-      if (!isAuthenticated) {
-        setLoading(false);
-        return;
-      }
-      try {
-        setLoading(true);
-        setError(null);
-        const validContent = await fetchUserContentWithDetails();
-        setUserContent(validContent);
-      } catch (err) {
-        setError(
-          err.response?.data?.error || err.message || "Error al obtener el contenido"
-        );
-      } finally {
-        setLoading(false);
-      }
-    };
-    loadContent();
-  }, [isAuthenticated]);
+    const t = setTimeout(() => {
+      setSearchDebounced(searchQuery.trim());
+    }, 400);
+    return () => clearTimeout(t);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [mediaFilter, searchDebounced]);
+
+  const loadLibraryPage = useCallback(async () => {
+    if (!isAuthenticated) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await contentApi.getUserContentWithDetails({
+        page: page + 1,
+        page_size: rowsPerPage,
+        media_type: mediaFilter,
+        search: searchDebounced,
+      });
+      const results = Array.isArray(data?.results)
+        ? data.results.filter((item) => item && item.content)
+        : [];
+      setUserContent(results);
+      setTotalCount(typeof data?.count === "number" ? data.count : 0);
+    } catch (err) {
+      setError(
+        err.response?.data?.error || err.message || "Error al obtener el contenido"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [isAuthenticated, page, rowsPerPage, mediaFilter, searchDebounced]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setLoading(false);
+      return;
+    }
+    loadLibraryPage();
+  }, [isAuthenticated, loadLibraryPage]);
 
   const handleFilterChange = (event, newFilter) => {
     setMediaFilter(newFilter || "ALL");
   };
 
-  const filteredContent = useMemo(() => {
-    let result = userContent.filter((contentProfile) => {
-      if (!contentProfile || !contentProfile.content) return false;
-      return (
-        mediaFilter === "ALL" || contentProfile.content.media_type === mediaFilter
-      );
-    });
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
 
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase().trim();
-      result = result.filter((contentProfile) => {
-        const title = (contentProfile.title || "").toLowerCase();
-        const author = (contentProfile.author || "").toLowerCase();
-        const note = (contentProfile.personal_note || "").toLowerCase();
-        const originalTitle = (contentProfile.content?.original_title || "").toLowerCase();
-        const mediaType = (contentProfile.content?.media_type || "").toLowerCase();
-        return (
-          title.includes(query) ||
-          author.includes(query) ||
-          note.includes(query) ||
-          originalTitle.includes(query) ||
-          mediaType.includes(query)
-        );
-      });
-    }
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
 
-    return result;
-  }, [userContent, mediaFilter, searchQuery]);
-
-  if (loading) return <Typography color="text.primary">Cargando contenido...</Typography>;
+  if (loading && userContent.length === 0 && !error)
+    return <Typography color="text.primary">Cargando contenido...</Typography>;
   if (error)
     return (
       <Box sx={{ pt: 12, px: 3, textAlign: "center" }}>
         <Typography color="error" gutterBottom>
           {error}
         </Typography>
-        <Button
-          variant="contained"
-          onClick={async () => {
-            if (!isAuthenticated) return;
-            setError(null);
-            setLoading(true);
-            try {
-              const validContent = await fetchUserContentWithDetails();
-              setUserContent(validContent);
-            } catch (err) {
-              setError(
-                err.response?.data?.error || err.message || "Error al obtener el contenido"
-              );
-            } finally {
-              setLoading(false);
-            }
-          }}
-        >
+        <Button variant="contained" onClick={() => loadLibraryPage()}>
           Reintentar
         </Button>
       </Box>
     );
   if (!isAuthenticated)
-    return <Typography color="text.primary">Por favor inicia sesión para ver el contenido</Typography>;
+    return (
+      <Typography color="text.primary">
+        Por favor inicia sesión para ver el contenido
+      </Typography>
+    );
+
+  const emptyMessage = searchDebounced
+    ? "No se encontró contenido con la búsqueda realizada."
+    : "No se encontró contenido para el filtro seleccionado.";
 
   return (
     <Box
@@ -140,9 +136,9 @@ const LibraryUser = () => {
         gutterBottom
         sx={{
           fontSize: {
-            xs: "1.5rem", // ~24px on mobile
-            sm: "1.75rem", // ~28px on small screens
-            md: "2.125rem", // ~34px on desktop (default h4)
+            xs: "1.5rem",
+            sm: "1.75rem",
+            md: "2.125rem",
           },
           fontWeight: 600,
         }}
@@ -155,8 +151,8 @@ const LibraryUser = () => {
           sx={{
             mb: 2,
             display: {
-              xs: "block", // mobile → stacked
-              md: "flex", // md and up → flex row
+              xs: "block",
+              md: "flex",
             },
             gap: 2,
           }}
@@ -164,8 +160,8 @@ const LibraryUser = () => {
           <Button
             sx={{
               width: {
-                xs: "100%", // full width on mobile
-                md: 280, // fixed 280px on md+
+                xs: "100%",
+                md: 280,
               },
               mb: {
                 xs: 2,
@@ -182,8 +178,8 @@ const LibraryUser = () => {
           <Button
             sx={{
               width: {
-                xs: "100%", // full width on mobile
-                md: 280, // fixed 280px on md+
+                xs: "100%",
+                md: 280,
               },
               mb: {
                 xs: 2,
@@ -202,8 +198,8 @@ const LibraryUser = () => {
           <Button
             sx={{
               width: {
-                xs: "100%", // full width on mobile
-                md: 280, // fixed 280px on md+
+                xs: "100%",
+                md: 280,
               },
               mb: {
                 xs: 2,
@@ -281,76 +277,93 @@ const LibraryUser = () => {
         </Box>
       </Box>
 
-      {mediaFilter === "TEXT" ? (
-        // Table view for text files
+      {loading && userContent.length === 0 ? (
+        <Typography color="text.secondary" sx={{ py: 2 }}>
+          Cargando…
+        </Typography>
+      ) : mediaFilter === "TEXT" ? (
         <Box sx={{ overflowX: "auto" }}>
-          {filteredContent.length === 0 ? (
-            <Typography variant="body1" color="text.secondary" align="center" sx={{ py: 4 }}>
-              {searchQuery.trim()
-                ? "No se encontró contenido con la búsqueda realizada."
-                : "No se encontró contenido para el filtro seleccionado."}
+          {userContent.length === 0 ? (
+            <Typography
+              variant="body1"
+              color="text.secondary"
+              align="center"
+              sx={{ py: 4 }}
+            >
+              {emptyMessage}
             </Typography>
           ) : (
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
-            <thead>
-              <tr>
-                <th style={{ textAlign: "left", padding: "12px", color: "inherit" }}>Título</th>
-                <th style={{ textAlign: "left", padding: "12px", color: "inherit" }}>Autor</th>
-                <th style={{ textAlign: "left", padding: "12px", color: "inherit" }}>Notas</th>
-                <th style={{ textAlign: "left", padding: "12px", color: "inherit" }}>Archivo</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredContent.map((contentProfile) => (
-                <tr
-                  key={contentProfile.id}
-                  style={{
-                    borderBottom: "1px solid #eee",
-                    cursor: "pointer",
-                  }}
-                  onClick={() =>
-                    navigate(
-                      `/content/${contentProfile.content.id}/library?context=library&id=${currentUser.id}`
-                    )
-                  }
-                >
-                  <td style={{ padding: "12px", color: "inherit" }}>{contentProfile.title}</td>
-                  <td style={{ padding: "12px", color: "inherit" }}>{contentProfile.author}</td>
-                  <td style={{ padding: "12px", color: "inherit" }}>
-                    {contentProfile.personal_note && (
-                      <IconButton
-                        size="small"
-                        title={contentProfile.personal_note}
-                      >
-                        <NoteIcon color="primary" />
-                      </IconButton>
-                    )}
-                  </td>
-                  <td style={{ padding: "12px", color: "inherit" }}>
-                    {(() => {
-                      const dlUrl = resolveMediaUrl(contentProfile.content.file_details?.url ?? contentProfile.content.file_details?.file);
-                      return dlUrl ? (
-                        <a
-                          href={dlUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style={{ color: "inherit", textDecoration: "underline" }}
-                        >
-                          Descargar
-                        </a>
-                      ) : null;
-                    })()}
-                  </td>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: "left", padding: "12px", color: "inherit" }}>
+                    Título
+                  </th>
+                  <th style={{ textAlign: "left", padding: "12px", color: "inherit" }}>
+                    Autor
+                  </th>
+                  <th style={{ textAlign: "left", padding: "12px", color: "inherit" }}>
+                    Notas
+                  </th>
+                  <th style={{ textAlign: "left", padding: "12px", color: "inherit" }}>
+                    Archivo
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {userContent.map((contentProfile) => (
+                  <tr
+                    key={contentProfile.id}
+                    style={{
+                      borderBottom: "1px solid #eee",
+                      cursor: "pointer",
+                    }}
+                    onClick={() =>
+                      navigate(
+                        `/content/${contentProfile.content.id}/library?context=library&id=${currentUser.id}`
+                      )
+                    }
+                  >
+                    <td style={{ padding: "12px", color: "inherit" }}>
+                      {contentProfile.title}
+                    </td>
+                    <td style={{ padding: "12px", color: "inherit" }}>
+                      {contentProfile.author}
+                    </td>
+                    <td style={{ padding: "12px", color: "inherit" }}>
+                      {contentProfile.personal_note && (
+                        <IconButton size="small" title={contentProfile.personal_note}>
+                          <NoteIcon color="primary" />
+                        </IconButton>
+                      )}
+                    </td>
+                    <td style={{ padding: "12px", color: "inherit" }}>
+                      {(() => {
+                        const dlUrl = resolveMediaUrl(
+                          contentProfile.content.file_details?.url ??
+                            contentProfile.content.file_details?.file
+                        );
+                        return dlUrl ? (
+                          <a
+                            href={dlUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ color: "inherit", textDecoration: "underline" }}
+                          >
+                            Descargar
+                          </a>
+                        ) : null;
+                      })()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           )}
         </Box>
       ) : (
-        // Grid view using ContentDisplay in card mode
         <Box display="grid" gridTemplateColumns="repeat(12, 1fr)" gap={3}>
-          {filteredContent.map((contentProfile) => (
+          {userContent.map((contentProfile) => (
             <Box
               gridColumn={{ xs: "span 12", sm: "span 6", md: "span 4" }}
               key={contentProfile.id}
@@ -368,17 +381,30 @@ const LibraryUser = () => {
             </Box>
           ))}
 
-          {filteredContent.length === 0 && (
+          {userContent.length === 0 && (
             <Box gridColumn={{ xs: "span 12" }}>
               <Typography variant="body1" color="text.secondary" align="center">
-                {searchQuery.trim()
-                  ? "No se encontró contenido con la búsqueda realizada."
-                  : "No se encontró contenido para el filtro seleccionado."}
+                {emptyMessage}
               </Typography>
             </Box>
           )}
         </Box>
       )}
+
+      <TablePagination
+        component="div"
+        count={totalCount}
+        page={page}
+        onPageChange={handleChangePage}
+        rowsPerPage={rowsPerPage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+        rowsPerPageOptions={[12, 24, 48]}
+        labelRowsPerPage="Por página"
+        labelDisplayedRows={({ from, to, count }) =>
+          `${from}–${to} de ${count !== -1 ? count : `más de ${to}`}`
+        }
+        sx={{ mt: 2, borderTop: 1, borderColor: "divider" }}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen
La ruta de biblioteca del usuario (`/content/library_user`) cargaba todo el contenido en una sola petición. Ahora el listado es **paginado en el servidor** y la interfaz incluye **paginación y tamaño de página** (MUI `TablePagination`), con **búsqueda con debounce** para no disparar una petición por cada tecla.

## API
- `GET /api/content/user-content-with-details/` devuelve un objeto con `count`, `current_page`, `total_pages` y `results` (misma forma que la búsqueda global).
- Parámetros opcionales: `page`, `page_size` (máx. 100), `media_type` (`ALL` por defecto o `IMAGE`, `TEXT`, etc.), `search`.

**Nota:** Cualquier cliente que esperara un array plano en la raíz de la respuesta debe actualizarse a `results`.

## Pruebas
- Añadidos tests Django: `UserLibraryWithDetailsAPITests` (paginación, filtro por tipo de medio, búsqueda).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-582b87a1-9380-469c-afa8-7ce277783ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-582b87a1-9380-469c-afa8-7ce277783ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

