### PR TITLE
Fix N+1 ContentProfile queries on topic content media type endpoint

### DIFF
--- a/acbc_app/content/tests.py
+++ b/acbc_app/content/tests.py
@@ -2485,6 +2485,45 @@ class KnowledgePathAndTopicMediaTypeAPITests(APITestCase):
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(response.data['results'][0]['media_type'], 'VIDEO')
 
+    def test_topic_content_media_type_profile_lookup_is_batched(self):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        topic = Topic.objects.create(
+            title='Batch Profile Topic',
+            description='N+1 regression test',
+            creator=self.author,
+        )
+        for index in range(8):
+            content = Content.objects.create(
+                uploaded_by=self.author,
+                media_type='TEXT',
+                original_title=f'Text Content {index}',
+            )
+            ContentProfile.objects.create(
+                content=content,
+                user=self.author,
+                title=f'Text Profile {index}',
+            )
+            topic.contents.add(content)
+
+        url = reverse('content:topic-content-media-type', args=[topic.id, 'text'])
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 8)
+        profile_queries = [
+            query['sql']
+            for query in context.captured_queries
+            if 'content_contentprofile' in query['sql'].lower()
+        ]
+        self.assertLessEqual(
+            len(profile_queries),
+            2,
+            msg='Expected batched profile prefetch, not one query per content item',
+        )
+
 
 class TopicContentSuggestionsAPITests(APITestCase):
     def setUp(self):

--- a/acbc_app/content/views.py
+++ b/acbc_app/content/views.py
@@ -2650,26 +2650,6 @@ class UserTopicInvitationsView(APIView):
 class TopicContentMediaTypeView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def get_content_profile(self, content, request, topic):
-        """
-        Get the appropriate ContentProfile based on context.
-        For topics, we want the topic creator's profile for the content.
-        """
-        try:
-            # Try to get the topic creator's profile for this content
-            return ContentProfile.objects.get(content=content, user=topic.creator)
-        except ContentProfile.DoesNotExist:
-            pass
-
-        # Fallback: try to get logged user's profile
-        try:
-            return ContentProfile.objects.get(content=content, user=request.user)
-        except ContentProfile.DoesNotExist:
-            pass
-
-        # Final fallback: return None (serializer will use original content data)
-        return None
-
     def get(self, request, pk, media_type):
         topic = get_object_or_404(Topic, pk=pk)
         media_type = media_type.upper()
@@ -2683,12 +2663,21 @@ class TopicContentMediaTypeView(APIView):
         )
         contents = topic.contents.filter(media_type=media_type).annotate(
             vote_count_value=Coalesce(vote_count_subquery, 0)
-        ).order_by('-vote_count_value', '-created_at').prefetch_related('file_details')
+        ).order_by('-vote_count_value', '-created_at').prefetch_related(
+            'file_details',
+            'profiles',
+            'profiles__user',
+        ).select_related('uploaded_by')
 
-        # Get the appropriate profile for each content
+        # Batch profile lookup via prefetch — avoids N+1 selects on content_contentprofile.
         contents_with_profiles = []
         for content in contents:
-            selected_profile = self.get_content_profile(content, request, topic)
+            selected_profile = get_topic_content_profile_for_display(
+                content,
+                request,
+                topic,
+                prefetched_profiles=list(content.profiles.all()),
+            )
             contents_with_profiles.append({
                 'content': content,
                 'selected_profile': selected_profile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Sentry reported an **N+1 Query** on `content_contentprofile` for the endpoint:

`/api/content/topics/{pk}/content/{media_type}/`

`TopicContentMediaTypeView` was calling `ContentProfile.objects.get()` once per content item when resolving the selected profile for each result.

## Solution

Reuse the existing `get_topic_content_profile_for_display()` helper (already used by `TopicDetailView` and `TopicContentSimpleView`) with batched profile prefetching:

- `prefetch_related('profiles', 'profiles__user')` on the content queryset
- `select_related('uploaded_by')` for serializer fallbacks
- In-memory profile selection via prefetched data (no per-item DB lookups)

## Testing

- Added `test_topic_content_media_type_profile_lookup_is_batched` to assert profile queries stay bounded when listing 8 text items
- Existing `test_topic_content_media_type_returns_filtered_content` still passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64467d08-7edf-4486-8388-df7857376438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64467d08-7edf-4486-8388-df7857376438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

