### PR TITLE
Fix NOWPayments invoice sync so paid registrations update correctly

### DIFF
--- a/acbc_app/payments/nowpayments_client.py
+++ b/acbc_app/payments/nowpayments_client.py
@@ -106,6 +106,34 @@ class NOWPaymentsClient:
     def get_payment_status(self, payment_id):
         return self._request('GET', f'/payment/{payment_id}')
 
+    def get_invoice_payment(self, invoice_id):
+        """Resolve the child payment created from a hosted invoice checkout."""
+        for param_name in ('invoiceId', 'iid'):
+            try:
+                payload = self._request(
+                    'GET',
+                    '/invoice-payment',
+                    params={param_name: invoice_id},
+                )
+            except NOWPaymentsError:
+                continue
+            if payload.get('payment_id') is not None:
+                return payload
+            if payload.get('message'):
+                continue
+            return payload
+        raise NOWPaymentsError('No NOWPayments payment found for invoice')
+
+    def list_payments(self, *, invoice_id=None, limit=10, page=0, order_by='desc'):
+        params = {
+            'limit': limit,
+            'page': page,
+            'orderBy': order_by,
+        }
+        if invoice_id is not None:
+            params['invoiceid'] = invoice_id
+        return self._request('GET', '/payment/', params=params)
+
     @staticmethod
     def sort_params(obj):
         """Recursively sort dict keys (required for IPN HMAC per NOWPayments docs)."""

--- a/acbc_app/payments/services.py
+++ b/acbc_app/payments/services.py
@@ -24,6 +24,96 @@ def _extract_pay_address(payload: dict) -> str:
     return payload.get('pay_address') or payload.get('payment_address') or ''
 
 
+def _invoice_id_for(crypto_payment: CryptoPayment):
+    payload = crypto_payment.provider_payload or {}
+    return payload.get('invoice_id') or payload.get('id') or crypto_payment.nowpayments_payment_id
+
+
+def _payment_id_for(crypto_payment: CryptoPayment):
+    payload = crypto_payment.provider_payload or {}
+    return payload.get('payment_id')
+
+
+def _pick_payment_payload_from_list(response: dict) -> dict:
+    if not isinstance(response, dict):
+        return {}
+    if response.get('payment_id') is not None:
+        return response
+    items = response.get('data') or []
+    if not items:
+        return {}
+    return items[0]
+
+
+def _merge_provider_payload(crypto_payment: CryptoPayment, payload: dict) -> dict:
+    previous_payload = crypto_payment.provider_payload or {}
+    safe_payload = to_ascii_safe_json(payload)
+    invoice_id = (
+        previous_payload.get('invoice_id')
+        or previous_payload.get('id')
+        or payload.get('invoice_id')
+        or payload.get('id')
+    )
+    if invoice_id is not None and not safe_payload.get('invoice_id'):
+        safe_payload['invoice_id'] = invoice_id
+    return safe_payload
+
+
+def fetch_remote_payment_payload(client: NOWPaymentsClient, crypto_payment: CryptoPayment) -> dict:
+    """
+    Resolve the latest NOWPayments payment payload for a local record.
+
+    Invoice checkouts store an invoice id first; the real payment_id appears only
+    after the customer pays on the hosted invoice page.
+    """
+    payment_id = _payment_id_for(crypto_payment)
+    invoice_id = _invoice_id_for(crypto_payment)
+
+    if payment_id is not None:
+        try:
+            return client.get_payment_status(payment_id)
+        except NOWPaymentsError as exc:
+            logger.warning(
+                'NOWPayments payment lookup failed for payment_id=%s order=%s: %s',
+                payment_id,
+                crypto_payment.order_id,
+                exc,
+            )
+
+    if invoice_id is None:
+        raise NOWPaymentsError('El pago no tiene invoice_id ni payment_id de NOWPayments.')
+
+    for resolver_name, resolver in (
+        ('invoice-payment', lambda: client.get_invoice_payment(invoice_id)),
+        ('payment-list', lambda: _pick_payment_payload_from_list(
+            client.list_payments(invoice_id=invoice_id, limit=5, order_by='desc'),
+        )),
+    ):
+        try:
+            payload = resolver()
+        except NOWPaymentsError as exc:
+            logger.warning(
+                'NOWPayments %s lookup failed for invoice_id=%s order=%s: %s',
+                resolver_name,
+                invoice_id,
+                crypto_payment.order_id,
+                exc,
+            )
+            continue
+        if payload.get('payment_id') is not None:
+            return payload
+
+    raise NOWPaymentsError('NOWPayments aún no reporta un pago para esta invoice.')
+
+
+def refresh_crypto_payment_from_nowpayments(crypto_payment: CryptoPayment) -> CryptoPayment:
+    client = NOWPaymentsClient()
+    if not client.configured:
+        return crypto_payment
+    remote = fetch_remote_payment_payload(client, crypto_payment)
+    return sync_payment_from_provider(crypto_payment, remote)
+
+
 def _public_base_url():
     from django.conf import settings
     return getattr(settings, 'ACADEMIA_PUBLIC_URL', 'http://localhost:8000').rstrip('/')
@@ -96,7 +186,7 @@ def sync_payment_from_provider(crypto_payment: CryptoPayment, payload: dict) -> 
         crypto_payment.pay_address = pay_address
     if payload.get('actually_paid') is not None:
         crypto_payment.actually_paid = payload.get('actually_paid')
-    crypto_payment.provider_payload = to_ascii_safe_json(payload)
+    crypto_payment.provider_payload = _merge_provider_payload(crypto_payment, payload)
     crypto_payment.save()
 
     if _should_mark_registration_paid(status, payload, crypto_payment):
@@ -130,14 +220,11 @@ def create_event_registration_payment(*, registration: EventRegistration, user, 
         .first()
     )
     if existing:
-        if existing.invoice_url:
-            return existing
-        if existing.nowpayments_payment_id:
-            try:
-                remote = client.get_payment_status(existing.nowpayments_payment_id)
-                return sync_payment_from_provider(existing, remote)
-            except NOWPaymentsError:
-                pass
+        try:
+            return refresh_crypto_payment_from_nowpayments(existing)
+        except NOWPaymentsError:
+            if existing.invoice_url:
+                return existing
 
     from django.conf import settings
 
@@ -168,6 +255,10 @@ def create_event_registration_payment(*, registration: EventRegistration, user, 
         payload.get('id'),
     )
 
+    stored_payload = to_ascii_safe_json(payload)
+    if payload.get('id') is not None and not stored_payload.get('invoice_id'):
+        stored_payload['invoice_id'] = payload.get('id')
+
     with transaction.atomic():
         crypto_payment = CryptoPayment.objects.create(
             registration=registration,
@@ -178,6 +269,6 @@ def create_event_registration_payment(*, registration: EventRegistration, user, 
             price_currency='usd',
             payment_status='waiting',
             invoice_url=invoice_url,
-            provider_payload=to_ascii_safe_json(payload),
+            provider_payload=stored_payload,
         )
     return crypto_payment

--- a/acbc_app/payments/tests.py
+++ b/acbc_app/payments/tests.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import json
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -8,8 +9,12 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from payments.models import CryptoPayment
-from payments.nowpayments_client import NOWPaymentsClient
-from payments.services import sync_payment_from_provider
+from payments.nowpayments_client import NOWPaymentsClient, NOWPaymentsError
+from payments.services import (
+    fetch_remote_payment_payload,
+    refresh_crypto_payment_from_nowpayments,
+    sync_payment_from_provider,
+)
 from payments.text_utils import to_ascii_safe, to_ascii_safe_json
 from tests.factories.events import EventFactory, EventRegistrationFactory
 from tests.factories.users import UserFactory
@@ -135,6 +140,75 @@ class IPNLookupTests(TestCase):
             'pay_amount': '50',
         })
         self.assertEqual(found.id, self.crypto_payment.id)
+
+    def test_ipn_finds_payment_by_payment_id_in_provider_payload(self):
+        from payments.views import _find_crypto_payment_for_ipn
+
+        self.crypto_payment.nowpayments_payment_id = 555444333
+        self.crypto_payment.provider_payload = {
+            'invoice_id': 999888777,
+            'payment_id': 12345,
+        }
+        self.crypto_payment.save(update_fields=['nowpayments_payment_id', 'provider_payload'])
+
+        found = _find_crypto_payment_for_ipn({
+            'payment_id': 12345,
+            'payment_status': 'finished',
+            'actually_paid': '50',
+            'pay_amount': '50',
+        })
+        self.assertEqual(found.id, self.crypto_payment.id)
+
+
+class InvoicePaymentSyncTests(TestCase):
+    def setUp(self):
+        self.event = EventFactory(reference_price=5.0)
+        self.registration = EventRegistrationFactory(
+            event=self.event,
+            payment_status='PENDING',
+        )
+        self.crypto_payment = CryptoPayment.objects.create(
+            registration=self.registration,
+            order_id='evt-reg-invoice-sync',
+            nowpayments_payment_id=999888777,
+            pay_currency='',
+            price_amount=5.0,
+            payment_status='waiting',
+            invoice_url='https://nowpayments.io/payment/?iid=999888777',
+            provider_payload={'id': 999888777, 'invoice_id': 999888777},
+        )
+
+    @patch.object(NOWPaymentsClient, 'get_invoice_payment')
+    def test_fetch_remote_payment_payload_uses_invoice_lookup(self, mock_get_invoice_payment):
+        mock_get_invoice_payment.return_value = {
+            'payment_id': 12345,
+            'payment_status': 'finished',
+            'actually_paid': '5',
+            'pay_amount': '5',
+            'pay_currency': 'bch',
+        }
+        client = NOWPaymentsClient()
+        payload = fetch_remote_payment_payload(client, self.crypto_payment)
+        self.assertEqual(payload['payment_id'], 12345)
+        mock_get_invoice_payment.assert_called_once_with(999888777)
+
+    @override_settings(NOWPAYMENTS_API_KEY='test-key')
+    @patch('payments.services.NOWPaymentsClient.get_invoice_payment')
+    def test_refresh_crypto_payment_marks_registration_paid(self, mock_get_invoice_payment):
+        mock_get_invoice_payment.return_value = {
+            'payment_id': 12345,
+            'payment_status': 'finished',
+            'actually_paid': '5',
+            'pay_amount': '5',
+            'pay_currency': 'bch',
+        }
+        refresh_crypto_payment_from_nowpayments(self.crypto_payment)
+        self.registration.refresh_from_db()
+        self.crypto_payment.refresh_from_db()
+        self.assertEqual(self.registration.payment_status, 'PAID')
+        self.assertEqual(self.crypto_payment.payment_status, 'finished')
+        self.assertEqual(self.crypto_payment.nowpayments_payment_id, 12345)
+        self.assertEqual(self.crypto_payment.provider_payload.get('invoice_id'), 999888777)
 
 
 @override_settings(NOWPAYMENTS_API_KEY='test-key')

--- a/acbc_app/payments/views.py
+++ b/acbc_app/payments/views.py
@@ -15,7 +15,9 @@ from payments.nowpayments_client import NOWPaymentsClient, NOWPaymentsError
 from payments.serializers import CryptoPaymentSerializer
 from payments.services import (
     ALLOWED_PAY_CURRENCIES,
+    OPEN_PAYMENT_STATUSES,
     create_event_registration_payment,
+    refresh_crypto_payment_from_nowpayments,
     sync_payment_from_provider,
 )
 
@@ -36,10 +38,19 @@ def _find_crypto_payment_for_ipn(body: dict):
         payment = CryptoPayment.objects.filter(nowpayments_payment_id=invoice_id).first()
         if payment:
             return payment
+        payment = CryptoPayment.objects.filter(provider_payload__invoice_id=invoice_id).first()
+        if payment:
+            return payment
+        payment = CryptoPayment.objects.filter(provider_payload__id=invoice_id).first()
+        if payment:
+            return payment
 
     payment_id = body.get('payment_id')
     if payment_id is not None:
         payment = CryptoPayment.objects.filter(nowpayments_payment_id=payment_id).first()
+        if payment:
+            return payment
+        payment = CryptoPayment.objects.filter(provider_payload__payment_id=payment_id).first()
         if payment:
             return payment
 
@@ -133,14 +144,9 @@ class CryptoPaymentDetailView(APIView):
             return Response({'error': 'Permiso denegado.'}, status=status.HTTP_403_FORBIDDEN)
 
         client = NOWPaymentsClient()
-        if client.configured and payment.nowpayments_payment_id:
-            remote_id = payment.nowpayments_payment_id
-            # Invoice flow stores invoice id first; payment status API needs payment_id.
-            if payment.provider_payload.get('payment_id'):
-                remote_id = payment.provider_payload['payment_id']
+        if client.configured:
             try:
-                remote = client.get_payment_status(remote_id)
-                payment = sync_payment_from_provider(payment, remote)
+                payment = refresh_crypto_payment_from_nowpayments(payment)
             except NOWPaymentsError as exc:
                 logger.warning('Could not refresh payment %s: %s', payment_id, exc)
 
@@ -162,6 +168,22 @@ class RegistrationPaymentsListView(APIView):
             return Response({'error': 'Permiso denegado.'}, status=status.HTTP_403_FORBIDDEN)
 
         payments = CryptoPayment.objects.filter(registration=registration).order_by('-created_at')[:10]
+        client = NOWPaymentsClient()
+        if client.configured:
+            refreshed = []
+            for payment in payments:
+                if payment.payment_status in OPEN_PAYMENT_STATUSES:
+                    try:
+                        payment = refresh_crypto_payment_from_nowpayments(payment)
+                    except NOWPaymentsError as exc:
+                        logger.warning(
+                            'Could not refresh payment %s for registration %s: %s',
+                            payment.id,
+                            registration_id,
+                            exc,
+                        )
+                refreshed.append(payment)
+            payments = refreshed
         return Response(CryptoPaymentSerializer(payments, many=True).data)
 
 

--- a/acbc_app/profiles/views.py
+++ b/acbc_app/profiles/views.py
@@ -47,6 +47,25 @@ from django.db.models import Count
 logger = logging.getLogger(__name__)
 
 
+def auth_cookie_kwargs() -> dict:
+    """Shared host-only cookie flags for set_cookie (refresh token)."""
+    return {
+        'httponly': True,
+        'secure': settings.SIMPLE_JWT['AUTH_COOKIE_SECURE'],
+        'samesite': settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE'],
+        'path': settings.SIMPLE_JWT['AUTH_COOKIE_PATH'],
+    }
+
+
+def delete_auth_cookie(response, cookie_name: str) -> None:
+    """Delete auth cookie using the same path/samesite scope as set_cookie."""
+    response.delete_cookie(
+        cookie_name,
+        path=settings.SIMPLE_JWT['AUTH_COOKIE_PATH'],
+        samesite=settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE'],
+    )
+
+
 def set_refresh_token_cookie(response, refresh_token: str) -> None:
     """
     Persist the refresh token in a browser cookie with max_age aligned to SIMPLE_JWT.
@@ -59,10 +78,7 @@ def set_refresh_token_cookie(response, refresh_token: str) -> None:
         settings.SIMPLE_JWT['REFRESH_COOKIE'],
         refresh_token,
         max_age=max_age,
-        httponly=True,
-        secure=settings.SIMPLE_JWT['AUTH_COOKIE_SECURE'],
-        samesite=settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE'],
-        path=settings.SIMPLE_JWT['AUTH_COOKIE_PATH'],
+        **auth_cookie_kwargs(),
     )
 
 
@@ -718,12 +734,7 @@ class LogoutView(APIView):
             refresh_cookie_name = settings.SIMPLE_JWT['REFRESH_COOKIE']
             logger.debug(f"Attempting to delete cookie: {refresh_cookie_name}")
             
-            # Delete the refresh token cookie
-            response.delete_cookie(
-                refresh_cookie_name,
-                path=settings.SIMPLE_JWT['AUTH_COOKIE_PATH'],
-                domain=None  # Let the browser determine the domain
-            )
+            delete_auth_cookie(response, refresh_cookie_name)
             
             logger.info(f"Logout successful for user {request.user.username}")
             return response

--- a/docs/payments/nowpayments-setup.md
+++ b/docs/payments/nowpayments-setup.md
@@ -1,12 +1,12 @@
 # Pasarela de pagos (NOWPayments) — BCH y Monero
 
-Academia Blockchain usa [NOWPayments](https://nowpayments.io/) para aceptar **Bitcoin Cash (BCH)** y **Monero (XMR)** en el registro a eventos de pago.
+Academia Blockchain usa [NOWPayments](https://nowpayments.io/) para aceptar pagos en cripto en el registro a eventos de pago.
 
 ## Configuración en NOWPayments
 
 1. Crear cuenta en [NOWPayments](https://account.nowpayments.io/create-account).
-2. Añadir wallets de cobro para **BCH** y **XMR** (Settings → Payments).
-3. Activar BCH y XMR en [Coin settings](https://account.nowpayments.io/coins-settings).
+2. Añadir wallets de cobro (Settings → Payments).
+3. Activar las monedas deseadas en [Coin settings](https://account.nowpayments.io/coins-settings).
 4. Generar **API Key** y **IPN Secret** (Payment Settings).
 5. En el panel, IPN callback URL (opcional si ya se envía por API):
    `https://TU-DOMINIO/api/payments/ipn/`
@@ -34,20 +34,27 @@ FRONTEND_PUBLIC_URL=http://localhost:5173
 ## Flujo (según [API NOWPayments](https://documenter.getpostman.com/view/7907941/2s93JusNJt))
 
 1. El usuario se registra en un evento con precio > 0.
-2. `POST /v1/payment` con `price_amount`, `price_currency`, `pay_currency`, `order_id`, `order_description`, `ipn_callback_url`.
-3. La respuesta incluye `payment_id`, `pay_address`, `pay_amount`, `payment_status` (inicialmente `waiting`).
-4. El usuario envía cripto a `pay_address`.
-5. NOWPayments envía IPN (POST) a `/api/payments/ipn/` en cada cambio de estado.
-6. Cuando el estado es `finished` (fondos en la wallet del comercio), el backend marca el registro como `PAID` y ejecuta `on_crypto_payment_completed`. El estado `confirmed` solo indica confirmación on-chain; no se usa para marcar el registro como pagado.
+2. `POST /v1/invoice` con `price_amount`, `price_currency`, `order_id`, `order_description`, `ipn_callback_url`, `success_url`, `cancel_url`.
+3. La respuesta incluye `id` (invoice_id) e `invoice_url`. El usuario paga en la página hospedada de NOWPayments.
+4. NOWPayments crea un **payment** hijo con su propio `payment_id` cuando el usuario elige moneda y envía fondos.
+5. NOWPayments envía IPN (POST) a `/api/payments/ipn/` en cada cambio de estado del **payment**.
+6. El backend también consulta NOWPayments al hacer polling (`GET /api/payments/{id}/`) usando `GET /v1/invoice-payment` o `GET /v1/payment/?invoiceid=...` hasta obtener el `payment_id`.
+7. Cuando el estado es `finished` (fondos en la wallet del comercio), el backend marca el registro como `PAID` y ejecuta `on_crypto_payment_completed`. El estado `confirmed` solo indica confirmación on-chain; no se usa para marcar el registro como pagado.
 
 Estados relevantes: `waiting` → `confirming` → `confirmed` → `sending` → `finished` (también `failed`, `expired`, `partially_paid`, `refunded`).
+
+### Importante: invoice_id ≠ payment_id
+
+Con invoices, el backend guarda primero el `invoice_id`. No uses `GET /v1/payment/{invoice_id}`: devuelve error o datos incorrectos. Hay que resolver el `payment_id` real vía IPN o `GET /v1/invoice-payment?invoiceId=...`.
 
 ## Webhook IPN
 
 - Header: `x-nowpayments-sig`
 - Firma: HMAC-SHA512 del JSON con **claves ordenadas recursivamente** e IPN secret.
 - Cuerpo: mismo formato que `GET /v1/payment/{payment_id}`.
+- Debe incluir `order_id` (lo enviamos al crear la invoice) para reconciliar pagos.
 - Whitelist IPs NOWPayments en firewall si aplica: `51.89.194.21`, `51.75.77.69`, `138.201.172.58`, `65.21.158.36`.
+- Verificar que `ACADEMIA_PUBLIC_URL` apunte al dominio público del backend y que `/api/payments/ipn/` sea accesible desde internet.
 
 ## Extender el backend al completar un pago
 
@@ -70,7 +77,7 @@ También se llama `on_crypto_payment_completed()` desde `sync_payment_from_provi
 | Método | Ruta | Descripción |
 |--------|------|-------------|
 | GET | `/api/payments/status/` | ¿Pasarela activa? Monedas soportadas |
-| POST | `/api/payments/registration/{id}/` | Crear pago (`pay_currency`: `bch` \| `xmr`) |
+| POST | `/api/payments/registration/{id}/` | Crear invoice NOWPayments y devolver `invoice_url` |
 | GET | `/api/payments/{id}/` | Estado del pago (sincroniza con NOWPayments) |
 | POST | `/api/payments/ipn/` | Webhook NOWPayments (sin auth) |
 

--- a/frontend/src/events/EventDetail.jsx
+++ b/frontend/src/events/EventDetail.jsx
@@ -18,6 +18,7 @@ import { AUTH_ERROR_STRATEGY, getErrorMessage, handleAuthError } from '../utils/
 import CryptoPaymentModal from './CryptoPaymentModal';
 import EventRegistrationModal from './EventRegistrationModal';
 import EventPaymentMethods from './EventPaymentMethods';
+import { getPaymentStatus, listRegistrationPayments } from '../api/paymentsApi';
 import {
   Alert,
   Box,
@@ -137,6 +138,50 @@ const EventDetail = () => {
     setIsRegistered(false);
     setUserRegistration(null);
   }, [eventId]);
+
+  useEffect(() => {
+    if (
+      !isAuthenticated
+      || !userRegistration?.id
+      || !(event?.reference_price > 0)
+      || userRegistration.payment_status === 'PAID'
+    ) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const syncPendingPayment = async () => {
+      try {
+        const payments = await listRegistrationPayments(userRegistration.id);
+        if (cancelled) return;
+        const paidPayment = payments.find((payment) => payment.is_paid);
+        if (paidPayment) {
+          setUserRegistration((prev) => (prev ? { ...prev, payment_status: 'PAID' } : prev));
+          return;
+        }
+        const openPayment = payments.find((payment) => payment.payment_status !== 'finished');
+        if (!openPayment) return;
+        const data = await getPaymentStatus(openPayment.id);
+        if (cancelled) return;
+        if (data.is_paid) {
+          setUserRegistration((prev) => (prev ? { ...prev, payment_status: 'PAID' } : prev));
+        }
+      } catch (err) {
+        handleAuthError(err, { strategy: AUTH_ERROR_STRATEGY.IGNORE });
+      }
+    };
+
+    syncPendingPayment();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isAuthenticated,
+    event?.reference_price,
+    userRegistration?.id,
+    userRegistration?.payment_status,
+  ]);
 
   useEffect(() => {
     const ownerId = eventOwnerId;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Paid NOWPayments invoices were not updating event registrations to `PAID`.

The integration creates hosted invoices (`POST /v1/invoice`), which initially return an `invoice_id`. The actual `payment_id` is only created after the customer pays on NOWPayments. Our backend was polling `GET /v1/payment/{invoice_id}`, which does not return the real payment status.

Symptoms:
- Payment succeeded in NOWPayments dashboard
- No visible backend callback effect (IPN may also fail to reconcile)
- Event page still showed **Pago pendiente**

## Solution

- Resolve invoice payments via `GET /v1/invoice-payment` (with `invoiceId` / `iid` fallback) and `GET /v1/payment/?invoiceid=...`
- Refresh open payments when polling payment detail and listing registration payments
- Improve IPN lookup by `invoice_id` / `payment_id` stored in `provider_payload`
- Sync pending registration status when revisiting an event page
- Update NOWPayments setup docs to describe invoice vs payment IDs

## Verification

- `python manage.py test payments.tests` (14 tests passing)

## Deploy note

After deploy, revisiting the event page or opening **Completar pago** should reconcile the existing $5 payment automatically. Also verify production `ACADEMIA_PUBLIC_URL` and IPN secret so webhooks reach `/api/payments/ipn/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14cf0ca2-0d1d-4082-a9b2-e7832646a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14cf0ca2-0d1d-4082-a9b2-e7832646a906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

