### PR TITLE
Fix default thumbnail fallback when OG image fails

### DIFF
--- a/frontend/src/content/ContentDisplay.jsx
+++ b/frontend/src/content/ContentDisplay.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   Box,
   Typography,
@@ -39,7 +39,11 @@ import SearchIcon from "@mui/icons-material/Search";
 import CloseIcon from "@mui/icons-material/Close";
 import { formatFileSize } from "../utils/fileUtils";
 import VoteComponent from "../votes/VoteComponent";
-import { getDefaultMediaThumbnail } from "./defaultMediaThumbnails";
+import {
+  SequentialThumbnail,
+  buildListingThumbnailSources,
+  buildMediaPreviewThumbnailSources,
+} from "./ContentListingThumbnail";
 
 const ContentDisplay = ({
   content,
@@ -57,20 +61,12 @@ const ContentDisplay = ({
   onSuggestFile = null,
 }) => {
   const [renderError, setRenderError] = useState(null);
-  const [imageLoadError, setImageLoadError] = useState(false);
   const [snackbar, setSnackbar] = useState({
     open: false,
     message: "",
     severity: "success",
   });
   const navigate = useNavigate();
-
-  // Must run before any early return (Rules of Hooks)
-  useEffect(() => {
-    if (content?.id != null) {
-      setImageLoadError(false);
-    }
-  }, [content?.id]);
 
   if (!content) {
     return null;
@@ -393,11 +389,12 @@ const ContentDisplay = ({
       }
       case "VIDEO":
         if (!fileUrl || !fileDetails?.file) {
-          const thumbUrl =
-            customThumbnailForDisplay ||
-            fileDetails?.og_image ||
-            getDefaultMediaThumbnail(mediaTypeUpper);
-          if (thumbUrl) {
+          const previewSources = buildMediaPreviewThumbnailSources({
+            customThumbnailForDisplay,
+            ogImage: fileDetails?.og_image,
+            mediaType: mediaTypeUpper,
+          });
+          if (previewSources.length > 0) {
             return (
               <Box
                 sx={{
@@ -413,18 +410,13 @@ const ContentDisplay = ({
                   borderColor: "divider",
                 }}
               >
-                <img
-                  src={thumbUrl}
-                  alt="Content thumbnail"
-                  style={{
-                    width: "100%",
-                    height: "100%",
-                    objectFit: "cover",
-                  }}
-                  onError={(e) => {
-                    console.error("Thumbnail failed to load in detailed mode:", thumbUrl);
-                    e.target.style.display = "none";
-                  }}
+                <SequentialThumbnail
+                  sources={previewSources}
+                  fallback={
+                    <Typography color="text.secondary">
+                      Archivo de video no disponible
+                    </Typography>
+                  }
                 />
               </Box>
             );
@@ -463,11 +455,12 @@ const ContentDisplay = ({
         );
       case "AUDIO":
         if (!fileUrl || !fileDetails?.file) {
-          const thumbUrl =
-            customThumbnailForDisplay ||
-            fileDetails?.og_image ||
-            getDefaultMediaThumbnail(mediaTypeUpper);
-          if (thumbUrl) {
+          const previewSources = buildMediaPreviewThumbnailSources({
+            customThumbnailForDisplay,
+            ogImage: fileDetails?.og_image,
+            mediaType: mediaTypeUpper,
+          });
+          if (previewSources.length > 0) {
             return (
               <Box
                 sx={{
@@ -483,18 +476,13 @@ const ContentDisplay = ({
                   borderColor: "divider",
                 }}
               >
-                <img
-                  src={thumbUrl}
-                  alt="Content thumbnail"
-                  style={{
-                    width: "100%",
-                    height: "100%",
-                    objectFit: "cover",
-                  }}
-                  onError={(e) => {
-                    console.error("Thumbnail failed to load in detailed mode:", thumbUrl);
-                    e.target.style.display = "none";
-                  }}
+                <SequentialThumbnail
+                  sources={previewSources}
+                  fallback={
+                    <Typography color="text.secondary">
+                      Archivo de audio no disponible
+                    </Typography>
+                  }
                 />
               </Box>
             );
@@ -1072,106 +1060,21 @@ const ContentDisplay = ({
                   },
                 }}
               >
-                {(() => {
-                  // Priority order: 1) custom thumbnail, 2) file image, 3) og_image,
-                  // 4) favicon, 5) default audio/video art, 6) media type icon
-
-                  // 1. Check if content has a file that is an image
-                  const isImage =
-                    contentData.media_type?.toUpperCase() === "IMAGE";
-                  const hasImageFile = isImage && fileDetails?.file;
-
-                  // 0. Check for user-defined thumbnail (ContentProfile)
-                  if (customThumbnailForDisplay && !imageLoadError) {
-                    return (
-                      <img
-                        src={customThumbnailForDisplay}
-                        alt="Content thumbnail"
-                        loading="lazy"
-                        style={{
-                          width: "100%",
-                          height: "100%",
-                          objectFit: "cover",
-                        }}
-                        onError={() => setImageLoadError(true)}
-                      />
-                    );
-                  }
-
-                  if (hasImageFile) {
-                    const imageSrc = resolveMediaUrl(fileDetails.url ?? fileDetails.file);
-                    return (
-                      <img
-                        src={imageSrc}
-                        alt={title || "Content image"}
-                        style={{
-                          width: "100%",
-                          height: "100%",
-                          objectFit: "cover",
-                        }}
-                        onError={() => setImageLoadError(true)}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          // Open the image in new tab when clicked
-                          window.open(imageSrc, "_blank");
-                        }}
-                      />
-                    );
-                  }
-
-                  // 2. Check for Open Graph image
-                  if (fileDetails?.og_image && !imageLoadError) {
-                    return (
-                      <img
-                        src={fileDetails.og_image}
-                        alt="Website preview"
-                        style={{
-                          width: "100%",
-                          height: "100%",
-                          objectFit: "cover",
-                        }}
-                        onError={() => setImageLoadError(true)}
-                      />
-                    );
-                  }
-
-                  // 3. Check for favicon
-                  if (favicon && !imageLoadError) {
-                    return (
-                      <img
-                        src={favicon}
-                        alt="Site favicon"
-                        style={{
-                          width: "32px",
-                          height: "32px",
-                          objectFit: "contain",
-                        }}
-                        onError={() => setImageLoadError(true)}
-                      />
-                    );
-                  }
-
-                  // 4. Default thumbnail for audio/video uploads without a cover
-                  const defaultMediaThumbnail = getDefaultMediaThumbnail(contentData.media_type);
-                  if (defaultMediaThumbnail && !imageLoadError) {
-                    return (
-                      <img
-                        src={defaultMediaThumbnail}
-                        alt="Content thumbnail"
-                        loading="lazy"
-                        style={{
-                          width: "100%",
-                          height: "100%",
-                          objectFit: "cover",
-                        }}
-                        onError={() => setImageLoadError(true)}
-                      />
-                    );
-                  }
-
-                  // 5. Fallback to media type icon
-                  return getMediaTypeIcon(contentData);
-                })()}
+                <SequentialThumbnail
+                  sources={buildListingThumbnailSources({
+                    customThumbnailForDisplay,
+                    hasImageFile:
+                      contentData.media_type?.toUpperCase() === "IMAGE" &&
+                      fileDetails?.file,
+                    fileDetails,
+                    favicon,
+                    mediaType: contentData.media_type,
+                    title,
+                    resolveMediaUrl,
+                  })}
+                  fallback={getMediaTypeIcon(contentData)}
+                  loading="lazy"
+                />
               </Box>
 
               {/* Content Information Section */}
@@ -1458,104 +1361,21 @@ const ContentDisplay = ({
                   bgcolor: "background.paper",
                 }}
               >
-                {(() => {
-                  // Priority order: 1) custom thumbnail, 2) file image, 3) og_image,
-                  // 4) favicon, 5) default audio/video art, 6) media type icon
-
-                  // 1. Check if content has a file that is an image
-                  const isImage =
-                    contentData.media_type?.toUpperCase() === "IMAGE";
-                  const hasImageFile = isImage && fileDetails?.file;
-
-                  // 0. Check for user-defined thumbnail (ContentProfile)
-                  if (customThumbnailForDisplay && !imageLoadError) {
-                    return (
-                      <img
-                        src={customThumbnailForDisplay}
-                        alt="Content thumbnail"
-                        loading="lazy"
-                        style={{
-                          width: "100%",
-                          height: "100%",
-                          objectFit: "cover",
-                        }}
-                        onError={() => setImageLoadError(true)}
-                      />
-                    );
-                  }
-
-                  if (hasImageFile) {
-                    const imageSrc = resolveMediaUrl(fileDetails.url ?? fileDetails.file);
-                    return (
-                      <img
-                        src={imageSrc}
-                        alt={title}
-                        style={{
-                          width: "100%",
-                          height: "100%",
-                          objectFit: "cover",
-                        }}
-                        onError={(e) => {
-                          console.log("Image failed to load:", imageSrc);
-                          e.target.style.display = "none";
-                        }}
-                      />
-                    );
-                  }
-
-                  // 2. Check for Open Graph image
-                  if (fileDetails?.og_image && !imageLoadError) {
-                    return (
-                      <img
-                        src={fileDetails.og_image}
-                        alt="Website preview"
-                        style={{
-                          width: "100%",
-                          height: "100%",
-                          objectFit: "cover",
-                        }}
-                        onError={() => setImageLoadError(true)}
-                      />
-                    );
-                  }
-
-                  // 3. Check for favicon
-                  if (favicon && !imageLoadError) {
-                    return (
-                      <img
-                        src={favicon}
-                        alt="Site favicon"
-                        style={{
-                          width: "32px",
-                          height: "32px",
-                          objectFit: "contain",
-                        }}
-                        onError={() => setImageLoadError(true)}
-                      />
-                    );
-                  }
-
-                  // 4. Default thumbnail for audio/video uploads without a cover
-                  const defaultMediaThumbnail = getDefaultMediaThumbnail(contentData.media_type);
-                  if (defaultMediaThumbnail && !imageLoadError) {
-                    return (
-                      <img
-                        src={defaultMediaThumbnail}
-                        alt="Content thumbnail"
-                        loading="lazy"
-                        style={{
-                          width: "100%",
-                          height: "100%",
-                          objectFit: "cover",
-                        }}
-                        onError={() => setImageLoadError(true)}
-                      />
-                    );
-                  }
-
-                  // 5. Fallback to media type icon
-                  return getMediaTypeIcon(contentData);
-                })()}
+                <SequentialThumbnail
+                  sources={buildListingThumbnailSources({
+                    customThumbnailForDisplay,
+                    hasImageFile:
+                      contentData.media_type?.toUpperCase() === "IMAGE" &&
+                      fileDetails?.file,
+                    fileDetails,
+                    favicon,
+                    mediaType: contentData.media_type,
+                    title,
+                    resolveMediaUrl,
+                  })}
+                  fallback={getMediaTypeIcon(contentData)}
+                  loading="lazy"
+                />
               </CardMedia>
               <CardContent sx={{ 
                 flexGrow: 1,

--- a/frontend/src/content/ContentListingThumbnail.jsx
+++ b/frontend/src/content/ContentListingThumbnail.jsx
@@ -1,0 +1,138 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getDefaultMediaThumbnail } from './defaultMediaThumbnails';
+
+/**
+ * Try thumbnail URLs in order; advance to the next source when the current img fails to load.
+ */
+export function SequentialThumbnail({
+  sources,
+  fallback = null,
+  loading = 'lazy',
+  imgStyle,
+  onImageClick,
+}) {
+  const sourceKey = useMemo(
+    () => sources.map((source) => source.src).join('|'),
+    [sources],
+  );
+  const [failedIndex, setFailedIndex] = useState(0);
+
+  useEffect(() => {
+    setFailedIndex(0);
+  }, [sourceKey]);
+
+  const current = sources[failedIndex];
+  if (!current) {
+    return fallback;
+  }
+
+  const handleClick = current.onClick || onImageClick;
+
+  return (
+    <img
+      src={current.src}
+      alt={current.alt}
+      loading={loading}
+      style={{
+        width: '100%',
+        height: '100%',
+        objectFit: current.objectFit || 'cover',
+        ...(current.style || {}),
+        ...(imgStyle || {}),
+      }}
+      onClick={handleClick}
+      onError={() => setFailedIndex((index) => index + 1)}
+    />
+  );
+}
+
+export function buildListingThumbnailSources({
+  customThumbnailForDisplay,
+  hasImageFile,
+  fileDetails,
+  favicon,
+  mediaType,
+  title,
+  resolveMediaUrl,
+}) {
+  const sources = [];
+
+  if (customThumbnailForDisplay) {
+    sources.push({
+      src: customThumbnailForDisplay,
+      alt: 'Content thumbnail',
+    });
+  }
+
+  if (hasImageFile) {
+    const imageSrc = resolveMediaUrl(fileDetails.url ?? fileDetails.file);
+    if (imageSrc) {
+      sources.push({
+        src: imageSrc,
+        alt: title || 'Content image',
+        onClick: (event) => {
+          event.stopPropagation();
+          window.open(imageSrc, '_blank');
+        },
+      });
+    }
+  }
+
+  if (fileDetails?.og_image) {
+    sources.push({
+      src: fileDetails.og_image,
+      alt: 'Website preview',
+    });
+  }
+
+  if (favicon) {
+    sources.push({
+      src: favicon,
+      alt: 'Site favicon',
+      objectFit: 'contain',
+      style: { width: '32px', height: '32px' },
+    });
+  }
+
+  const defaultMediaThumbnail = getDefaultMediaThumbnail(mediaType);
+  if (defaultMediaThumbnail) {
+    sources.push({
+      src: defaultMediaThumbnail,
+      alt: 'Content thumbnail',
+    });
+  }
+
+  return sources;
+}
+
+export function buildMediaPreviewThumbnailSources({
+  customThumbnailForDisplay,
+  ogImage,
+  mediaType,
+}) {
+  const sources = [];
+
+  if (customThumbnailForDisplay) {
+    sources.push({
+      src: customThumbnailForDisplay,
+      alt: 'Content thumbnail',
+    });
+  }
+
+  if (ogImage) {
+    sources.push({
+      src: ogImage,
+      alt: 'Content thumbnail',
+    });
+  }
+
+  const defaultMediaThumbnail = getDefaultMediaThumbnail(mediaType);
+  if (defaultMediaThumbnail) {
+    sources.push({
+      src: defaultMediaThumbnail,
+      alt: 'Content thumbnail',
+    });
+  }
+
+  return sources;
+}

--- a/frontend/src/content/__tests__/ContentListingThumbnail.test.jsx
+++ b/frontend/src/content/__tests__/ContentListingThumbnail.test.jsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  SequentialThumbnail,
+  buildListingThumbnailSources,
+  buildMediaPreviewThumbnailSources,
+} from '../ContentListingThumbnail';
+
+describe('ContentListingThumbnail', () => {
+  it('falls back to the next source when an image fails to load', () => {
+    render(
+      <SequentialThumbnail
+        sources={[
+          { src: 'https://example.com/broken-og.jpg', alt: 'og' },
+          { src: '/images/video_thumbnail_default.webp', alt: 'default' },
+        ]}
+        fallback={<span>icon fallback</span>}
+      />,
+    );
+
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'src',
+      'https://example.com/broken-og.jpg',
+    );
+
+    fireEvent.error(screen.getByRole('img'));
+
+    expect(screen.getByRole('img')).toHaveAttribute(
+      'src',
+      '/images/video_thumbnail_default.webp',
+    );
+  });
+
+  it('builds listing sources ending with the default media thumbnail', () => {
+    const sources = buildListingThumbnailSources({
+      customThumbnailForDisplay: null,
+      hasImageFile: false,
+      fileDetails: { og_image: 'https://example.com/og.jpg' },
+      favicon: null,
+      mediaType: 'VIDEO',
+      title: 'Test video',
+      resolveMediaUrl: (value) => value,
+    });
+
+    expect(sources.map((source) => source.src)).toEqual([
+      'https://example.com/og.jpg',
+      '/images/video_thumbnail_default.webp',
+    ]);
+  });
+
+  it('builds preview sources for detailed video cards', () => {
+    const sources = buildMediaPreviewThumbnailSources({
+      customThumbnailForDisplay: null,
+      ogImage: 'https://example.com/og.jpg',
+      mediaType: 'VIDEO',
+    });
+
+    expect(sources.map((source) => source.src)).toEqual([
+      'https://example.com/og.jpg',
+      '/images/video_thumbnail_default.webp',
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Video cards sometimes showed the generic media icon instead of the default thumbnail when a YouTube `og_image` URL existed but failed to load (404, hotlink block, expired preview, etc.).

Root cause: `ContentDisplay` used a single shared `imageLoadError` flag. When OG failed, that flag blocked **all** later fallbacks — including the default WebP artwork.

## Fix

- Add `SequentialThumbnail` to try thumbnail sources in order and advance on `onError`.
- Use it in card, preview, and detailed audio/video views.
- Keep the same priority: custom thumbnail → image file → OG → favicon → default artwork → icon.

## Test plan

- [x] `npm test -- --run src/content/__tests__/ContentListingThumbnail.test.jsx`
- [ ] Video with broken OG URL shows default thumbnail in topic cards
- [ ] Video with working OG URL still shows OG image
- [ ] Video without OG/thumbnail still shows default artwork
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f0615b2-f8e9-4e26-9fbe-b7119a0c1be8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f0615b2-f8e9-4e26-9fbe-b7119a0c1be8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

