### PR TITLE
Topic visibility (is_visible): creator control, 3-content rule, listings & search

### DIFF
--- a/acbc_app/comments/views.py
+++ b/acbc_app/comments/views.py
@@ -12,6 +12,7 @@ from utils.notification_utils import notify_comment_reply, notify_knowledge_path
 
 from comments.managers import CommentManager
 from content.models import Topic, Content
+from content.utils import get_topic_for_public_or_privileged
 from comments.models import Comment
 from comments.serializers import CommentSerializer, KnowledgePathCommentSerializer, ContentTopicCommentSerializer, \
     TopicCommentSerializer, CommentCreateSerializer
@@ -257,7 +258,7 @@ class TopicCommentsView(APIView):
                 'topic_id': pk,
             })
             
-            topic = get_object_or_404(Topic, pk=pk)
+            topic = get_topic_for_public_or_privileged(request, pk)
             topic_type = ContentType.objects.get_for_model(Topic)
             
             # Get comments that:
@@ -300,7 +301,7 @@ class TopicCommentsView(APIView):
                 'body_length': len(request.data.get('body', '')),
             })
             
-            topic = get_object_or_404(Topic, pk=pk)
+            topic = get_topic_for_public_or_privileged(request, pk)
             topic_type = ContentType.objects.get_for_model(Topic)
             
             comment_data = {
@@ -362,7 +363,7 @@ class ContentTopicCommentsView(BaseCommentView):
         return ContentTopicCommentSerializer
 
     def get_queryset(self, topic_pk, content_pk):
-        topic = get_object_or_404(Topic, pk=topic_pk)
+        topic = get_topic_for_public_or_privileged(self.request, topic_pk)
         content = get_object_or_404(topic.contents, pk=content_pk)
         return Comment.objects.filter(
             content_type=ContentType.objects.get_for_model(Content),
@@ -373,7 +374,7 @@ class ContentTopicCommentsView(BaseCommentView):
         ).select_related('author')
 
     def save_serializer(self, serializer, topic_pk, content_pk):
-        topic = get_object_or_404(Topic, pk=topic_pk)
+        topic = get_topic_for_public_or_privileged(self.request, topic_pk)
         content = get_object_or_404(topic.contents, pk=content_pk)
         comment = serializer.save(
             object_id=content.id,

--- a/acbc_app/content/migrations/0010_topic_is_visible.py
+++ b/acbc_app/content/migrations/0010_topic_is_visible.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+from django.db.models import Count
+
+
+def forwards_set_topic_visibility(apps, schema_editor):
+    Topic = apps.get_model("content", "Topic")
+    qs = Topic.objects.annotate(_n=Count("contents"))
+    for topic in qs.iterator(chunk_size=500):
+        topic.is_visible = topic._n >= 3
+        topic.save(update_fields=["is_visible"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("content", "0009_alter_filedetails_file_max_length"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="topic",
+            name="is_visible",
+            field=models.BooleanField(
+                default=False,
+                help_text="Whether this topic appears in public listings and search. Hidden topics remain accessible by direct link to creator and moderators.",
+            ),
+        ),
+        migrations.RunPython(forwards_set_topic_visibility, migrations.RunPython.noop),
+    ]

--- a/acbc_app/content/models.py
+++ b/acbc_app/content/models.py
@@ -264,9 +264,23 @@ class Topic(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
     moderators = models.ManyToManyField(User, related_name='moderated_topics')
     related_topics = models.ManyToManyField('self', blank=True, related_name='related_to', symmetrical=False)
+    is_visible = models.BooleanField(
+        default=False,
+        help_text="Whether this topic appears in public listings and search. Hidden topics remain accessible by direct link to creator and moderators.",
+    )
 
     def __str__(self):
         return self.title
+
+    def can_be_visible(self):
+        """At least three content items are required to mark the topic as public."""
+        return self.contents.count() >= 3
+
+    def ensure_visibility_consistency(self):
+        """If the topic no longer has enough content, force it to stay non-public."""
+        if not self.can_be_visible() and self.is_visible:
+            self.is_visible = False
+            self.save(update_fields=['is_visible'])
 
     def is_moderator_or_creator(self, user):
         return user == self.creator or user in self.moderators.all()

--- a/acbc_app/content/serializers.py
+++ b/acbc_app/content/serializers.py
@@ -246,6 +246,7 @@ class CollectionSerializer(serializers.ModelSerializer):
 class TopicBasicSerializer(serializers.ModelSerializer):
     topic_image = serializers.ImageField(max_length=None, allow_empty_file=True, required=False)
     creator_username = serializers.CharField(source='creator.username', read_only=True)
+    can_be_visible = serializers.SerializerMethodField()
     title = serializers.CharField(
         max_length=200,
         required=True,
@@ -261,8 +262,30 @@ class TopicBasicSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Topic
-        fields = ['id', 'title', 'description', 'creator', 'creator_username', 'topic_image', 'topic_image_focal_x', 'topic_image_focal_y']
-        read_only_fields = ['creator']
+        fields = [
+            'id', 'title', 'description', 'creator', 'creator_username', 'topic_image',
+            'topic_image_focal_x', 'topic_image_focal_y', 'is_visible', 'can_be_visible',
+        ]
+        read_only_fields = ['creator', 'can_be_visible']
+
+    def get_can_be_visible(self, obj):
+        return obj.can_be_visible()
+
+    def validate_is_visible(self, value):
+        if value is True:
+            if self.instance is None:
+                raise serializers.ValidationError(
+                    'Los temas nuevos empiezan como no públicos; puedes marcarlos públicos al editarlos.'
+                )
+            if not self.instance.can_be_visible():
+                raise serializers.ValidationError(
+                    'Los temas necesitan al menos 3 contenidos para ser públicos.'
+                )
+        return value
+
+    def create(self, validated_data):
+        validated_data['is_visible'] = False
+        return super().create(validated_data)
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)

--- a/acbc_app/content/tests.py
+++ b/acbc_app/content/tests.py
@@ -923,6 +923,83 @@ class TopicAPITests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_topic_list_anonymous_only_includes_visible_topics(self):
+        Topic.objects.create(
+            title="Hidden List Topic",
+            description="x",
+            creator=self.user,
+            is_visible=False,
+        )
+        visible = Topic.objects.create(
+            title="Visible List Topic",
+            description="y",
+            creator=self.user,
+            is_visible=True,
+        )
+        self.client.force_authenticate(user=None)
+        url = reverse("content:topics")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = {t["id"] for t in response.data}
+        self.assertIn(visible.id, ids)
+        self.assertNotIn(self.topic.id, ids)
+
+    def test_topic_detail_non_visible_returns_404_for_outsider(self):
+        hidden = Topic.objects.create(
+            title="Secret",
+            description="z",
+            creator=self.user,
+            is_visible=False,
+        )
+        outsider = User.objects.create_user(
+            username="outsider2",
+            email="out2@example.com",
+            password="pass12345",
+        )
+        self.client.force_authenticate(user=outsider)
+        url = reverse("content:topic-detail", args=[hidden.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_topic_creator_cannot_set_visible_without_three_contents(self):
+        url = reverse("content:topic-detail", args=[self.topic.id])
+        response = self.client.patch(url, {"is_visible": True}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_topic_creator_can_set_visible_with_three_contents(self):
+        for i in range(3):
+            c = Content.objects.create(
+                uploaded_by=self.user,
+                media_type="TEXT",
+                original_title=f"C{i}",
+            )
+            self.topic.contents.add(c)
+        url = reverse("content:topic-detail", args=[self.topic.id])
+        response = self.client.patch(url, {"is_visible": True}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data.get("is_visible"))
+        self.topic.refresh_from_db()
+        self.assertTrue(self.topic.is_visible)
+
+    def test_topic_remove_content_forces_not_visible_below_threshold(self):
+        contents = []
+        for i in range(3):
+            c = Content.objects.create(
+                uploaded_by=self.user,
+                media_type="TEXT",
+                original_title=f"R{i}",
+            )
+            contents.append(c)
+            self.topic.contents.add(c)
+        self.topic.is_visible = True
+        self.topic.save(update_fields=["is_visible"])
+
+        url = reverse("content:topic-edit-content", args=[self.topic.id])
+        response = self.client.patch(url, {"content_ids": [contents[0].id]}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.topic.refresh_from_db()
+        self.assertFalse(self.topic.is_visible)
+
 
 class PublicationAPITests(APITestCase):
     """Test suite for Publication API endpoints"""

--- a/acbc_app/content/utils.py
+++ b/acbc_app/content/utils.py
@@ -1,7 +1,9 @@
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.http import Http404
+from django.shortcuts import get_object_or_404
 import logging
-from content.models import Content
+from content.models import Content, Topic, TopicModeratorInvitation
 from votes.models import VoteCount
 
 # Get logger for content utils
@@ -109,3 +111,24 @@ def get_topic_contents_ordered_for_public_view(topic):
     extras = [c for c in topic.contents.all() if c.id not in seen]
     extras.sort(key=lambda c: c.id)
     return ordered + extras
+
+
+def user_can_access_non_public_topic(topic, user):
+    """Creator, moderators, and users with a pending moderator invite can open a non-public topic."""
+    if not user.is_authenticated:
+        return False
+    if topic.creator_id == user.id:
+        return True
+    if topic.moderators.filter(pk=user.pk).exists():
+        return True
+    return TopicModeratorInvitation.objects.filter(
+        topic=topic, invited_user=user, status="PENDING"
+    ).exists()
+
+
+def get_topic_for_public_or_privileged(request, pk):
+    """404 for users who may not load a non-public topic (direct URL)."""
+    topic = get_object_or_404(Topic, pk=pk)
+    if not topic.is_visible and not user_can_access_non_public_topic(topic, request.user):
+        raise Http404()
+    return topic

--- a/acbc_app/content/views.py
+++ b/acbc_app/content/views.py
@@ -9,6 +9,7 @@ from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 import os
 from django.conf import settings
+from django.http import Http404
 from rest_framework import viewsets, permissions
 from rest_framework.decorators import action
 from django.apps import apps
@@ -27,7 +28,18 @@ from utils.notification_utils import (
     notify_topic_moderator_invitation_declined,
     notify_topic_moderator_removed,
 )
-from content.models import Library, Collection, Content, Topic, ContentProfile, FileDetails, Publication, TopicModeratorInvitation, ContentSuggestion, FileSuggestion
+from content.models import (
+    Library,
+    Collection,
+    Content,
+    Topic,
+    ContentProfile,
+    FileDetails,
+    Publication,
+    TopicModeratorInvitation,
+    ContentSuggestion,
+    FileSuggestion,
+)
 from knowledge_paths.models import KnowledgePath, Node
 from votes.models import VoteCount
 from content.serializers import (
@@ -52,7 +64,12 @@ from knowledge_paths.serializers import (
     NodeSerializer
 )
 from .serializers import PublicationSerializer
-from content.utils import get_top_voted_contents, get_topic_contents_ordered_for_public_view
+from content.utils import (
+    get_top_voted_contents,
+    get_topic_contents_ordered_for_public_view,
+    get_topic_for_public_or_privileged,
+    user_can_access_non_public_topic,
+)
 from bs4 import BeautifulSoup
 import requests
 import re
@@ -1365,7 +1382,18 @@ class TopicView(APIView):
         return [permission() for permission in self.permission_classes]
 
     def get(self, request):
-        topics = Topic.objects.all()
+        if request.user.is_authenticated:
+            topics = (
+                Topic.objects.filter(
+                    models.Q(is_visible=True)
+                    | models.Q(creator=request.user)
+                    | models.Q(moderators=request.user)
+                )
+                .distinct()
+                .order_by("-created_at")
+            )
+        else:
+            topics = Topic.objects.filter(is_visible=True).order_by("-created_at")
         serializer = TopicBasicSerializer(topics, many=True, context={'request': request})
         return Response(serializer.data)
 
@@ -1397,10 +1425,13 @@ class TopicDetailView(APIView):
             Topic.objects.prefetch_related(
                 'contents',
                 'contents__file_details',
-                'contents__profiles'
+                'contents__profiles',
+                'moderators',
             ),
             pk=pk
         )
+        if not topic.is_visible and not user_can_access_non_public_topic(topic, request.user):
+            raise Http404()
 
         # Get contents ordered by vote count per media type (same order as "ver todos")
         ordered_contents = []
@@ -1442,7 +1473,7 @@ class TopicDetailView(APIView):
 
     def patch(self, request, pk):
         logger.info("Topic PATCH topic_id=%s", pk)
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
 
         if not topic.is_moderator_or_creator(request.user):
             logger.warning("Topic PATCH forbidden topic_id=%s", pk)
@@ -1451,11 +1482,16 @@ class TopicDetailView(APIView):
                 status=status.HTTP_403_FORBIDDEN
             )
 
+        is_creator = topic.creator_id == request.user.id
+
         try:
             data = request.data.copy() if hasattr(request.data, 'copy') else dict(request.data)
         except Exception as e:
             logger.exception("Topic PATCH copy request.data failed: %s", e)
             return Response({"error": "Error procesando la peticion."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        if not is_creator and "is_visible" in data:
+            data.pop("is_visible", None)
 
         has_image = "topic_image" in request.FILES
         logger.info("Topic PATCH topic_id=%s has_image=%s", pk, has_image)
@@ -1492,7 +1528,7 @@ class TopicDetailView(APIView):
 
     def delete(self, request, pk):
         logger.info("Topic DELETE topic_id=%s user=%s", pk, request.user.username)
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
 
         if topic.creator != request.user:
             logger.warning("Topic DELETE forbidden topic_id=%s user=%s (only creator can delete)", pk, request.user.username)
@@ -1513,6 +1549,8 @@ class TopicContentSimpleView(APIView):
 
     def get(self, request, pk):
         topic = get_object_or_404(Topic.objects.prefetch_related("contents"), pk=pk)
+        if not topic.is_visible and not user_can_access_non_public_topic(topic, request.user):
+            raise Http404()
 
         if not topic.is_moderator_or_creator(request.user):
             return Response(
@@ -1579,7 +1617,7 @@ class TopicBasicView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, pk):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         serializer = TopicBasicSerializer(topic)
         return Response(serializer.data)
 
@@ -1588,7 +1626,7 @@ class TopicEditContentView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request, pk):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         
         # Check if user is creator or moderator
         if not topic.is_moderator_or_creator(request.user):
@@ -1610,7 +1648,8 @@ class TopicEditContentView(APIView):
             contents = [profile.content for profile in content_profiles]
             
             topic.contents.add(*contents)
-            
+            topic.ensure_visibility_consistency()
+
             return Response(
                 {'message': 'Content added successfully'}, 
                 status=status.HTTP_200_OK
@@ -1622,7 +1661,7 @@ class TopicEditContentView(APIView):
             )
 
     def patch(self, request, pk):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         
         # Check if user is creator or moderator
         if not topic.is_moderator_or_creator(request.user):
@@ -1636,6 +1675,7 @@ class TopicEditContentView(APIView):
         try:
             contents = Content.objects.filter(id__in=content_ids)
             topic.contents.remove(*contents)
+            topic.ensure_visibility_consistency()
             return Response(
                 {'message': 'Content removed successfully'}, 
                 status=status.HTTP_200_OK
@@ -1653,7 +1693,7 @@ class TopicModeratorsView(APIView):
 
     def post(self, request, pk):
         """Add moderators to a topic. Only the creator can add moderators."""
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         
         # Check if user is the creator
         if topic.creator != request.user:
@@ -1697,7 +1737,7 @@ class TopicModeratorsView(APIView):
 
     def delete(self, request, pk):
         """Remove moderators from a topic. Only the creator can remove moderators."""
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         
         # Check if user is the creator
         if topic.creator != request.user:
@@ -1775,7 +1815,7 @@ class TopicModeratorInviteView(APIView):
     parser_classes = [JSONParser]
 
     def post(self, request, pk):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         
         # Check if user is the creator
         if topic.creator != request.user:
@@ -1870,7 +1910,7 @@ class TopicModeratorInvitationsView(APIView):
     permission_classes = [IsAuthenticated]
     
     def get(self, request, pk):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         
         # Creator can see all invitations, invited users can see their own
         if topic.creator == request.user:
@@ -1896,7 +1936,7 @@ class TopicModeratorAcceptView(APIView):
     permission_classes = [IsAuthenticated]
     
     def post(self, request, pk, invitation_id):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         invitation = get_object_or_404(TopicModeratorInvitation, pk=invitation_id, topic=topic)
         
         # Check if user is the invited user
@@ -1947,7 +1987,7 @@ class TopicModeratorDeclineView(APIView):
     permission_classes = [IsAuthenticated]
     
     def post(self, request, pk, invitation_id):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         invitation = get_object_or_404(TopicModeratorInvitation, pk=invitation_id, topic=topic)
         
         # Check if user is the invited user
@@ -2054,7 +2094,7 @@ class TopicContentMediaTypeView(APIView):
         return None
 
     def get(self, request, pk, media_type):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         media_type = media_type.upper()
         content_type = ContentType.objects.get_for_model(Content)
         vote_count_subquery = Subquery(
@@ -2988,7 +3028,7 @@ class TopicContentSuggestionCreateView(APIView):
     parser_classes = [JSONParser]
 
     def post(self, request, pk):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         
         content_id = request.data.get('content_id')
         message = request.data.get('message', '')
@@ -3201,7 +3241,7 @@ class TopicContentSuggestionsView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, pk):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         
         # Get filter parameters
         status_filter = request.query_params.get('status', None)
@@ -3244,7 +3284,7 @@ class TopicContentSuggestionAcceptView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request, pk, suggestion_id):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         suggestion = get_object_or_404(ContentSuggestion, pk=suggestion_id, topic=topic)
         
         # Check if user is moderator or creator
@@ -3271,7 +3311,8 @@ class TopicContentSuggestionAcceptView(APIView):
             # Add content to topic if not duplicate
             if not suggestion.is_duplicate:
                 topic.contents.add(suggestion.content)
-            
+            topic.ensure_visibility_consistency()
+
             # Send notification to suggester
             try:
                 from utils.notification_utils import notify_content_suggestion_accepted
@@ -3301,7 +3342,7 @@ class TopicContentSuggestionRejectView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request, pk, suggestion_id):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         suggestion = get_object_or_404(ContentSuggestion, pk=suggestion_id, topic=topic)
         
         # Check if user is moderator or creator
@@ -3392,7 +3433,7 @@ class TopicContentSuggestionDeleteView(APIView):
     permission_classes = [IsAuthenticated]
 
     def delete(self, request, pk, suggestion_id):
-        topic = get_object_or_404(Topic, pk=pk)
+        topic = get_topic_for_public_or_privileged(request, pk)
         suggestion = get_object_or_404(ContentSuggestion, pk=suggestion_id, topic=topic)
         
         # Only the user who created the suggestion can delete it

--- a/acbc_app/search/services.py
+++ b/acbc_app/search/services.py
@@ -99,7 +99,7 @@ def search_topics(query):
     logger.debug(f"Searching topics for query: '{query}'")
     
     try:
-        topic_query = Q(title__icontains=query) | Q(description__icontains=query)
+        topic_query = (Q(title__icontains=query) | Q(description__icontains=query)) & Q(is_visible=True)
         topics = Topic.objects.filter(topic_query).only(
             'id', 'title', 'description', 'created_at'
         ).order_by('-created_at')
@@ -131,7 +131,7 @@ def search_knowledge_paths(query):
     logger.debug(f"Searching knowledge paths for query: '{query}'")
     
     try:
-        path_query = Q(title__icontains=query) | Q(description__icontains=query)
+        path_query = (Q(title__icontains=query) | Q(description__icontains=query)) & Q(is_visible=True)
         paths = KnowledgePath.objects.filter(path_query).only(
             'id', 'title', 'description', 'created_at'
         ).order_by('-created_at')

--- a/acbc_app/search/tests.py
+++ b/acbc_app/search/tests.py
@@ -17,13 +17,21 @@ class SearchAPITests(APITestCase):
         # Invisible profile (should not appear)
         self.profile3 = ContentProfile.objects.create(content=self.content2, title="Hidden", author="Bob", is_visible=False)
 
-        # Create Topics
-        self.topic1 = Topic.objects.create(title="Smart Contracts", description="All about smart contracts")
-        self.topic2 = Topic.objects.create(title="Consensus", description="Consensus mechanisms")
+        # Create Topics (only visible topics appear in search)
+        self.topic1 = Topic.objects.create(
+            title="Smart Contracts", description="All about smart contracts", is_visible=True
+        )
+        self.topic2 = Topic.objects.create(
+            title="Consensus", description="Consensus mechanisms", is_visible=True
+        )
 
-        # Create Knowledge Paths
-        self.kp1 = KnowledgePath.objects.create(title="Intro to Blockchain", description="Start here")
-        self.kp2 = KnowledgePath.objects.create(title="Advanced Blockchain", description="Deep dive")
+        # Create Knowledge Paths (only visible paths appear in search)
+        self.kp1 = KnowledgePath.objects.create(
+            title="Intro to Blockchain", description="Start here", is_visible=True
+        )
+        self.kp2 = KnowledgePath.objects.create(
+            title="Advanced Blockchain", description="Deep dive", is_visible=True
+        )
 
     def test_search_content(self):
         url = reverse('search:search')
@@ -70,7 +78,7 @@ class SearchAPITests(APITestCase):
         url = reverse('search:search')
         # Create extra topics to force pagination
         for i in range(15):
-            Topic.objects.create(title=f"Extra Topic {i}", description="Extra")
+            Topic.objects.create(title=f"Extra Topic {i}", description="Extra", is_visible=True)
         response = self.client.get(url, {'q': 'Extra', 'type': 'topics', 'page_size': 10})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data['results']), 10)

--- a/acbc_app/votes/views.py
+++ b/acbc_app/votes/views.py
@@ -11,6 +11,7 @@ import logging
 
 from comments.models import Comment
 from content.models import Topic, Content, Publication, ContentSuggestion
+from content.utils import get_topic_for_public_or_privileged
 from knowledge_paths.models import KnowledgePath
 from votes.models import Vote, VoteCount
 from utils.notification_utils import notify_content_upvote, notify_knowledge_path_upvote
@@ -393,7 +394,7 @@ class ContentVoteView(BaseGetVoteView):
             })
             
             content = get_object_or_404(Content, pk=content_pk)
-            topic = get_object_or_404(Topic, pk=topic_pk)
+            topic = get_topic_for_public_or_privileged(request, topic_pk)
             action = request.data.get('action')
             
             logger.debug(f"Content found: {content.id} - {content.original_title}")
@@ -465,7 +466,7 @@ class ContentVoteView(BaseGetVoteView):
         """Get vote information for content within a topic."""
         try:
             content = get_object_or_404(Content, pk=content_pk)
-            topic = get_object_or_404(Topic, pk=topic_pk)
+            topic = get_topic_for_public_or_privileged(request, topic_pk)
             
             logger.debug("Retrieving vote info for content", extra={
                 'user_id': request.user.id if request.user.is_authenticated else None,

--- a/frontend/src/profiles/Profile.jsx
+++ b/frontend/src/profiles/Profile.jsx
@@ -410,6 +410,7 @@ const Profile = () => {
                     <TopicsByUser 
                         userId={profile?.user?.id} 
                         userName={profile?.user?.username || 'User'}
+                        isOwnProfile={isOwnProfile}
                     />
                 );
             case 'events':

--- a/frontend/src/topics/TopicEdit.jsx
+++ b/frontend/src/topics/TopicEdit.jsx
@@ -13,6 +13,11 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  FormControlLabel,
+  Switch,
+  Tooltip,
+  Stack,
+  AlertTitle,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import EditIcon from "@mui/icons-material/Edit";
@@ -20,6 +25,9 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import SaveIcon from "@mui/icons-material/Save";
 import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import contentApi from "../api/contentApi";
 import { useAuth } from "../context/AuthContext";
 import TopicModerators from "./TopicModerators";
@@ -38,15 +46,22 @@ const TopicEdit = () => {
   const [formData, setFormData] = useState({
     title: "",
     description: "",
+    is_visible: false,
   });
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeletingTopic, setIsDeletingTopic] = useState(false);
+
+  const contentCount = topic?.contents?.length ?? 0;
+  const canBePublic =
+    Boolean(topic?.can_be_visible) && contentCount >= 3;
 
   const isFormDirty =
     topic &&
     (formData.title !== (topic.title || "") ||
-      formData.description !== (topic.description || ""));
+      formData.description !== (topic.description || "") ||
+      Boolean(formData.is_visible) !== Boolean(topic.is_visible));
 
   const creatorId = topic ? (typeof topic.creator === "object" ? topic.creator?.id : topic.creator) : null;
   const userId = user?.id;
@@ -65,6 +80,7 @@ const TopicEdit = () => {
         setFormData({
           title: data.title || "",
           description: data.description || "",
+          is_visible: Boolean(data.is_visible),
         });
         setLoading(false);
       } catch (err) {
@@ -117,13 +133,30 @@ const TopicEdit = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSaving(true);
+    setSaveError(null);
     try {
-      const updatedTopic = await contentApi.updateTopic(topicId, formData);
+      const payload = {
+        title: formData.title,
+        description: formData.description,
+      };
+      if (isCreator) {
+        payload.is_visible = Boolean(formData.is_visible);
+      }
+      const updatedTopic = await contentApi.updateTopic(topicId, payload);
       setTopic(updatedTopic);
+      setFormData((prev) => ({
+        ...prev,
+        is_visible: Boolean(updatedTopic.is_visible),
+      }));
       setError(null);
       navigate(`/content/topics/${topicId}`);
     } catch (err) {
-      setError("Error al actualizar los detalles del tema");
+      const msg =
+        err?.response?.data?.is_visible?.[0] ||
+        err?.response?.data?.is_visible ||
+        err?.response?.data?.detail ||
+        err?.response?.data?.error;
+      setSaveError(msg || "Error al actualizar los detalles del tema");
     } finally {
       setSaving(false);
     }
@@ -243,6 +276,75 @@ const TopicEdit = () => {
         {/* Topic Title and Description Form */}
         <Box>
             <form id="topic-edit-form" onSubmit={handleSubmit}>
+              {saveError && (
+                <Alert severity="error" sx={{ mb: 2 }} onClose={() => setSaveError(null)}>
+                  {saveError}
+                </Alert>
+              )}
+              {isCreator && !canBePublic && (
+                <Alert severity="warning" icon={<WarningAmberIcon />} sx={{ borderRadius: 2, mb: 2 }}>
+                  <AlertTitle sx={{ fontWeight: 700 }}>Aún no puedes marcarlo como público</AlertTitle>
+                  <Typography variant="body2" sx={{ mb: 1 }}>
+                    Para que el tema sea público en listados y búsqueda necesitas <strong>al menos 3 contenidos</strong> en el tema.
+                    Actualmente hay <strong>{contentCount}</strong>.
+                  </Typography>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => navigate(`/content/topics/${topicId}/edit-content`)}
+                    sx={{ textTransform: "none", borderRadius: 2 }}
+                  >
+                    Ir a editar contenido
+                  </Button>
+                </Alert>
+              )}
+
+              {isCreator && (
+                <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2, flexWrap: "wrap" }}>
+                  <Chip
+                    size="small"
+                    icon={formData.is_visible ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                    label={formData.is_visible ? "Público" : "No público"}
+                    color={formData.is_visible ? "success" : "default"}
+                    variant={formData.is_visible ? "filled" : "outlined"}
+                  />
+                  <Tooltip
+                    title={
+                      !canBePublic && !formData.is_visible
+                        ? "Necesitas al menos 3 contenidos en el tema para hacerlo público."
+                        : ""
+                    }
+                    disableHoverListener={canBePublic || formData.is_visible}
+                  >
+                    <span>
+                      <FormControlLabel
+                        control={
+                          <Switch
+                            checked={Boolean(formData.is_visible)}
+                            disabled={!canBePublic && !formData.is_visible}
+                            onChange={(e) =>
+                              setFormData((prev) => ({ ...prev, is_visible: e.target.checked }))
+                            }
+                          />
+                        }
+                        label={
+                          <Stack direction="row" spacing={0.75} alignItems="center">
+                            {formData.is_visible ? (
+                              <VisibilityIcon fontSize="small" />
+                            ) : (
+                              <VisibilityOffIcon fontSize="small" />
+                            )}
+                            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                              Visible en listados y búsqueda
+                            </Typography>
+                          </Stack>
+                        }
+                      />
+                    </span>
+                  </Tooltip>
+                </Stack>
+              )}
+
               <TextField
                 fullWidth
                 label="Título"

--- a/frontend/src/topics/TopicList.jsx
+++ b/frontend/src/topics/TopicList.jsx
@@ -10,8 +10,11 @@ import {
     CardActionArea,
     Button,
     Alert,
-    CircularProgress 
+    CircularProgress,
+    Chip,
 } from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import AddIcon from '@mui/icons-material/Add';
 import contentApi from '../api/contentApi';
 import { isAuthenticated } from '../context/localStorageUtils';
@@ -94,9 +97,17 @@ const TopicList = () => {
                                     }}
                                 />
                                 <CardContent>
-                                    <Typography variant="h6" gutterBottom color="text.primary">
-                                        {topic.title}
-                                    </Typography>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+                                        <Typography variant="h6" color="text.primary">
+                                            {topic.title}
+                                        </Typography>
+                                        {isAuthenticated() && topic.is_visible === false && (
+                                            <Chip size="small" icon={<VisibilityOffIcon />} label="No público" variant="outlined" />
+                                        )}
+                                        {isAuthenticated() && topic.is_visible === true && (
+                                            <Chip size="small" icon={<VisibilityIcon />} label="Público" color="success" variant="outlined" />
+                                        )}
+                                    </Box>
                                     {topic.description && (
                                         <Typography variant="body2" color="text.secondary" noWrap>
                                             {topic.description}

--- a/frontend/src/topics/TopicsByUser.jsx
+++ b/frontend/src/topics/TopicsByUser.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Avatar, Box, Typography } from '@mui/material';
+import { Avatar, Box, Typography, Chip } from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import contentApi from '../api/contentApi';
 import { MEDIA_BASE_URL } from '../api/config';
 
-const TopicsByUser = ({ userId, userName }) => {
+const TopicsByUser = ({ userId, userName, isOwnProfile = false }) => {
   const navigate = useNavigate();
   const [topics, setTopics] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -16,10 +18,13 @@ const TopicsByUser = ({ userId, userName }) => {
         // For now, fetch all topics and filter by creator
         // In the future, we might want a specific endpoint for this
         const allTopics = await contentApi.getTopics();
-        const userTopics = Array.isArray(allTopics) 
-          ? allTopics.filter(topic => 
-              topic.creator != null && userId != null && String(topic.creator) === String(userId)
-            )
+        const userTopics = Array.isArray(allTopics)
+          ? allTopics.filter((topic) => {
+              if (topic.creator == null || userId == null) return false;
+              if (String(topic.creator) !== String(userId)) return false;
+              if (!isOwnProfile && topic.is_visible === false) return false;
+              return true;
+            })
           : [];
         setTopics(userTopics);
       } catch (err) {
@@ -33,7 +38,7 @@ const TopicsByUser = ({ userId, userName }) => {
     if (userId) {
       fetchTopics();
     }
-  }, [userId]);
+  }, [userId, isOwnProfile]);
 
   const getTopicImageUrl = (topic) => {
     if (topic.topic_image) {
@@ -102,21 +107,47 @@ const TopicsByUser = ({ userId, userName }) => {
                 
                 <div className="flex-1 min-w-0">
                   {/* Title Section */}
-                  <Typography
-                    variant="h6"
+                  <Box
                     sx={{
-                      fontWeight: 600,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      flexWrap: 'wrap',
                       mb: 1,
-                      cursor: 'pointer',
-                      '&:hover': { color: 'primary.main' }
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      navigate(`/content/topics/${topic.id}`);
                     }}
                   >
-                    {topic.title}
-                  </Typography>
+                    <Typography
+                      variant="h6"
+                      sx={{
+                        fontWeight: 600,
+                        cursor: 'pointer',
+                        '&:hover': { color: 'primary.main' },
+                      }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        navigate(`/content/topics/${topic.id}`);
+                      }}
+                    >
+                      {topic.title}
+                    </Typography>
+                    {isOwnProfile && topic.is_visible === false && (
+                      <Chip
+                        size="small"
+                        icon={<VisibilityOffIcon />}
+                        label="No público"
+                        variant="outlined"
+                      />
+                    )}
+                    {isOwnProfile && topic.is_visible === true && (
+                      <Chip
+                        size="small"
+                        icon={<VisibilityIcon />}
+                        label="Público"
+                        color="success"
+                        variant="outlined"
+                      />
+                    )}
+                  </Box>
 
                   {/* Description */}
                   {topic.description && (

--- a/frontend/src/topics/TopicsUser.jsx
+++ b/frontend/src/topics/TopicsUser.jsx
@@ -19,6 +19,8 @@ import {
   Alert
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import SupervisorAccountIcon from '@mui/icons-material/SupervisorAccount';
 import MailIcon from '@mui/icons-material/Mail';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
@@ -359,9 +361,17 @@ const TopicsUser = () => {
                         }}
                       />
                       <CardContent>
-                        <Typography variant="h6" gutterBottom color="text.primary">
-                          {topic.title}
-                        </Typography>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+                          <Typography variant="h6" color="text.primary">
+                            {topic.title}
+                          </Typography>
+                          {topic.is_visible === false && (
+                            <Chip size="small" icon={<VisibilityOffIcon />} label="No público" variant="outlined" />
+                          )}
+                          {topic.is_visible === true && (
+                            <Chip size="small" icon={<VisibilityIcon />} label="Público" color="success" variant="outlined" />
+                          )}
+                        </Box>
                         {topic.description && (
                           <Typography variant="body2" color="text.secondary" noWrap>
                             {topic.description}
@@ -423,9 +433,17 @@ const TopicsUser = () => {
                         }}
                       />
                       <CardContent>
-                        <Typography variant="h6" gutterBottom color="text.primary">
-                          {topic.title}
-                        </Typography>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 1 }}>
+                          <Typography variant="h6" color="text.primary">
+                            {topic.title}
+                          </Typography>
+                          {topic.is_visible === false && (
+                            <Chip size="small" icon={<VisibilityOffIcon />} label="No público" variant="outlined" />
+                          )}
+                          {topic.is_visible === true && (
+                            <Chip size="small" icon={<VisibilityIcon />} label="Público" color="success" variant="outlined" />
+                          )}
+                        </Box>
                         {topic.description && (
                           <Typography variant="body2" color="text.secondary" noWrap>
                             {topic.description}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `is_visible` to the `Topic` model so creators can keep a theme out of public listings and search (similar spirit to knowledge paths). A topic can only be set visible if it has **at least three** linked contents; the backend enforces this and automatically clears visibility if content drops below three.

## Backend

- New field `Topic.is_visible` (default `False` for new rows). Migration `0010_topic_is_visible` backfills: existing topics with ≥3 contents become visible.
- `TopicBasicSerializer`: `is_visible`, read-only `can_be_visible`, validation on create/update; new topics always start non-public.
- `TopicView` GET: anonymous users only see visible topics; authenticated users also see topics they created or moderate.
- Topic detail, votes, comments, content edit, moderators, suggestions, etc.: non-visible topics return **404** unless the user is creator, moderator, or has a **pending** moderator invitation (so invitees can still open the topic to accept).
- `TopicDetailView` PATCH: only the **creator** may change `is_visible` (moderators cannot flip visibility).
- After add/remove/accept content on a topic, `ensure_visibility_consistency()` runs so visibility cannot stay true with fewer than three items.
- Search: topic and knowledge path results only include `is_visible=True` (aligned with public knowledge path listing).

## Frontend

- **TopicEdit**: chips (Público / No público), warning when fewer than three contents, switch "Visible en listados y búsqueda" (disabled until eligible, same pattern as `KnowledgePathEdit`), dedicated save error alert for API validation messages.
- **TopicList**, **TopicsUser**, **TopicsByUser** (own profile): small visibility chips where useful. **TopicsByUser** for other users' profiles only lists public topics.

## Tests

- Extended `TopicAPITests` for list filtering, 404 for hidden detail, PATCH validation, and auto-hide after content removal.
- Updated `SearchAPITests` fixtures so topics and paths used in search are visible.

## Notes

- Apply migration: `python manage.py migrate` (could not run DB-backed tests in this environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83a55763-630e-44e3-8de4-960dbc3fbf36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83a55763-630e-44e3-8de4-960dbc3fbf36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

