### PR TITLE
Improve Cloudflare Notion task titles from finding messages

### DIFF
--- a/scripts/cloudflare_notion_notify.py
+++ b/scripts/cloudflare_notion_notify.py
@@ -104,6 +104,26 @@ def lcp_rating(ms: float | None) -> str:
     return "poor"
 
 
+def build_task_title(findings: list[dict[str, Any]], max_len: int = 200) -> str:
+    """Use the primary finding message as the Notion title (readable, no JSON dumps)."""
+    if not findings:
+        return "Cloudflare: sin hallazgos"
+
+    title = findings[0]["message"]
+    extra = len(findings) - 1
+    if extra > 0:
+        suffix = f" (+{extra} más)"
+        title = f"{title}{suffix}"
+
+    if len(title) <= max_len:
+        return title
+
+    trimmed = title[: max_len - 3].rstrip()
+    if " " in trimmed:
+        trimmed = trimmed.rsplit(" ", 1)[0]
+    return f"{trimmed}..."
+
+
 def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | None:
     """Return notification payload if something is worth communicating."""
     findings: list[dict[str, Any]] = []
@@ -116,11 +136,12 @@ def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | Non
         lcp = row.get("lcp_p75_ms")
         rating = lcp_rating(lcp)
         if rating in ("needs_improvement", "poor"):
+            label = "lento" if rating == "needs_improvement" else "muy lento"
             findings.append(
                 {
                     "severity": "high" if rating == "poor" else "medium",
                     "category": "lcp",
-                    "message": f"LCP p75 {lcp} ms ({rating}) en {host} ({samples} muestras)",
+                    "message": f"LCP {label} (p75 {lcp} ms) en {host} — {samples} muestras",
                 }
             )
         inp = row.get("inp_p75_ms")
@@ -194,12 +215,15 @@ def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | Non
         return None
 
     priority_order = {"high": 0, "medium": 1, "low": 2}
-    findings.sort(key=lambda f: priority_order.get(f["severity"], 9))
+    category_order = {"lcp": 0, "inp": 1, "cls": 2, "security": 3, "cache": 4, "traffic": 5}
+    findings.sort(
+        key=lambda f: (
+            priority_order.get(f["severity"], 9),
+            category_order.get(f.get("category", ""), 9),
+        )
+    )
 
-    title_seed = findings[0]["message"]
-    title = f"Cloudflare: {title_seed}"
-    if len(title) > 72:
-        title = title[:69] + "..."
+    title = build_task_title(findings)
 
     report_day = report.get("generated_at", "")[:10] or date.today().isoformat()
     dedup_id = f"cf-analytics-{report_day}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

The Notion task from the first failed Cloudflare run had a bad title:
`Cloudflare: Error parcial al consultar Cloudflare: top_countries: [ ...`

That happened because (a) API errors were treated as high-severity findings, and (b) titles were prefixed + hard-truncated at 72 chars.

PR #68 already fixed the API errors and GraphQL queries. This PR improves titles for real insights.

## Changes

- Title = primary finding `message` directly (no `Cloudflare:` prefix, no JSON)
- When multiple findings: append `(+N más)` e.g. `LCP lento (p75 3152 ms) en www... (+2 más)`
- Sort findings by severity, then category priority (LCP > cache > traffic)
- Truncate at word boundary up to 200 chars (Notion table still truncates visually, but title is meaningful)

## Example title (same data as user's report, without API errors)

`LCP lento (p75 3152.0 ms) en www.academiablockchain.com — 14 muestras (+2 más)`

## Note

The existing task `cf-analytics-2026-06-17` was created by the old run and won't auto-update (dedup). Delete it manually and re-run the workflow to get a clean task.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-331095a9-ed08-47e1-8c77-8d73ef404bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-331095a9-ed08-47e1-8c77-8d73ef404bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

