### PR TITLE
Improve topic timeline content selector

### DIFF
--- a/frontend/src/topics/timeline/TopicTimelineContentSelector.jsx
+++ b/frontend/src/topics/timeline/TopicTimelineContentSelector.jsx
@@ -1,0 +1,346 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  Checkbox,
+  Chip,
+  FormControl,
+  IconButton,
+  InputLabel,
+  Link as MuiLink,
+  MenuItem,
+  Paper,
+  Radio,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import SearchIcon from '@mui/icons-material/Search';
+import { formatDate } from '../../utils/dateUtils';
+
+const MEDIA_TYPE_LABELS = {
+  VIDEO: 'Video',
+  AUDIO: 'Audio',
+  IMAGE: 'Imagen',
+  TEXT: 'Texto',
+};
+
+const getContentData = (item) => item?.content || item;
+
+const getItemId = (item) => {
+  const content = getContentData(item);
+  return content?.id != null ? String(content.id) : null;
+};
+
+const getItemTitle = (item) => {
+  const content = getContentData(item);
+  return (
+    item?.title ||
+    item?.selected_profile?.title ||
+    content?.original_title ||
+    'Contenido sin titulo'
+  );
+};
+
+const getItemAuthor = (item) => {
+  const content = getContentData(item);
+  return item?.author || item?.selected_profile?.author || content?.original_author || 'Desconocido';
+};
+
+const getItemMediaType = (item) => {
+  const content = getContentData(item);
+  return (content?.media_type || item?.media_type || 'TEXT').toUpperCase();
+};
+
+const getItemCreatedAt = (item) => {
+  const content = getContentData(item);
+  return item?.created_at || content?.created_at || item?.selected_profile?.created_at || null;
+};
+
+const normalizeItems = (items = []) => (
+  items
+    .map((item) => ({
+      id: getItemId(item),
+      title: getItemTitle(item),
+      author: getItemAuthor(item),
+      mediaType: getItemMediaType(item),
+      createdAt: getItemCreatedAt(item),
+      contentId: getItemId(item),
+    }))
+    .filter((item) => item.id)
+);
+
+const TopicTimelineContentSelector = ({
+  items = [],
+  selectedIds = [],
+  primaryContentId = '',
+  loading = false,
+  onSelectionChange,
+  onPrimaryChange,
+}) => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [mediaTypeFilter, setMediaTypeFilter] = useState('');
+  const [sortField, setSortField] = useState('title');
+  const [sortDirection, setSortDirection] = useState('asc');
+
+  const normalizedItems = useMemo(() => normalizeItems(items), [items]);
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const filteredItems = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    let result = normalizedItems.filter((item) => {
+      const matchesMedia = !mediaTypeFilter || item.mediaType === mediaTypeFilter;
+      const matchesSearch = !query ||
+        item.title.toLowerCase().includes(query) ||
+        item.author.toLowerCase().includes(query) ||
+        (MEDIA_TYPE_LABELS[item.mediaType] || item.mediaType).toLowerCase().includes(query);
+      return matchesMedia && matchesSearch;
+    });
+
+    result = [...result].sort((a, b) => {
+      let aValue = '';
+      let bValue = '';
+      if (sortField === 'author') {
+        aValue = a.author.toLowerCase();
+        bValue = b.author.toLowerCase();
+      } else if (sortField === 'mediaType') {
+        aValue = MEDIA_TYPE_LABELS[a.mediaType] || a.mediaType;
+        bValue = MEDIA_TYPE_LABELS[b.mediaType] || b.mediaType;
+      } else if (sortField === 'createdAt') {
+        aValue = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+        bValue = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      } else {
+        aValue = a.title.toLowerCase();
+        bValue = b.title.toLowerCase();
+      }
+
+      if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
+      if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
+      return 0;
+    });
+
+    return result;
+  }, [mediaTypeFilter, normalizedItems, searchQuery, sortDirection, sortField]);
+
+  const selectedItems = useMemo(
+    () => normalizedItems.filter((item) => selectedSet.has(item.id)),
+    [normalizedItems, selectedSet],
+  );
+
+  const setSelectedIds = (nextIds) => {
+    const nextUniqueIds = [...new Set(nextIds)];
+    onSelectionChange(nextUniqueIds);
+    if (nextUniqueIds.length === 0) {
+      onPrimaryChange('');
+      return;
+    }
+    if (!nextUniqueIds.includes(primaryContentId)) {
+      onPrimaryChange(nextUniqueIds[0]);
+    }
+  };
+
+  const handleToggle = (itemId) => {
+    if (selectedSet.has(itemId)) {
+      setSelectedIds(selectedIds.filter((id) => id !== itemId));
+    } else {
+      setSelectedIds([...selectedIds, itemId]);
+    }
+  };
+
+  const handleSelectVisible = (event) => {
+    const visibleIds = filteredItems.map((item) => item.id);
+    if (event.target.checked) {
+      setSelectedIds([...selectedIds, ...visibleIds]);
+    } else {
+      setSelectedIds(selectedIds.filter((id) => !visibleIds.includes(id)));
+    }
+  };
+
+  const visibleSelectedCount = filteredItems.filter((item) => selectedSet.has(item.id)).length;
+  const allVisibleSelected = filteredItems.length > 0 && visibleSelectedCount === filteredItems.length;
+  const someVisibleSelected = visibleSelectedCount > 0 && !allVisibleSelected;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, bgcolor: 'background.paper' }}>
+      <Stack spacing={2}>
+        <Box>
+          <Typography variant="subtitle1" fontWeight={700}>
+            Contenidos del tema
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Selecciona uno o varios contenidos ya agregados al tema. Marca un contenido principal para destacarlo en la entrada.
+          </Typography>
+        </Box>
+
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} alignItems={{ xs: 'stretch', md: 'center' }}>
+          <TextField
+            placeholder="Buscar por titulo, autor o tipo..."
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            size="small"
+            disabled={loading}
+            InputProps={{
+              startAdornment: <SearchIcon sx={{ mr: 1, color: 'text.secondary' }} />,
+            }}
+            sx={{ flexGrow: 1, minWidth: { md: 240 } }}
+          />
+
+          <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 160 } }} disabled={loading}>
+            <InputLabel>Tipo</InputLabel>
+            <Select
+              value={mediaTypeFilter}
+              label="Tipo"
+              onChange={(event) => setMediaTypeFilter(event.target.value)}
+            >
+              <MenuItem value="">
+                <em>Todos los tipos</em>
+              </MenuItem>
+              {Object.entries(MEDIA_TYPE_LABELS).map(([value, label]) => (
+                <MenuItem key={value} value={value}>{label}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 160 } }} disabled={loading}>
+            <InputLabel>Ordenar por</InputLabel>
+            <Select
+              value={sortField}
+              label="Ordenar por"
+              onChange={(event) => setSortField(event.target.value)}
+            >
+              <MenuItem value="title">Titulo</MenuItem>
+              <MenuItem value="author">Autor</MenuItem>
+              <MenuItem value="mediaType">Tipo</MenuItem>
+              <MenuItem value="createdAt">Fecha de subida</MenuItem>
+            </Select>
+          </FormControl>
+
+          <Tooltip title={sortDirection === 'asc' ? 'Ascendente' : 'Descendente'}>
+            <IconButton
+              onClick={() => setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'))}
+              size="small"
+              disabled={loading}
+              sx={{ border: 1, borderColor: 'divider', alignSelf: { xs: 'flex-start', md: 'center' } }}
+            >
+              {sortDirection === 'asc' ? <ArrowUpwardIcon /> : <ArrowDownwardIcon />}
+            </IconButton>
+          </Tooltip>
+        </Stack>
+
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} justifyContent="space-between" alignItems={{ xs: 'flex-start', sm: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            {loading
+              ? 'Cargando contenidos...'
+              : `${filteredItems.length} contenido(s) disponible(s) - ${selectedIds.length} seleccionado(s)`}
+          </Typography>
+          {selectedItems.length > 0 && (
+            <Stack direction="row" spacing={0.75} sx={{ flexWrap: 'wrap', gap: 0.75 }}>
+              {selectedItems.slice(0, 4).map((item) => (
+                <Chip key={item.id} size="small" label={item.title} onDelete={() => handleToggle(item.id)} />
+              ))}
+              {selectedItems.length > 4 && (
+                <Chip size="small" label={`+${selectedItems.length - 4} mas`} variant="outlined" />
+              )}
+            </Stack>
+          )}
+        </Stack>
+
+        <TableContainer sx={{ maxHeight: 360, border: 1, borderColor: 'divider' }}>
+          <Table stickyHeader size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell padding="checkbox">
+                  <Checkbox
+                    checked={allVisibleSelected}
+                    indeterminate={someVisibleSelected}
+                    onChange={handleSelectVisible}
+                    disabled={loading || filteredItems.length === 0}
+                  />
+                </TableCell>
+                <TableCell padding="checkbox">Principal</TableCell>
+                <TableCell>Titulo</TableCell>
+                <TableCell>Tipo</TableCell>
+                <TableCell>Autor</TableCell>
+                <TableCell>Fecha</TableCell>
+                <TableCell>Ver</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filteredItems.map((item) => {
+                const selected = selectedSet.has(item.id);
+                return (
+                  <TableRow
+                    key={item.id}
+                    hover
+                    onClick={() => handleToggle(item.id)}
+                    selected={selected}
+                    sx={{ cursor: 'pointer' }}
+                  >
+                    <TableCell padding="checkbox">
+                      <Checkbox checked={selected} />
+                    </TableCell>
+                    <TableCell padding="checkbox" onClick={(event) => event.stopPropagation()}>
+                      <Radio
+                        checked={primaryContentId === item.id}
+                        disabled={!selected}
+                        onChange={() => onPrimaryChange(item.id)}
+                        inputProps={{ 'aria-label': `Marcar ${item.title} como contenido principal` }}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" fontWeight={selected ? 700 : 400}>
+                        {item.title}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        size="small"
+                        color="primary"
+                        variant="outlined"
+                        label={MEDIA_TYPE_LABELS[item.mediaType] || item.mediaType}
+                      />
+                    </TableCell>
+                    <TableCell>{item.author}</TableCell>
+                    <TableCell>{item.createdAt ? formatDate(item.createdAt) : '-'}</TableCell>
+                    <TableCell onClick={(event) => event.stopPropagation()}>
+                      <MuiLink
+                        href={`/content/${item.contentId}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, textDecoration: 'none' }}
+                      >
+                        Ver
+                        <OpenInNewIcon fontSize="small" />
+                      </MuiLink>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+              {!loading && filteredItems.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={7} align="center" sx={{ py: 3 }}>
+                    {normalizedItems.length === 0
+                      ? 'Este tema todavia no tiene contenidos para adjuntar.'
+                      : 'No se encontro contenido con los filtros aplicados.'}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Stack>
+    </Paper>
+  );
+};
+
+export default TopicTimelineContentSelector;

--- a/frontend/src/topics/timeline/TopicTimelineEntryForm.jsx
+++ b/frontend/src/topics/timeline/TopicTimelineEntryForm.jsx
@@ -1,34 +1,17 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Alert,
   Box,
   Button,
-  Checkbox,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  FormControl,
-  InputLabel,
-  ListItemText,
-  MenuItem,
-  OutlinedInput,
-  Select,
   Stack,
   TextField,
   Typography,
 } from '@mui/material';
-
-const getAvailableContentId = (item) => item?.content?.id ?? item?.id;
-
-const getAvailableContentTitle = (item) => (
-  item?.title ||
-  item?.content?.original_title ||
-  item?.selected_profile?.title ||
-  'Contenido sin titulo'
-);
-
-const getAvailableContentMediaType = (item) => item?.content?.media_type || item?.media_type || 'TEXT';
+import TopicTimelineContentSelector from './TopicTimelineContentSelector';
 
 const buildInitialState = (entry) => {
   const links = [...(entry?.contents || [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
@@ -63,40 +46,25 @@ const TopicTimelineEntryForm = ({
     }
   }, [entry, open]);
 
-  const contentOptions = useMemo(() => {
-    return (availableContents || [])
-      .map((item) => ({
-        id: String(getAvailableContentId(item)),
-        title: getAvailableContentTitle(item),
-        mediaType: getAvailableContentMediaType(item),
-      }))
-      .filter((item) => item.id && item.id !== 'undefined');
-  }, [availableContents]);
-
-  const selectedLabels = form.selectedContentIds
-    .map((id) => contentOptions.find((item) => item.id === id)?.title)
-    .filter(Boolean)
-    .join(', ');
-
   const handleFieldChange = (field) => (event) => {
     setForm((prev) => ({ ...prev, [field]: event.target.value }));
   };
 
-  const handleContentChange = (event) => {
-    const value = typeof event.target.value === 'string'
-      ? event.target.value.split(',')
-      : event.target.value;
+  const handleContentSelectionChange = (selectedIds) => {
     setForm((prev) => {
-      const nextSelected = value;
-      const nextPrimary = nextSelected.includes(prev.primaryContentId)
+      const nextPrimary = selectedIds.includes(prev.primaryContentId)
         ? prev.primaryContentId
-        : (nextSelected[0] || '');
+        : (selectedIds[0] || '');
       return {
         ...prev,
-        selectedContentIds: nextSelected,
+        selectedContentIds: selectedIds,
         primaryContentId: nextPrimary,
       };
     });
+  };
+
+  const handlePrimaryContentChange = (contentId) => {
+    setForm((prev) => ({ ...prev, primaryContentId: contentId }));
   };
 
   const handleSubmit = (event) => {
@@ -167,45 +135,14 @@ const TopicTimelineEntryForm = ({
               />
             </Stack>
 
-            <FormControl fullWidth disabled={loadingContents}>
-              <InputLabel id="timeline-entry-content-label">Contenidos del tema</InputLabel>
-              <Select
-                labelId="timeline-entry-content-label"
-                multiple
-                value={form.selectedContentIds}
-                onChange={handleContentChange}
-                input={<OutlinedInput label="Contenidos del tema" />}
-                renderValue={() => selectedLabels || 'Sin contenidos adjuntos'}
-              >
-                {contentOptions.map((item) => (
-                  <MenuItem key={item.id} value={item.id}>
-                    <Checkbox checked={form.selectedContentIds.includes(item.id)} />
-                    <ListItemText primary={item.title} secondary={item.mediaType} />
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-
-            {form.selectedContentIds.length > 0 && (
-              <FormControl fullWidth>
-                <InputLabel id="timeline-primary-content-label">Contenido principal</InputLabel>
-                <Select
-                  labelId="timeline-primary-content-label"
-                  value={form.primaryContentId}
-                  label="Contenido principal"
-                  onChange={handleFieldChange('primaryContentId')}
-                >
-                  {form.selectedContentIds.map((id) => {
-                    const option = contentOptions.find((item) => item.id === id);
-                    return (
-                      <MenuItem key={id} value={id}>
-                        {option?.title || `Contenido ${id}`}
-                      </MenuItem>
-                    );
-                  })}
-                </Select>
-              </FormControl>
-            )}
+            <TopicTimelineContentSelector
+              items={availableContents}
+              selectedIds={form.selectedContentIds}
+              primaryContentId={form.primaryContentId}
+              loading={loadingContents}
+              onSelectionChange={handleContentSelectionChange}
+              onPrimaryChange={handlePrimaryContentChange}
+            />
 
             <Typography variant="caption" color="text.secondary">
               La fecha es opcional. Si no agregas fecha ni etiqueta, la entrada se mostrara como una etapa numerada.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace the timeline entry multi-select dropdown with a richer topic-content selector inspired by the library selector UX
- Add search, media-type filter, sorting, select-visible checkbox, selected chips, and a primary-content radio action
- Keep timeline payload semantics unchanged: selected rows still map to topic `content_id`, with one `PRIMARY` item and the rest as `REFERENCE`

## Testing
- `npx eslint src/topics/timeline/TopicTimelineEntryForm.jsx src/topics/timeline/TopicTimelineContentSelector.jsx --max-warnings 0` ✅
- `npm run build` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1877aced-ceb4-4644-ab66-0b8209b544ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1877aced-ceb4-4644-ab66-0b8209b544ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

