### PR TITLE
Notify Notion only for high-severity Cloudflare findings

### DIFF
--- a/scripts/cloudflare-report.env.example
+++ b/scripts/cloudflare-report.env.example
@@ -22,5 +22,6 @@ CF_REPORT_DAYS=7
 
 # --- Notion (optional; for --notify-notion) ---
 # GitHub Actions secrets: NOTION_API_KEY, NOTION_DATABASE_ID
+# CF_NOTION_MIN_SEVERITY=high   # only create tasks for high (default); use medium to include LCP needs_improvement, cache, firewall
 NOTION_API_KEY=
 NOTION_DATABASE_ID=

--- a/scripts/cloudflare_notion_notify.py
+++ b/scripts/cloudflare_notion_notify.py
@@ -16,6 +16,10 @@ from typing import Any
 NOTION_API = "https://api.notion.com/v1"
 NOTION_VERSION = "2022-06-28"
 
+NOTION_MIN_SEVERITY = os.environ.get("CF_NOTION_MIN_SEVERITY", "high").strip().lower()
+
+SEVERITY_RANK = {"high": 0, "medium": 1, "low": 2}
+
 PROYECTO_ACBC = "Desarrollo de Software para Academia Blockchain"
 
 PROPERTY_ALIASES: dict[str, list[str]] = {
@@ -124,6 +128,12 @@ def build_task_title(findings: list[dict[str, Any]], max_len: int = 200) -> str:
     return f"{trimmed}..."
 
 
+def findings_meet_notify_threshold(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return findings at or above CF_NOTION_MIN_SEVERITY (default: high only)."""
+    min_rank = SEVERITY_RANK.get(NOTION_MIN_SEVERITY, SEVERITY_RANK["high"])
+    return [f for f in findings if SEVERITY_RANK.get(f.get("severity", ""), 9) <= min_rank]
+
+
 def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | None:
     """Return notification payload if something is worth communicating."""
     findings: list[dict[str, Any]] = []
@@ -214,16 +224,20 @@ def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | Non
     if not findings:
         return None
 
+    notify_findings = findings_meet_notify_threshold(findings)
+    if not notify_findings:
+        return None
+
     priority_order = {"high": 0, "medium": 1, "low": 2}
     category_order = {"lcp": 0, "inp": 1, "cls": 2, "security": 3, "cache": 4, "traffic": 5}
-    findings.sort(
+    notify_findings.sort(
         key=lambda f: (
             priority_order.get(f["severity"], 9),
             category_order.get(f.get("category", ""), 9),
         )
     )
 
-    title = build_task_title(findings)
+    title = build_task_title(notify_findings)
 
     report_day = report.get("generated_at", "")[:10] or date.today().isoformat()
     dedup_id = f"cf-analytics-{report_day}"
@@ -235,7 +249,7 @@ def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | Non
         "",
         "Hallazgos:",
     ]
-    for item in findings:
+    for item in notify_findings:
         body_lines.append(f"- [{item['severity']}] {item['message']}")
     body_lines.extend(
         [
@@ -250,7 +264,7 @@ def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | Non
         "tipo": "Tarea",
         "title": title,
         "body": "\n".join(body_lines),
-        "findings": findings,
+        "findings": notify_findings,
         "report_day": report_day,
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Only create Notion tasks when at least one finding has severity `high` (default via `CF_NOTION_MIN_SEVERITY=high`).

Medium/low findings remain in the local report JSON but no longer trigger Slack/Notion noise.

**What qualifies as `high` today:** LCP p75 > 4000 ms (`poor` rating only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-331095a9-ed08-47e1-8c77-8d73ef404bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-331095a9-ed08-47e1-8c77-8d73ef404bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

