### PR TITLE
Notion title: Cloudflare: prefix + finding message

### DIFF
--- a/scripts/cloudflare_notion_notify.py
+++ b/scripts/cloudflare_notion_notify.py
@@ -109,16 +109,16 @@ def lcp_rating(ms: float | None) -> str:
 
 
 def build_task_title(findings: list[dict[str, Any]], max_len: int = 200) -> str:
-    """Use the primary finding message as the Notion title (readable, no JSON dumps)."""
+    """Notion title: Cloudflare: + primary finding message."""
     if not findings:
         return "Cloudflare: sin hallazgos"
 
-    title = findings[0]["message"]
+    message = findings[0]["message"]
     extra = len(findings) - 1
     if extra > 0:
-        suffix = f" (+{extra} más)"
-        title = f"{title}{suffix}"
+        message = f"{message} (+{extra} más)"
 
+    title = f"Cloudflare: {message}"
     if len(title) <= max_len:
         return title
 
@@ -146,12 +146,11 @@ def evaluate_actionable_insights(report: dict[str, Any]) -> dict[str, Any] | Non
         lcp = row.get("lcp_p75_ms")
         rating = lcp_rating(lcp)
         if rating in ("needs_improvement", "poor"):
-            label = "lento" if rating == "needs_improvement" else "muy lento"
             findings.append(
                 {
                     "severity": "high" if rating == "poor" else "medium",
                     "category": "lcp",
-                    "message": f"LCP {label} (p75 {lcp} ms) en {host} — {samples} muestras",
+                    "message": f"LCP p75 {lcp} ms ({rating}) en {host} ({samples} muestras)",
                 }
             )
         inp = row.get("inp_p75_ms")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Notion task title format:

`Cloudflare: {finding.message}`

Example: `Cloudflare: LCP p75 4500.0 ms (poor) en www.academiablockchain.com (14 muestras)`

The `message` matches the hallazgo line in the report body (API-derived metrics + rating label).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-331095a9-ed08-47e1-8c77-8d73ef404bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-331095a9-ed08-47e1-8c77-8d73ef404bff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

