### PR TITLE
Fix detailed media player click behavior

### DIFF
--- a/frontend/src/content/ContentDisplay.jsx
+++ b/frontend/src/content/ContentDisplay.jsx
@@ -446,16 +446,7 @@ const ContentDisplay = ({
               width: "100%",
               maxWidth: "800px",
               mx: "auto",
-              cursor: isClickable ? "pointer" : "default",
-              "&:hover": isClickable
-                ? {
-                    boxShadow: 2,
-                    borderRadius: 0.5,
-                  }
-                : {},
             }}
-            onClick={isClickable ? handleContentClick : undefined}
-            title={isClickable ? "Haz clic para abrir el video en una nueva pestaña" : undefined}
           >
             <video controls style={{ width: "100%" }} src={fileUrl}>
               Tu navegador no admite la etiqueta de video.
@@ -522,16 +513,7 @@ const ContentDisplay = ({
               width: "100%",
               maxWidth: "600px",
               mx: "auto",
-              cursor: isClickable ? "pointer" : "default",
-              "&:hover": isClickable
-                ? {
-                    boxShadow: 2,
-                    borderRadius: 0.5,
-                  }
-                : {},
             }}
-            onClick={isClickable ? handleContentClick : undefined}
-            title={isClickable ? "Haz clic para abrir el audio en una nueva pestaña" : undefined}
           >
             <audio controls style={{ width: "100%" }} src={fileUrl}>
               Tu navegador no admite la etiqueta de audio.

--- a/frontend/src/content/__tests__/ContentDisplay.test.jsx
+++ b/frontend/src/content/__tests__/ContentDisplay.test.jsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ContentDisplay from '../ContentDisplay';
+
+const renderContentDisplay = (content) =>
+  render(
+    <MemoryRouter>
+      <ContentDisplay content={content} variant="detailed" showAuthor={false} />
+    </MemoryRouter>,
+  );
+
+describe('ContentDisplay', () => {
+  let openSpy;
+
+  beforeEach(() => {
+    openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  it('does not open the file in a new tab when interacting with the detailed video player', () => {
+    const content = {
+      id: 10,
+      media_type: 'VIDEO',
+      original_title: 'Ucronia 03 - PCR',
+      file_details: {
+        file: '/media/videos/ucronia.mp4',
+        url: '/media/videos/ucronia.mp4',
+        file_size: 1024,
+      },
+    };
+
+    const { container } = renderContentDisplay(content);
+
+    fireEvent.click(container.querySelector('video'));
+
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps the explicit download action available for detailed video content', () => {
+    const content = {
+      id: 10,
+      media_type: 'VIDEO',
+      original_title: 'Ucronia 03 - PCR',
+      file_details: {
+        file: '/media/videos/ucronia.mp4',
+        url: '/media/videos/ucronia.mp4',
+        file_size: 1024,
+      },
+    };
+
+    renderContentDisplay(content);
+
+    fireEvent.click(screen.getByRole('button', { name: /descargar archivo/i }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'http://localhost:8000/media/videos/ucronia.mp4',
+      '_blank',
+    );
+  });
+});

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -21,11 +21,3 @@ if (!window.matchMedia) {
     })),
   });
 }
-import { expect, afterEach } from 'vitest';
-import { cleanup } from '@testing-library/react';
-import '@testing-library/jest-dom/vitest';
-
-// Cleanup after each test
-afterEach(() => {
-  cleanup();
-});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove click-to-open behavior from detailed video/audio player containers so native controls can be used without opening a new tab.
- Add a regression test for detailed video interaction and explicit download behavior.
- Clean up duplicated test setup imports/cleanup registration so Vitest can run.

## Testing
- `npm test -- ContentDisplay`
- `npm run build`

## Notes
- `npm run lint` is currently blocked by the existing ESLint config referencing missing dependencies: `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11318c4f-5396-4f67-9b58-f3188bf61dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11318c4f-5396-4f67-9b58-f3188bf61dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

