### PR TITLE
fix(tests): gamification test import and suggestion email coverage

### DIFF
--- a/acbc_app/profiles/tests.py
+++ b/acbc_app/profiles/tests.py
@@ -1715,18 +1715,18 @@ class EmailServiceTests(TestCase):
     @patch('profiles.email_service.EmailService._is_email_enabled')
     @patch('profiles.email_service.EmailService._validate_configuration')
     @patch('profiles.email_service.EmailService._validate_email')
-    @patch('profiles.email_service.EmailMultiAlternatives')
+    @patch('postmarker.django.PostmarkEmailMultiAlternatives')
     def test_send_email_success(self, mock_ema_class, mock_validate_email, mock_validate_config, mock_is_enabled):
         """Test successful email sending via Django backend (Postmark when enabled)"""
         mock_is_enabled.return_value = True
         mock_ema_instance = mock_ema_class.return_value
-        
+
         result = EmailService.send_email(
             receiver_email='test@example.com',
             subject='Test Subject',
             text_message='Test message'
         )
-        
+
         self.assertTrue(result)
         mock_ema_instance.send.assert_called_once_with(fail_silently=False)
     
@@ -1746,12 +1746,12 @@ class EmailServiceTests(TestCase):
     @patch('profiles.email_service.EmailService._is_email_enabled')
     @patch('profiles.email_service.EmailService._validate_configuration')
     @patch('profiles.email_service.EmailService._validate_email')
-    @patch('profiles.email_service.EmailMultiAlternatives')
+    @patch('postmarker.django.PostmarkEmailMultiAlternatives')
     def test_send_email_send_failure(self, mock_ema_class, mock_validate_email, mock_validate_config, mock_is_enabled):
         """Test email sending when backend send raises"""
         mock_is_enabled.return_value = True
         mock_ema_class.return_value.send.side_effect = Exception("Backend error")
-        
+
         with self.assertRaises(EmailServiceError):
             EmailService.send_email(
                 receiver_email='test@example.com',

--- a/acbc_app/profiles/views.py
+++ b/acbc_app/profiles/views.py
@@ -1475,19 +1475,17 @@ class SuggestionCreateView(APIView):
                 'suggestion': suggestion,
                 'site_url': site_url,
             }
-            
-            # Send email using template to the primary admin email only
-            admin_email = getattr(settings, 'ADMIN_EMAIL', 'alejandro@academiablockchain.com')
-            EmailService.send_template_email(
-                receiver_email=admin_email,
+
+            EmailService.send_to_admins(
                 subject=subject,
                 template_name='suggestion_notification',
                 context=context,
-                tags=['suggestion', 'notification', 'admin']
+                tags=['suggestion', 'notification', 'admin'],
             )
-            
+
             logger.info(
-                f"Suggestion notification email sent successfully to primary admin: {admin_email}"
+                "Suggestion notification email dispatched to administrators for suggestion id=%s",
+                suggestion.id,
             )
                 
         except EmailServiceError as e:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Test suite:** Removed the empty `acbc_app/__init__.py` so Python does not treat `acbc_app` as a top-level package. That was causing test modules to load as `acbc_app.gamification.tests` while Django registered `gamification.models.Badge`, producing duplicate model registration and a single failing error in CI-style runs.
- **Suggestions:** `SuggestionCreateView` now uses `EmailService.send_to_admins` with the existing template so all staff (and `ADMIN_EMAIL`) get the notification, matching the tests that patch `send_to_admins`.
- **Email tests:** Mocks now patch `postmarker.django.PostmarkEmailMultiAlternatives`, which is what `EmailService.send_email` uses when Postmarker is installed.

## Verification

- `coverage run --source='.' manage.py test` from `acbc_app`: **381 tests OK** (same command shape as `.github/workflows/deploy.yml`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da52453e-e0c5-40d2-aa4f-1e9f6b178a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da52453e-e0c5-40d2-aa4f-1e9f6b178a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

