### PR TITLE
Remove deployment job from CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,10 @@
-name: Test and Deploy to Server
+name: CI
 
 on:
   push:
-    branches: [ main ]  # Trigger on push to main branch
+    branches: [ main ]
   pull_request:
-    branches: [ main ]  # Also run tests on PRs
-  # Optionally trigger manually
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -114,49 +113,3 @@ jobs:
         cd acbc_app
         python manage.py check --deploy
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: test  # Only run deploy if tests pass
-    if: github.ref == 'refs/heads/main'  # Only deploy on main branch
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Deploy to server
-      uses: appleboy/ssh-action@v1.0.3
-      with:
-        host: ${{ secrets.HOST }}
-        username: ${{ secrets.USERNAME }}
-        key: ${{ secrets.SSH_PRIVATE_KEY }}
-        port: ${{ secrets.PORT || 22 }}
-        script: |
-          set -e
-          # Project dir: use DEPLOY_PATH secret or default ~/Sophia.AI
-          cd ${{ secrets.DEPLOY_PATH || '~/Sophia.AI' }}
-
-          echo "Pulling latest changes..."
-          git pull
-
-          echo "Building and starting Docker Compose (production)..."
-          docker compose -f docker-compose.prod.yml build --no-cache
-          docker compose -f docker-compose.prod.yml up -d --force-recreate
-
-          echo "Running migrations..."
-          docker compose -f docker-compose.prod.yml exec -T backend python manage.py migrate --noinput
-
-          echo "Collecting static files..."
-          docker compose -f docker-compose.prod.yml exec -T backend python manage.py collectstatic --noinput
-
-          echo "Verifying health..."
-          curl -sf http://localhost/health/ > /dev/null || { docker compose -f docker-compose.prod.yml logs backend; exit 1; }
-          curl -sf http://localhost/health > /dev/null || true
-
-          if command -v nginx > /dev/null 2>&1; then
-            echo "Testing nginx configuration..."
-            sudo nginx -t
-            echo "Reloading nginx..."
-            sudo nginx -s reload
-          fi
-
-          echo "Deployment completed successfully!"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rename the GitHub Actions workflow to CI
- Remove the SSH deployment job so pushes to main only run tests
- Keep existing test triggers for main, pull requests, and manual runs

## Testing
- GitHub Actions PR run passed: test job succeeded, no deploy job ran
- Local CI equivalent passed:
  - Django DB config validated against PostgreSQL
  - Migrations completed
  - Django test suite: 437 tests passed
  - Coverage report generated: 72% total coverage
  - `python manage.py check --deploy` completed with existing security warnings only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7fab912-7575-47ad-8fb7-cb62013622cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7fab912-7575-47ad-8fb7-cb62013622cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

