### PR TITLE
fix: NOTION_API_KEY único y tipo Tarea siempre

### DIFF
--- a/.github/workflows/cloudflare-analytics-report.yml
+++ b/.github/workflows/cloudflare-analytics-report.yml
@@ -30,19 +30,14 @@ jobs:
           CF_ZONE_NAME: ${{ secrets.CF_ZONE_NAME }}
           CF_REPORT_DAYS: ${{ github.event.inputs.days || '7' }}
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
-          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
           NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
-          NOTION_TASKS_DATABASE_ID: ${{ secrets.NOTION_TASKS_DATABASE_ID }}
         run: |
           if [ -z "$CF_API_TOKEN" ] || [ -z "$CF_ACCOUNT_ID" ]; then
             echo "Missing GitHub secrets: CF_API_TOKEN and CF_ACCOUNT_ID are required."
             exit 1
           fi
-          if [ -z "$NOTION_API_KEY" ] && [ -z "$NOTION_TOKEN" ]; then
-            echo "Warning: NOTION_API_KEY/NOTION_TOKEN not set; will skip Notion notify."
-          fi
-          if [ -z "$NOTION_DATABASE_ID" ] && [ -z "$NOTION_TASKS_DATABASE_ID" ]; then
-            echo "Warning: NOTION_DATABASE_ID not set; will skip Notion notify."
+          if [ -z "$NOTION_API_KEY" ] || [ -z "$NOTION_DATABASE_ID" ]; then
+            echo "Warning: NOTION_API_KEY and NOTION_DATABASE_ID required for Notion notify; will skip if missing."
           fi
           python3 scripts/cloudflare_analytics_report.py --days "${CF_REPORT_DAYS}" --notify-notion
 
@@ -50,4 +45,4 @@ jobs:
         if: success()
         run: |
           echo "JSON/MD reports are gitignored — run locally to persist under reports/cloudflare/."
-          echo "Notion: a row is created only when actionable insights are detected (dedup by cf-analytics-YYYY-MM-DD)."
+          echo "Notion: Tarea created only when actionable (dedup cf-analytics-YYYY-MM-DD)."

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -125,7 +125,9 @@ Fetches Cloudflare analytics (traffic, Core Web Vitals, security events) via Gra
 
 **GitHub Actions (scheduled):** `.github/workflows/cloudflare-analytics-report.yml` runs weekly, evaluates actionable insights, and **creates a Notion row** in `NOTION_DATABASE_ID` when warranted (dedup `cf-analytics-YYYY-MM-DD`). Reports on the runner are not committed.
 
-**GitHub secrets:** `CF_*`, `NOTION_DATABASE_ID`, `NOTION_API_KEY` (or `NOTION_TOKEN`).
+**GitHub secrets:** `CF_*`, `NOTION_DATABASE_ID`, `NOTION_API_KEY`.
+
+Cloudflare → Notion rows are always **tipo = Tarea** (severity only affects title/body ordering, not tipo).
 
 **Local reports (persistent):** after `git pull`, run without `--notify-notion` to save under `reports/cloudflare/` (gitignored).
 

--- a/scripts/cloudflare-report.env.example
+++ b/scripts/cloudflare-report.env.example
@@ -20,8 +20,7 @@ CF_REPORT_DAYS=7
 # Output directory (default: <repo>/reports/cloudflare)
 # CF_REPORT_OUTPUT_DIR=./reports/cloudflare
 
-# --- GitHub Actions (repository secrets, same names) ---
-# Settings → Secrets and variables → Actions
-# CF_API_TOKEN, CF_ACCOUNT_ID, CF_ZONE_NAME (or CF_ZONE_ID)
-# NOTION_DATABASE_ID (or NOTION_TASKS_DATABASE_ID)
-# NOTION_API_KEY (or NOTION_TOKEN) — integration must access the database
+# --- Notion (optional; for --notify-notion) ---
+# GitHub Actions secrets: NOTION_API_KEY, NOTION_DATABASE_ID
+NOTION_API_KEY=
+NOTION_DATABASE_ID=

--- a/scripts/cloudflare_notion_notify.py
+++ b/scripts/cloudflare_notion_notify.py
@@ -202,11 +202,6 @@ def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | Non
     if not findings:
         return None
 
-    severities = [f["severity"] for f in findings]
-    has_high = "high" in severities
-    has_medium = "medium" in severities
-    tipo = "Tarea" if has_high or has_medium else "Idea"
-
     priority_order = {"high": 0, "medium": 1, "low": 2}
     findings.sort(key=lambda f: priority_order.get(f["severity"], 9))
 
@@ -237,7 +232,7 @@ def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | Non
 
     return {
         "dedup_id": dedup_id,
-        "tipo": tipo,
+        "tipo": "Tarea",
         "title": title,
         "body": "\n".join(body_lines),
         "findings": findings,
@@ -246,19 +241,17 @@ def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | Non
 
 
 def notion_database_id_from_env() -> str:
-    for key in ("NOTION_DATABASE_ID", "NOTION_TASKS_DATABASE_ID"):
-        value = os.environ.get(key, "").strip()
-        if value:
-            return value
-    raise RuntimeError("Missing NOTION_DATABASE_ID or NOTION_TASKS_DATABASE_ID")
+    value = os.environ.get("NOTION_DATABASE_ID", "").strip()
+    if not value:
+        raise RuntimeError("Missing NOTION_DATABASE_ID")
+    return value
 
 
 def notion_token_from_env() -> str:
-    for key in ("NOTION_API_KEY", "NOTION_TOKEN", "NOTION_SECRET"):
-        value = os.environ.get(key, "").strip()
-        if value:
-            return value
-    raise RuntimeError("Missing NOTION_API_KEY (or NOTION_TOKEN)")
+    value = os.environ.get("NOTION_API_KEY", "").strip()
+    if not value:
+        raise RuntimeError("Missing NOTION_API_KEY")
+    return value
 
 
 def notion_page_exists(database_id: str, token: str, prop_map: dict[str, str], dedup_id: str) -> bool:
@@ -307,10 +300,9 @@ def build_notion_properties(
     if fecha_prop and schema_properties[fecha_prop]["type"] == "date":
         properties[fecha_prop] = {"date": {"start": insight["report_day"]}}
 
-    if insight["tipo"] == "Tarea":
-        estado_prop = prop_map.get("estado")
-        if estado_prop and schema_properties[estado_prop]["type"] == "status":
-            properties[estado_prop] = {"status": {"name": "Por Hacer"}}
+    estado_prop = prop_map.get("estado")
+    if estado_prop and schema_properties[estado_prop]["type"] == "status":
+        properties[estado_prop] = {"status": {"name": "Por Hacer"}}
 
     body = insight["body"]
     body_prop = prop_map.get("slack_procesado") or prop_map.get("notas")
@@ -373,15 +365,9 @@ def maybe_notify_notion(report: dict[str, Any]) -> dict[str, Any] | None:
     if insight is None:
         return {"status": "no_action", "reason": "no_actionable_insights"}
 
-    if not any(
-        os.environ.get(key, "").strip()
-        for key in (
-            "NOTION_API_KEY",
-            "NOTION_TOKEN",
-            "NOTION_SECRET",
-            "NOTION_DATABASE_ID",
-            "NOTION_TASKS_DATABASE_ID",
-        )
+    if not (
+        os.environ.get("NOTION_API_KEY", "").strip()
+        and os.environ.get("NOTION_DATABASE_ID", "").strip()
     ):
         return {
             "status": "skipped",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- Single Notion secret name: **NOTION_API_KEY**
- Cloudflare notifications always create **tipo = Tarea** (severity only sorts findings in body)
- Workflow and env example updated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-331095a9-ed08-47e1-8c77-8d73ef404bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-331095a9-ed08-47e1-8c77-8d73ef404bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

