### PR TITLE
Eliminar logs de depuración del frontend en producción

### DIFF
--- a/frontend/src/api/certificatesApi.js
+++ b/frontend/src/api/certificatesApi.js
@@ -1,150 +1,147 @@
 import axiosInstance from './axiosConfig';
 
 const certificatesApi = {
-    requestCertificate: async (pathId, data) => {
-        try {
-            const response = await axiosInstance.post(`/certificates/request/${pathId}/`, {
-                notes: data.notes
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error requesting certificate:', error);
-            throw error;
-        }
-    },
-
-    requestEventCertificate: async (eventId, data) => {
-        try {
-            const response = await axiosInstance.post(`/certificates/event-request/${eventId}/`, {
-                notes: data.notes
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error requesting event certificate:', error);
-            throw error;
-        }
-    },
-
-    getCertificateRequestStatus: async (pathId) => {
-        try {
-            const response = await axiosInstance.get(`/certificates/request-status/${pathId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error getting certificate request status:', error);
-            throw error;
-        }
-    },
-
-    getEventCertificateRequestStatus: async (eventId) => {
-        try {
-            const response = await axiosInstance.get(`/certificates/event-request-status/${eventId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error getting event certificate request status:', error);
-            throw error;
-        }
-    },
-
-    getCertificateRequests: async () => {
-        try {
-            const response = await axiosInstance.get('/certificates/requests/');
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching certificate requests:', error);
-            throw error;
-        }
-    },
-
-    approveCertificateRequest: async (requestId, note = '') => {
-        try {
-            const response = await axiosInstance.post(`/certificates/requests/${requestId}/approve/`, { note });
-            return response.data;
-        } catch (error) {
-            console.error('Error approving certificate request:', error);
-            throw error;
-        }
-    },
-
-    rejectCertificateRequest: async (requestId, reason) => {
-        try {
-            const response = await axiosInstance.post(`/certificates/requests/${requestId}/reject/`, { rejection_reason: reason });
-            return response.data;
-        } catch (error) {
-            console.error('Error rejecting certificate request:', error);
-            throw error;
-        }
-    },
-
-    cancelCertificateRequest: async (requestId) => {
-        try {
-            const response = await axiosInstance.post(`/certificates/requests/${requestId}/cancel/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error cancelling certificate request:', error);
-            throw error;
-        }
-    },
-
-    getCertificates: async () => {
-        try {
-            const response = await axiosInstance.get('/certificates/');
-            return response.data;
-        } catch (error) {
-            console.error('Error getting certificates:', error);
-            throw error;
-        }
-    },
-
-    getUserCertificatesById: async (userId) => {
-        try {
-            const response = await axiosInstance.get(`/certificates/?user=${userId}`);
-            return response.data;
-        } catch (error) {
-            console.error('Error getting user certificates by ID:', error);
-            throw error;
-        }
-    },
-
-    getKnowledgePathCertificateRequests: async (pathId) => {
-        try {
-            const response = await axiosInstance.get(`/certificates/requests/knowledge-path/${pathId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching knowledge path certificate requests:', error);
-            throw error;
-        }
-    },
-
-    getEventCertificateRequests: async (eventId) => {
-        try {
-            const response = await axiosInstance.get(`/certificates/requests/event/${eventId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching event certificate requests:', error);
-            throw error;
-        }
-    },
-
-    generateEventCertificate: async (eventId, registrationId, data = {}) => {
-        try {
-            const url = `/certificates/generate-event-certificate/${eventId}/${registrationId}/`;
-            const requestData = {
-                note: data.note || ''
-            };
-            
-            console.log('DEBUG: Calling certificate generation API');
-            console.log('DEBUG: URL:', url);
-            console.log('DEBUG: Data:', requestData);
-            
-            const response = await axiosInstance.post(url, requestData);
-            console.log('DEBUG: Response:', response.data);
-            return response.data;
-        } catch (error) {
-            console.error('Error generating event certificate:', error);
-            console.error('DEBUG: Error response:', error.response?.data);
-            throw error;
-        }
+  requestCertificate: async (pathId, data) => {
+    try {
+      const response = await axiosInstance.post(`/certificates/request/${pathId}/`, {
+        notes: data.notes
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error requesting certificate:', error);
+      throw error;
     }
+  },
+
+  requestEventCertificate: async (eventId, data) => {
+    try {
+      const response = await axiosInstance.post(`/certificates/event-request/${eventId}/`, {
+        notes: data.notes
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error requesting event certificate:', error);
+      throw error;
+    }
+  },
+
+  getCertificateRequestStatus: async (pathId) => {
+    try {
+      const response = await axiosInstance.get(`/certificates/request-status/${pathId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error getting certificate request status:', error);
+      throw error;
+    }
+  },
+
+  getEventCertificateRequestStatus: async (eventId) => {
+    try {
+      const response = await axiosInstance.get(`/certificates/event-request-status/${eventId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error getting event certificate request status:', error);
+      throw error;
+    }
+  },
+
+  getCertificateRequests: async () => {
+    try {
+      const response = await axiosInstance.get('/certificates/requests/');
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching certificate requests:', error);
+      throw error;
+    }
+  },
+
+  approveCertificateRequest: async (requestId, note = '') => {
+    try {
+      const response = await axiosInstance.post(`/certificates/requests/${requestId}/approve/`, { note });
+      return response.data;
+    } catch (error) {
+      console.error('Error approving certificate request:', error);
+      throw error;
+    }
+  },
+
+  rejectCertificateRequest: async (requestId, reason) => {
+    try {
+      const response = await axiosInstance.post(`/certificates/requests/${requestId}/reject/`, { rejection_reason: reason });
+      return response.data;
+    } catch (error) {
+      console.error('Error rejecting certificate request:', error);
+      throw error;
+    }
+  },
+
+  cancelCertificateRequest: async (requestId) => {
+    try {
+      const response = await axiosInstance.post(`/certificates/requests/${requestId}/cancel/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error cancelling certificate request:', error);
+      throw error;
+    }
+  },
+
+  getCertificates: async () => {
+    try {
+      const response = await axiosInstance.get('/certificates/');
+      return response.data;
+    } catch (error) {
+      console.error('Error getting certificates:', error);
+      throw error;
+    }
+  },
+
+  getUserCertificatesById: async (userId) => {
+    try {
+      const response = await axiosInstance.get(`/certificates/?user=${userId}`);
+      return response.data;
+    } catch (error) {
+      console.error('Error getting user certificates by ID:', error);
+      throw error;
+    }
+  },
+
+  getKnowledgePathCertificateRequests: async (pathId) => {
+    try {
+      const response = await axiosInstance.get(`/certificates/requests/knowledge-path/${pathId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching knowledge path certificate requests:', error);
+      throw error;
+    }
+  },
+
+  getEventCertificateRequests: async (eventId) => {
+    try {
+      const response = await axiosInstance.get(`/certificates/requests/event/${eventId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching event certificate requests:', error);
+      throw error;
+    }
+  },
+
+  generateEventCertificate: async (eventId, registrationId, data = {}) => {
+    try {
+      const url = `/certificates/generate-event-certificate/${eventId}/${registrationId}/`;
+      const requestData = {
+        note: data.note || ''
+      };
+
+
+      const response = await axiosInstance.post(url, requestData);
+
+      return response.data;
+    } catch (error) {
+      console.error('Error generating event certificate:', error);
+      console.error('DEBUG: Error response:', error.response?.data);
+      throw error;
+    }
+  }
 };
 
-export default certificatesApi; 
+export default certificatesApi;

--- a/frontend/src/api/contentApi.js
+++ b/frontend/src/api/contentApi.js
@@ -1,1291 +1,1288 @@
 import axiosInstance from './axiosConfig';
 
 const contentApi = {
-    getUserContent: async () => {
-        try {
-            const response = await axiosInstance.get('/content/user-content/');
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching user content:', error);
-            if (error.code === 'ECONNABORTED') {
-                throw new Error('La solicitud expiró. Por favor, inténtelo de nuevo.');
-            }
-            throw error;
-        }
-    },
-
-    getUserContentWithDetails: async (params = {}) => {
-        try {
-            const query = {
-                page: params.page ?? 1,
-                page_size: params.page_size ?? 12,
-            };
-            if (params.media_type && params.media_type !== 'ALL') {
-                query.media_type = params.media_type;
-            }
-            if (params.search) {
-                query.search = params.search;
-            }
-            const response = await axiosInstance.get('/content/user-content-with-details/', {
-                params: query,
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching user content with details:', error);
-            if (error.code === 'ECONNABORTED') {
-                throw new Error('La solicitud expiró. Por favor, inténtelo de nuevo.');
-            }
-            throw error;
-        }
-    },
-
-    getUserContentById: async (userId) => {
-        try {
-            const response = await axiosInstance.get(`/content/user-content/${userId}/`);
-            return response.data;
-        } catch (error) {
-            console.error(`Error fetching content for user ${userId}:`, error);
-            if (error.code === 'ECONNABORTED') {
-                throw new Error('La solicitud expiró. Por favor, inténtelo de nuevo.');
-            }
-            if (error.response?.status === 404) {
-                throw new Error(`Usuario con ID ${userId} no encontrado.`);
-            }
-            throw error;
-        }
-    },
-
-    // Presign: get URL to upload file directly to S3
-    uploadContentPresign: async (metadata) => {
-        console.log('[S3 upload] Presign request:', { filename: metadata?.filename, file_size: metadata?.file_size, media_type: metadata?.media_type });
-        try {
-            const response = await axiosInstance.post('/content/upload-content/presign/', metadata, {
-                timeout: 15000,
-                headers: { 'Content-Type': 'application/json' }
-            });
-            console.log('[S3 upload] Presign OK, key:', response.data?.key);
-            return response.data;
-        } catch (err) {
-            console.error('[S3 upload] Presign failed:', err.response?.status, err.response?.data || err.message);
-            throw err;
-        }
-    },
-
-    // Upload file directly to S3 with optional progress (XHR for progress)
-    uploadFileToS3: async (file, uploadPayload, onProgress) => {
-        if (uploadPayload?.upload_mode === 'multipart') {
-            return contentApi.uploadFileToS3Multipart(file, uploadPayload, onProgress);
-        }
-        const uploadUrl = typeof uploadPayload === 'string' ? uploadPayload : uploadPayload?.upload_url;
-        const urlHost = uploadUrl ? new URL(uploadUrl).host : '(no URL)';
-        console.log('[S3 upload] PUT to S3 starting, host:', urlHost, 'size:', file?.size);
-        return new Promise((resolve, reject) => {
-            const xhr = new XMLHttpRequest();
-            xhr.open('PUT', uploadUrl);
-            xhr.setRequestHeader('Content-Type', file.type || 'application/octet-stream');
-            xhr.withCredentials = false;
-            if (onProgress && xhr.upload) {
-                xhr.upload.onprogress = (e) => {
-                    if (e.lengthComputable) onProgress({ loaded: e.loaded, total: e.total });
-                };
-            }
-            xhr.onload = () => {
-                if (xhr.status >= 200 && xhr.status < 300) {
-                    console.log('[S3 upload] PUT to S3 success, status:', xhr.status);
-                    resolve();
-                } else {
-                    console.error('[S3 upload] PUT to S3 failed:', xhr.status, xhr.statusText);
-                    reject(new Error(`S3 upload failed: ${xhr.status} ${xhr.statusText}`));
-                }
-            };
-            xhr.onerror = () => {
-                console.error('[S3 upload] PUT to S3 network error');
-                reject(new Error('S3 upload failed'));
-            };
-            xhr.send(file);
-        });
-    },
-
-    uploadFileToS3Multipart: async (file, uploadPayload, onProgress) => {
-        const partUrls = uploadPayload?.part_urls || [];
-        const partSize = uploadPayload?.part_size || (64 * 1024 * 1024);
-        const totalSize = file?.size || 0;
-        if (!partUrls.length) {
-            throw new Error('Multipart upload inválido: no hay partes para subir');
-        }
-
-        let uploadedBytes = 0;
-        const parts = [];
-        const uploadPart = (partUrl, blob, partNumber) =>
-            new Promise((resolve, reject) => {
-                const xhr = new XMLHttpRequest();
-                xhr.open('PUT', partUrl);
-                xhr.withCredentials = false;
-                let lastLoaded = 0;
-                if (onProgress && xhr.upload) {
-                    xhr.upload.onprogress = (e) => {
-                        if (!e.lengthComputable) return;
-                        const delta = e.loaded - lastLoaded;
-                        lastLoaded = e.loaded;
-                        uploadedBytes += Math.max(0, delta);
-                        onProgress({ loaded: Math.min(uploadedBytes, totalSize), total: totalSize });
-                    };
-                }
-                xhr.onload = () => {
-                    if (xhr.status >= 200 && xhr.status < 300) {
-                        const etag = xhr.getResponseHeader('ETag');
-                        if (!etag) {
-                            reject(new Error(`S3 multipart upload failed: missing ETag for part ${partNumber}`));
-                            return;
-                        }
-                        resolve({ part_number: partNumber, etag });
-                    } else {
-                        reject(new Error(`S3 multipart upload failed: ${xhr.status} ${xhr.statusText}`));
-                    }
-                };
-                xhr.onerror = () => reject(new Error('S3 multipart upload failed'));
-                xhr.send(blob);
-            });
-
-        for (const part of partUrls) {
-            const partNumber = Number(part.part_number);
-            if (!partNumber || !part.upload_url) {
-                throw new Error('Multipart upload inválido: parte incompleta');
-            }
-            const start = (partNumber - 1) * partSize;
-            const end = Math.min(start + partSize, totalSize);
-            const chunk = file.slice(start, end);
-            const uploadedPart = await uploadPart(part.upload_url, chunk, partNumber);
-            uploadedBytes = end;
-            if (onProgress) onProgress({ loaded: uploadedBytes, total: totalSize });
-            parts.push(uploadedPart);
-        }
-
-        return {
-            upload_id: uploadPayload.upload_id,
-            parts: parts.sort((a, b) => a.part_number - b.part_number),
-        };
-    },
-
-    // Confirm: after S3 upload, create Content/ContentProfile/FileDetails
-    uploadContentConfirm: async (key, metadata) => {
-        console.log('[S3 upload] Confirm request, key:', key);
-        try {
-            const response = await axiosInstance.post('/content/upload-content/confirm/', { key, ...metadata }, {
-                timeout: 15000,
-                headers: { 'Content-Type': 'application/json' }
-            });
-            console.log('[S3 upload] Confirm OK, content_id:', response.data?.content_id);
-            return response.data;
-        } catch (err) {
-            console.error('[S3 upload] Confirm failed:', err.response?.status, err.response?.data || err.message);
-            throw err;
-        }
-    },
-
-    // Full S3 flow: presign -> upload to S3 -> confirm. Falls back to FormData upload if S3 not configured (e.g. dev).
-    uploadContentViaS3: async (file, metadata, onProgress) => {
-        console.log('[S3 upload] Starting flow for file:', file?.name, 'size:', file?.size);
-        try {
-            const presignData = await contentApi.uploadContentPresign({
-                filename: file.name,
-                file_size: file.size,
-                content_type: file.type || 'application/octet-stream',
-                media_type: metadata.media_type,
-                title: metadata.title,
-                author: metadata.author,
-                personalNote: metadata.personalNote,
-                is_visible: metadata.is_visible,
-                is_producer: metadata.is_producer,
-                has_spanish_subtitles: metadata.has_spanish_subtitles,
-                has_spanish_dubbing: metadata.has_spanish_dubbing
-            });
-            const uploadMetadata = await contentApi.uploadFileToS3(
-                file,
-                presignData.upload_mode ? presignData : presignData.upload_url,
-                onProgress
-            );
-            const result = await contentApi.uploadContentConfirm(presignData.key, {
-                media_type: metadata.media_type,
-                title: metadata.title,
-                author: metadata.author,
-                personalNote: metadata.personalNote,
-                is_visible: metadata.is_visible,
-                is_producer: metadata.is_producer,
-                has_spanish_subtitles: metadata.has_spanish_subtitles,
-                has_spanish_dubbing: metadata.has_spanish_dubbing,
-                file_size: file.size,
-                ...(uploadMetadata || {})
-            });
-            console.log('[S3 upload] Flow complete, content_id:', result?.content_id);
-            return result;
-        } catch (err) {
-            if (err.response?.status === 503) {
-                console.warn('[S3 upload] 503 received, falling back to FormData upload');
-                const formData = new FormData();
-                formData.append('file', file);
-                formData.append('media_type', metadata.media_type);
-                formData.append('title', metadata.title || '');
-                formData.append('author', metadata.author || '');
-                formData.append('personalNote', metadata.personalNote || '');
-                formData.append('is_visible', String(metadata.is_visible ?? true));
-                formData.append('is_producer', String(metadata.is_producer ?? false));
-                formData.append('has_spanish_subtitles', String(metadata.has_spanish_subtitles ?? false));
-                formData.append('has_spanish_dubbing', String(metadata.has_spanish_dubbing ?? false));
-                const fallbackResult = await contentApi.uploadContent(formData, { onUploadProgress: onProgress ? (e) => onProgress(e) : undefined });
-                console.log('[S3 upload] FormData fallback OK, content_id:', fallbackResult?.content_id);
-                return fallbackResult;
-            }
-            console.error('[S3 upload] Flow failed:', err.response?.status, err.message);
-            throw err;
-        }
-    },
-
-    // Legacy: single POST with FormData (used for URL-only or fallback)
-    uploadContent: async (contentData, options = {}) => {
-        try {
-            const config = contentData instanceof FormData
-                ? {
-                    timeout: options.timeout ?? 60000,
-                    onUploadProgress: options.onUploadProgress
-                }
-                : { headers: { 'Content-Type': 'multipart/form-data' } };
-            const response = await axiosInstance.post('/content/upload-content/', contentData, config);
-            return response.data;
-        } catch (error) {
-            console.error('Error uploading content:', error);
-            if (error.response) console.error('Error response:', error.response.data);
-            throw error;
-        }
-    },
-
-    getContentDetails: async (contentId, context = null, contextId = null) => {
-        try {
-            let url = `/content/content_details/${contentId}/`;
-            if (context && contextId) {
-                url += `?context=${context}&id=${contextId}`;
-            }
-            const response = await axiosInstance.get(url);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching content details:', error);
-            throw error;
-        }
-    },
-
-    getContentPreview: async (contentId, context = null, contextId = null) => {
-        try {
-            let url = `/content/content_preview/${contentId}/`;
-            if (context && contextId) {
-                url += `?context=${context}&id=${contextId}`;
-            }
-            const response = await axiosInstance.get(url);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching content preview:', error);
-            throw error;
-        }
-    },
-
-    getUserCollections: async () => {
-        try {
-            const response = await axiosInstance.get('/content/collections/');
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching user collections:', error);
-            throw error;
-        }
-    },
-
-    /**
-     * Paginated public collections (is_public + at least one visible item).
-     * @param {{ page?: number, page_size?: number, search?: string, owner?: number }} params
-     * @param {number} [params.owner] - filter by library owner's user id
-     */
-    getPublicCollections: async (params = {}) => {
-        try {
-            const searchParams = new URLSearchParams();
-            if (params.page != null) searchParams.set('page', String(params.page));
-            if (params.page_size != null) searchParams.set('page_size', String(params.page_size));
-            if (params.search) searchParams.set('search', params.search.trim());
-            if (params.owner != null && params.owner !== '') {
-                searchParams.set('owner', String(params.owner));
-            }
-            const qs = searchParams.toString();
-            const url = qs ? `/content/collections/public/?${qs}` : '/content/collections/public/';
-            const response = await axiosInstance.get(url);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching public collections:', error);
-            throw error;
-        }
-    },
-
-    createCollection: async (collectionData) => {
-        try {
-            const response = await axiosInstance.post('/content/collections/', collectionData);
-            return response.data;
-        } catch (error) {
-            console.error('Error creating collection:', error);
-            throw error;
-        }
-    },
-
-    getCollection: async (collectionId) => {
-        try {
-            const response = await axiosInstance.get(`/content/collections/${collectionId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching collection:', error.response || error);
-            throw error;
-        }
-    },
-
-    updateCollection: async (collectionId, collectionData) => {
-        try {
-            const response = await axiosInstance.patch(`/content/collections/${collectionId}/`, collectionData);
-            return response.data;
-        } catch (error) {
-            console.error('Error updating collection:', error.response || error);
-            throw error;
-        }
-    },
-
-    getCollectionContent: async (collectionId) => {
-        try {
-            const response = await axiosInstance.get(`/content/collections/${collectionId}/content/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching collection content:', error.response || error);
-            throw error;
-        }
-    },
-
-    addContentToCollection: async (collectionId, contentProfileIds) => {
-        try {
-            // Ensure contentProfileIds is an array
-            const ids = Array.isArray(contentProfileIds) ? contentProfileIds : [contentProfileIds];
-            
-            const response = await axiosInstance.post(`/content/collections/${collectionId}/content/`, {
-                content_profile_ids: ids
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error adding content to collection:', error);
-            throw error;
-        }
-    },
-
-    removeContentFromCollection: async (contentProfileId) => {
-        try {
-            const response = await axiosInstance.patch(`/content/content-profiles/${contentProfileId}/`, {
-                collection: null
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error removing content from collection:', error);
-            throw error;
-        }
-    },
-
-    createTopic: async (topicData) => {
-        try {
-            const response = await axiosInstance.post('/content/topics/', topicData);
-            return response.data;
-        } catch (error) {
-            console.error('Error creating topic:', error);
-            throw error;
-        }
-    },
-
-    getTopicDetails: async (topicId, params = {}) => {
-        try {
-            const response = await axiosInstance.get(`/content/topics/${topicId}/`, { params });
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching topic details:', error);
-            throw error;
-        }
-    },
-
-    getTopicDetailsSimple: async (topicId) => {
-        try {
-            const response = await axiosInstance.get(`/content/topics/${topicId}/content-simple/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching topic details (simple):', error);
-            throw error;
-        }
-    },
-
-    updateTopicImage: async (topicId, formData) => {
-        try {
-            const response = await axiosInstance.patch(
-                `/content/topics/${topicId}/`,
-                formData,
-                {
-                    headers: {
-                        'Content-Type': 'multipart/form-data',
-                    },
-                }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error updating topic image:', error);
-            throw error;
-        }
-    },
-
-    getTopics: async () => {
-        try {
-            const response = await axiosInstance.get('/content/topics/');
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching topics:', error);
-            throw error;
-        }
-    },
-
-    addContentToTopic: async (topicId, contentProfileIds) => {
-        try {
-            const response = await axiosInstance.post(`/content/topics/${topicId}/content/`, {
-                content_profile_ids: contentProfileIds
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error adding content to topic:', error.response || error);
-            throw error;
-        }
-    },
-
-    removeContentFromTopic: async (topicId, contentIds) => {
-        try {
-            const response = await axiosInstance.patch(`/content/topics/${topicId}/content/`, {
-                content_ids: contentIds
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error removing content from topic:', error);
-            throw error;
-        }
-    },
-
-    getTopicContentByType: async (topicId, mediaType, params = {}) => {
-        try {
-            const response = await axiosInstance.get(`/content/topics/${topicId}/content/${mediaType}/`, {
-                params: {
-                    page: params.page,
-                    page_size: params.page_size,
-                },
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching topic content by type:', error);
-            throw error;
-        }
-    },
-
-    getTopicTimeline: async (topicId) => {
-        try {
-            const response = await axiosInstance.get(`/content/topics/${topicId}/timeline/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching topic timeline:', error);
-            throw error;
-        }
-    },
-
-    createTopicTimelineEntry: async (topicId, entryData) => {
-        try {
-            const response = await axiosInstance.post(`/content/topics/${topicId}/timeline/`, entryData);
-            return response.data;
-        } catch (error) {
-            console.error('Error creating topic timeline entry:', error.response || error);
-            throw error;
-        }
-    },
-
-    updateTopicTimelineEntry: async (topicId, entryId, entryData) => {
-        try {
-            const response = await axiosInstance.patch(`/content/topics/${topicId}/timeline/${entryId}/`, entryData);
-            return response.data;
-        } catch (error) {
-            console.error('Error updating topic timeline entry:', error.response || error);
-            throw error;
-        }
-    },
-
-    deleteTopicTimelineEntry: async (topicId, entryId) => {
-        try {
-            const response = await axiosInstance.delete(`/content/topics/${topicId}/timeline/${entryId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error deleting topic timeline entry:', error.response || error);
-            throw error;
-        }
-    },
-
-    reorderTopicTimeline: async (topicId, entryIds) => {
-        try {
-            const response = await axiosInstance.post(`/content/topics/${topicId}/timeline/reorder/`, {
-                entry_ids: entryIds,
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error reordering topic timeline:', error.response || error);
-            throw error;
-        }
-    },
-
-    getTopicBasicDetails: async (topicId) => {
-        try {
-            const response = await axiosInstance.get(`/content/topics/${topicId}/basic/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching topic basic details:', error);
-            throw error;
-        }
-    },
-
-    getRecentContent: async () => {
-        try {
-            const response = await axiosInstance.get('/content/recent-user-content/');
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching recent content:', error);
-            throw error;
-        }
-    },
-
-    updateContentProfile: async (profileId, profileData) => {
-        try {
-            const response = await axiosInstance.patch(
-                `/content/content-profiles/${profileId}/`,
-                profileData
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error updating content profile:', error);
-            throw error;
-        }
-    },
-
-    updateContentProfileContent: async (profileId, contentId) => {
-        try {
-            const response = await axiosInstance.put(
-                `/content/content-profiles/${profileId}/`,
-                { content_id: contentId }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error updating content profile content reference:', error);
-            throw error;
-        }
-    },
-
-    updateContent: async (contentId, contentData) => {
-        try {
-            console.log('contentApi.updateContent called with:', { contentId, contentData });
-            const response = await axiosInstance.put(
-                `/content/content_update/${contentId}/`,
-                contentData
-            );
-            console.log('contentApi.updateContent response:', response.data);
-            return response.data;
-        } catch (error) {
-            console.error('Error updating content:', error);
-            console.error('Error response:', error.response?.data);
-            throw error;
-        }
-    },
-
-    checkContentModification: async (contentId) => {
-        try {
-            const response = await axiosInstance.get(`/content/content_modification_check/${contentId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error checking content modification:', error);
-            throw error;
-        }
-    },
-
-    deleteContent: async (contentId) => {
-        try {
-            await axiosInstance.delete(`/content/content_details/${contentId}/`);
-        } catch (error) {
-            console.error('Error deleting content:', error);
-            throw error;
-        }
-    },
-
-    createPublication: async (publicationData) => {
-        try {
-            const response = await axiosInstance.post('/content/publications/', publicationData);
-            return response.data;
-        } catch (error) {
-            console.error('Error creating publication:', error);
-            throw error;
-        }
-    },
-
-    getUserPublications: async () => {
-        try {
-            const response = await axiosInstance.get('/content/publications/');
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching user publications:', error);
-            throw error;
-        }
-    },
-
-    getUserPublicationsById: async (userId) => {
-        try {
-            const response = await axiosInstance.get(`/content/publications/user/${userId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching user publications:', error);
-            throw error;
-        }
-    },
-
-    getPublicationDetails: async (publicationId) => {
-        try {
-            const response = await axiosInstance.get(`/content/publications/${publicationId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching publication details:', error);
-            throw error;
-        }
-    },
-
-    updatePublication: async (publicationId, publicationData) => {
-        try {
-            const response = await axiosInstance.put(`/content/publications/${publicationId}/`, publicationData);
-            return response.data;
-        } catch (error) {
-            console.error('Error updating publication:', error);
-            throw error;
-        }
-    },
-
-    deletePublication: async (publicationId) => {
-        try {
-            const response = await axiosInstance.delete(`/content/publications/${publicationId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error deleting publication:', error);
-            throw error;
-        }
-    },
-
-    getContentReferences: async (contentId) => {
-        try {
-            const response = await axiosInstance.get(`/content/references/${contentId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching content references:', error);
-            throw error;
-        }
-    },
-
-    updateTopic: async (topicId, topicData) => {
-        try {
-            const response = await axiosInstance.patch(`/content/topics/${topicId}/`, topicData);
-            return response.data;
-        } catch (error) {
-            console.error('Error updating topic:', error);
-            throw error;
-        }
-    },
-
-    deleteTopic: async (topicId) => {
-        try {
-            await axiosInstance.delete(`/content/topics/${topicId}/`);
-        } catch (error) {
-            console.error('Error deleting topic:', error);
-            throw error;
-        }
-    },
-
-    addTopicModerators: async (topicId, usernames) => {
-        try {
-            const response = await axiosInstance.post(`/content/topics/${topicId}/moderators/`, {
-                usernames: usernames
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error adding topic moderators:', error);
-            throw error;
-        }
-    },
-
-    removeTopicModerators: async (topicId, usernames) => {
-        try {
-            const response = await axiosInstance.delete(`/content/topics/${topicId}/moderators/`, {
-                data: { usernames: usernames }
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error removing topic moderators:', error);
-            throw error;
-        }
-    },
-
-    searchUsersByUsername: async (query) => {
-        try {
-            const response = await axiosInstance.get('/content/users/search/', {
-                params: { q: query || '' }
-            });
-            return response.data?.results ?? [];
-        } catch (error) {
-            console.error('Error searching users:', error.response || error);
-            return [];
-        }
-    },
-
-    inviteTopicModerator: async (topicId, username, message = '') => {
-        try {
-            const response = await axiosInstance.post(`/content/topics/${topicId}/moderators/invite/`, {
-                username: username,
-                message: message
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error inviting topic moderator:', error.response || error);
-            throw error;
-        }
-    },
-
-    getTopicModeratorInvitations: async (topicId) => {
-        try {
-            const response = await axiosInstance.get(`/content/topics/${topicId}/moderators/invitations/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching topic moderator invitations:', error.response || error);
-            throw error;
-        }
-    },
-
-    acceptTopicModeratorInvitation: async (topicId, invitationId) => {
-        try {
-            const response = await axiosInstance.post(`/content/topics/${topicId}/moderators/invitations/${invitationId}/accept/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error accepting topic moderator invitation:', error.response || error);
-            throw error;
-        }
-    },
-
-    declineTopicModeratorInvitation: async (topicId, invitationId) => {
-        try {
-            const response = await axiosInstance.post(`/content/topics/${topicId}/moderators/invitations/${invitationId}/decline/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error declining topic moderator invitation:', error.response || error);
-            throw error;
-        }
-    },
-
-    getUserTopics: async (type = null) => {
-        try {
-            const url = type ? `/content/user/topics/?type=${type}` : '/content/user/topics/';
-            const response = await axiosInstance.get(url);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching user topics:', error.response || error);
-            throw error;
-        }
-    },
-
-    getUserTopicInvitations: async (status = 'PENDING') => {
-        try {
-            const response = await axiosInstance.get(`/content/user/topics/invitations/?status=${status}`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching user topic invitations:', error.response || error);
-            throw error;
-        }
-    },
-
-    // Content Suggestions API methods
-    createContentSuggestion: async (topicId, contentId, message = '') => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/topics/${topicId}/content-suggestions/create/`,
-                { content_id: contentId, message: message }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error creating content suggestion:', error.response || error);
-            throw error;
-        }
-    },
-
-    getTopicContentSuggestions: async (topicId, filters = {}) => {
-        try {
-            const params = new URLSearchParams();
-            if (filters.status) params.append('status', filters.status);
-            if (filters.is_duplicate !== undefined) params.append('is_duplicate', filters.is_duplicate);
-            
-            const url = `/content/topics/${topicId}/content-suggestions${params.toString() ? '?' + params.toString() : ''}`;
-            const response = await axiosInstance.get(url);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching topic content suggestions:', error.response || error);
-            throw error;
-        }
-    },
-
-    acceptContentSuggestion: async (topicId, suggestionId) => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/topics/${topicId}/content-suggestions/${suggestionId}/accept/`
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error accepting content suggestion:', error.response || error);
-            throw error;
-        }
-    },
-
-    rejectContentSuggestion: async (topicId, suggestionId, rejectionReason) => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/topics/${topicId}/content-suggestions/${suggestionId}/reject/`,
-                { rejection_reason: rejectionReason }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error rejecting content suggestion:', error.response || error);
-            throw error;
-        }
-    },
-
-    getUserContentSuggestions: async (filters = {}) => {
-        try {
-            const params = new URLSearchParams();
-            if (filters.status) params.append('status', filters.status);
-            if (filters.topic_id) params.append('topic_id', filters.topic_id);
-            
-            const url = `/content/user/content-suggestions${params.toString() ? '?' + params.toString() : ''}`;
-            const response = await axiosInstance.get(url);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching user content suggestions:', error.response || error);
-            throw error;
-        }
-    },
-    deleteContentSuggestion: async (topicId, suggestionId) => {
-        try {
-            const response = await axiosInstance.delete(
-                `/content/topics/${topicId}/content-suggestions/${suggestionId}/`
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error deleting content suggestion:', error.response || error);
-            throw error;
-        }
-    },
-
-    // File Suggestions API methods (URL -> optional file attachment)
-    createFileSuggestion: async (contentId, formData, options = {}) => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/content/${contentId}/file-suggestions/`,
-                formData,
-                {
-                    timeout: options.timeout ?? 30000,
-                    onUploadProgress: options.onUploadProgress,
-                }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error creating file suggestion:', error.response || error);
-            throw error;
-        }
-    },
-
-    /** Presign for large file suggestions (direct S3 PUT, no multipart timeout through Django). */
-    fileSuggestionPresign: async (contentId, metadata) => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/content/${contentId}/file-suggestions/presign/`,
-                metadata,
-                {
-                    timeout: 60000,
-                    headers: { 'Content-Type': 'application/json' },
-                }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error presigning file suggestion:', error.response || error);
-            throw error;
-        }
-    },
-
-    /** After S3 PUT, register the FileSuggestion row (small JSON request). */
-    fileSuggestionConfirm: async (contentId, payload) => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/content/${contentId}/file-suggestions/confirm/`,
-                payload,
-                {
-                    timeout: 120000,
-                    headers: { 'Content-Type': 'application/json' },
-                }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error confirming file suggestion:', error.response || error);
-            throw error;
-        }
-    },
-
-    /** Presign for original uploader to attach a file (no FileSuggestion). */
-    ownerAttachPresign: async (contentId, metadata) => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/content/${contentId}/owner-attach/presign/`,
-                metadata,
-                {
-                    timeout: 60000,
-                    headers: { 'Content-Type': 'application/json' },
-                }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error presigning owner attach:', error.response || error);
-            throw error;
-        }
-    },
-
-    /** After S3 PUT, persist key on FileDetails (uploader only). */
-    ownerAttachConfirm: async (contentId, payload) => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/content/${contentId}/owner-attach/confirm/`,
-                payload,
-                {
-                    timeout: 120000,
-                    headers: { 'Content-Type': 'application/json' },
-                }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error confirming owner attach:', error.response || error);
-            throw error;
-        }
-    },
-
-    createOwnerContentFileAttach: async (contentId, formData, options = {}) => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/content/${contentId}/owner-attach/`,
-                formData,
-                {
-                    timeout: options.timeout ?? 30000,
-                    onUploadProgress: options.onUploadProgress,
-                }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error attaching owner file:', error.response || error);
-            throw error;
-        }
-    },
-
-    /**
-     * Large-friendly flow: presign -> PUT to S3 (XHR progress) -> confirm.
-     * If S3 is not configured (503), falls back to multipart POST with no timeout.
-     */
-    uploadFileSuggestionViaS3: async (contentId, file, message = '', onProgress) => {
-        try {
-            const presignData = await contentApi.fileSuggestionPresign(contentId, {
-                filename: file.name,
-                file_size: file.size,
-                content_type: file.type || 'application/octet-stream',
-            });
-            const uploadMetadata = await contentApi.uploadFileToS3(
-                file,
-                presignData.upload_mode ? presignData : presignData.upload_url,
-                onProgress
-            );
-            return await contentApi.fileSuggestionConfirm(contentId, {
-                key: presignData.key,
-                file_size: file.size,
-                message: message || '',
-                ...(uploadMetadata || {}),
-            });
-        } catch (err) {
-            if (err.response?.status === 503) {
-                console.warn('[File suggestion] S3 unavailable, using multipart fallback');
-                const formData = new FormData();
-                formData.append('file', file);
-                formData.append('message', message || '');
-                return await contentApi.createFileSuggestion(contentId, formData, {
-                    timeout: 0,
-                    onUploadProgress: onProgress
-                        ? (e) => {
-                              if (e.total) onProgress({ loaded: e.loaded, total: e.total });
-                          }
-                        : undefined,
-                });
-            }
-            throw err;
-        }
-    },
-
-    /**
-     * Same as uploadFileSuggestionViaS3 but for the original uploader (no FileSuggestion, no message).
-     */
-    uploadOwnerContentFileViaS3: async (contentId, file, onProgress) => {
-        try {
-            const presignData = await contentApi.ownerAttachPresign(contentId, {
-                filename: file.name,
-                file_size: file.size,
-                content_type: file.type || 'application/octet-stream',
-            });
-            const uploadMetadata = await contentApi.uploadFileToS3(
-                file,
-                presignData.upload_mode ? presignData : presignData.upload_url,
-                onProgress
-            );
-            return await contentApi.ownerAttachConfirm(contentId, {
-                key: presignData.key,
-                file_size: file.size,
-                ...(uploadMetadata || {}),
-            });
-        } catch (err) {
-            if (err.response?.status === 503) {
-                console.warn('[Owner attach] S3 unavailable, using multipart fallback');
-                const formData = new FormData();
-                formData.append('file', file);
-                return await contentApi.createOwnerContentFileAttach(contentId, formData, {
-                    timeout: 0,
-                    onUploadProgress: onProgress
-                        ? (e) => {
-                              if (e.total) onProgress({ loaded: e.loaded, total: e.total });
-                          }
-                        : undefined,
-                });
-            }
-            throw err;
-        }
-    },
-
-    listFileSuggestions: async (contentId) => {
-        try {
-            const response = await axiosInstance.get(
-                `/content/content/${contentId}/file-suggestions/list/`
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error listing file suggestions:', error.response || error);
-            throw error;
-        }
-    },
-
-    acceptFileSuggestion: async (suggestionId) => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/file-suggestions/${suggestionId}/accept/`
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error accepting file suggestion:', error.response || error);
-            throw error;
-        }
-    },
-
-    rejectFileSuggestion: async (suggestionId, rejectionReason = '') => {
-        try {
-            const response = await axiosInstance.post(
-                `/content/file-suggestions/${suggestionId}/reject/`,
-                { rejection_reason: rejectionReason }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error rejecting file suggestion:', error.response || error);
-            throw error;
-        }
-    },
-
-    createContentProfile: async (contentId, profileData) => {
-        try {
-            const response = await axiosInstance.post(`/content/content-profiles/`, {
-                content: contentId,
-                ...profileData
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error creating content profile:', error);
-            throw error;
-        }
-    },
-
-    fetchUrlMetadata: async (url) => {
-        console.log('\n=== Fetching URL Metadata ===');
-        console.log('URL:', url);
-        
-        try {
-            // First try server-side proxy if CORS allows
-            try {
-                console.log('Attempting server-side proxy...');
-                const response = await axiosInstance.post('/content/preview-url/', { url });
-                console.log('Server proxy successful:', response.data);
-                return response.data;
-            } catch (error) {
-                // Log the full error for debugging
-                console.log('Server proxy failed:', error.response?.data?.error || error.message);
-                
-                // If we got an error message from the server, use it
-                if (error.response?.data?.error) {
-                    throw new Error(error.response.data.error);
-                }
-                
-                console.log('Falling back to client-side fetch');
-            }
-
-            // Only try client-side fetch for certain domains that we know support CORS
-            const allowedDomains = ['youtube.com', 'youtu.be', 'github.com', 'githubusercontent.com'];
-            const urlDomain = new URL(url).hostname;
-            const isAllowedDomain = allowedDomains.some(domain => urlDomain.includes(domain));
-
-            if (!isAllowedDomain) {
-                throw new Error('No se puede obtener la vista previa para esta URL');
-            }
-
-            // Fallback to direct fetch if server fails
-            console.log('Making direct fetch request...');
-            const response = await fetch(url);
-            if (!response.ok) {
-                throw new Error('Error al obtener los datos de la URL');
-            }
-
-            const contentType = (response.headers.get('content-type') || '').toLowerCase();
-            if (contentType.includes('application/pdf')) {
-                const parsedUrl = new URL(url);
-                const fileName = decodeURIComponent(parsedUrl.pathname.split('/').pop() || 'Documento PDF');
-                return {
-                    title: fileName,
-                    description: 'Documento PDF',
-                    type: 'document',
-                    siteName: parsedUrl.hostname
-                };
-            }
-
-            if (!contentType.includes('text/html')) {
-                throw new Error('La URL debe apuntar a una página web o PDF');
-            }
-
-            const html = await response.text();
-            console.log('Parsing HTML content...');
-            const doc = new DOMParser().parseFromString(html, 'text/html');
-
-            // Extract Open Graph metadata
-            console.log('Extracting metadata...');
-            const metadata = {
-                title: getMetaContent(doc, 'og:title') || doc.title,
-                description: getMetaContent(doc, 'og:description') || getMetaContent(doc, 'description'),
-                image: getMetaContent(doc, 'og:image'),
-                siteName: getMetaContent(doc, 'og:site_name'),
-                type: getMetaContent(doc, 'og:type') || 'website',
-                favicon: getFavicon(doc, url)
-            };
-
-            console.log('Initial metadata:', metadata);
-
-            // Special handling for YouTube
-            if (url.includes('youtube.com') || url.includes('youtu.be')) {
-                console.log('Detected YouTube URL, fetching additional data...');
-                const videoId = extractYouTubeId(url);
-                if (videoId) {
-                    console.log('YouTube video ID:', videoId);
-                    metadata.image = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
-                    metadata.type = 'video';
-                    metadata.siteName = 'YouTube';
-                    
-                    try {
-                        console.log('Fetching YouTube oEmbed data...');
-                        const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`;
-                        const oembedResponse = await fetch(oembedUrl);
-                        if (!oembedResponse.ok) {
-                            throw new Error('Error al obtener los datos de YouTube');
-                        }
-                        const oembedData = await oembedResponse.json();
-                        if (oembedData.title) {
-                            console.log('YouTube title:', oembedData.title);
-                            metadata.title = oembedData.title;
-                        }
-                    } catch (e) {
-                        console.warn('Failed to fetch YouTube oEmbed data:', e.message);
-                    }
-                }
-            }
-
-            // Validate required fields
-            if (!metadata.title && !metadata.description && !metadata.image) {
-                throw new Error('No se pudo extraer la información de vista previa de esta URL');
-            }
-
-            console.log('Final metadata:', metadata);
-            return metadata;
-        } catch (error) {
-            // Log the full error for debugging
-            console.error('Error fetching URL metadata:', error);
-            
-            // Return a user-friendly error message
-            throw new Error(error.message || 'Error al obtener los datos de la URL');
-        }
+  getUserContent: async () => {
+    try {
+      const response = await axiosInstance.get('/content/user-content/');
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching user content:', error);
+      if (error.code === 'ECONNABORTED') {
+        throw new Error('La solicitud expiró. Por favor, inténtelo de nuevo.');
+      }
+      throw error;
     }
+  },
+
+  getUserContentWithDetails: async (params = {}) => {
+    try {
+      const query = {
+        page: params.page ?? 1,
+        page_size: params.page_size ?? 12
+      };
+      if (params.media_type && params.media_type !== 'ALL') {
+        query.media_type = params.media_type;
+      }
+      if (params.search) {
+        query.search = params.search;
+      }
+      const response = await axiosInstance.get('/content/user-content-with-details/', {
+        params: query
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching user content with details:', error);
+      if (error.code === 'ECONNABORTED') {
+        throw new Error('La solicitud expiró. Por favor, inténtelo de nuevo.');
+      }
+      throw error;
+    }
+  },
+
+  getUserContentById: async (userId) => {
+    try {
+      const response = await axiosInstance.get(`/content/user-content/${userId}/`);
+      return response.data;
+    } catch (error) {
+      console.error(`Error fetching content for user ${userId}:`, error);
+      if (error.code === 'ECONNABORTED') {
+        throw new Error('La solicitud expiró. Por favor, inténtelo de nuevo.');
+      }
+      if (error.response?.status === 404) {
+        throw new Error(`Usuario con ID ${userId} no encontrado.`);
+      }
+      throw error;
+    }
+  },
+
+  // Presign: get URL to upload file directly to S3
+  uploadContentPresign: async (metadata) => {
+
+    try {
+      const response = await axiosInstance.post('/content/upload-content/presign/', metadata, {
+        timeout: 15000,
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      return response.data;
+    } catch (err) {
+      console.error('[S3 upload] Presign failed:', err.response?.status, err.response?.data || err.message);
+      throw err;
+    }
+  },
+
+  // Upload file directly to S3 with optional progress (XHR for progress)
+  uploadFileToS3: async (file, uploadPayload, onProgress) => {
+    if (uploadPayload?.upload_mode === 'multipart') {
+      return contentApi.uploadFileToS3Multipart(file, uploadPayload, onProgress);
+    }
+    const uploadUrl = typeof uploadPayload === 'string' ? uploadPayload : uploadPayload?.upload_url;
+
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('PUT', uploadUrl);
+      xhr.setRequestHeader('Content-Type', file.type || 'application/octet-stream');
+      xhr.withCredentials = false;
+      if (onProgress && xhr.upload) {
+        xhr.upload.onprogress = (e) => {
+          if (e.lengthComputable) onProgress({ loaded: e.loaded, total: e.total });
+        };
+      }
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+
+          resolve();
+        } else {
+          console.error('[S3 upload] PUT to S3 failed:', xhr.status, xhr.statusText);
+          reject(new Error(`S3 upload failed: ${xhr.status} ${xhr.statusText}`));
+        }
+      };
+      xhr.onerror = () => {
+        console.error('[S3 upload] PUT to S3 network error');
+        reject(new Error('S3 upload failed'));
+      };
+      xhr.send(file);
+    });
+  },
+
+  uploadFileToS3Multipart: async (file, uploadPayload, onProgress) => {
+    const partUrls = uploadPayload?.part_urls || [];
+    const partSize = uploadPayload?.part_size || 64 * 1024 * 1024;
+    const totalSize = file?.size || 0;
+    if (!partUrls.length) {
+      throw new Error('Multipart upload inválido: no hay partes para subir');
+    }
+
+    let uploadedBytes = 0;
+    const parts = [];
+    const uploadPart = (partUrl, blob, partNumber) =>
+    new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('PUT', partUrl);
+      xhr.withCredentials = false;
+      let lastLoaded = 0;
+      if (onProgress && xhr.upload) {
+        xhr.upload.onprogress = (e) => {
+          if (!e.lengthComputable) return;
+          const delta = e.loaded - lastLoaded;
+          lastLoaded = e.loaded;
+          uploadedBytes += Math.max(0, delta);
+          onProgress({ loaded: Math.min(uploadedBytes, totalSize), total: totalSize });
+        };
+      }
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          const etag = xhr.getResponseHeader('ETag');
+          if (!etag) {
+            reject(new Error(`S3 multipart upload failed: missing ETag for part ${partNumber}`));
+            return;
+          }
+          resolve({ part_number: partNumber, etag });
+        } else {
+          reject(new Error(`S3 multipart upload failed: ${xhr.status} ${xhr.statusText}`));
+        }
+      };
+      xhr.onerror = () => reject(new Error('S3 multipart upload failed'));
+      xhr.send(blob);
+    });
+
+    for (const part of partUrls) {
+      const partNumber = Number(part.part_number);
+      if (!partNumber || !part.upload_url) {
+        throw new Error('Multipart upload inválido: parte incompleta');
+      }
+      const start = (partNumber - 1) * partSize;
+      const end = Math.min(start + partSize, totalSize);
+      const chunk = file.slice(start, end);
+      const uploadedPart = await uploadPart(part.upload_url, chunk, partNumber);
+      uploadedBytes = end;
+      if (onProgress) onProgress({ loaded: uploadedBytes, total: totalSize });
+      parts.push(uploadedPart);
+    }
+
+    return {
+      upload_id: uploadPayload.upload_id,
+      parts: parts.sort((a, b) => a.part_number - b.part_number)
+    };
+  },
+
+  // Confirm: after S3 upload, create Content/ContentProfile/FileDetails
+  uploadContentConfirm: async (key, metadata) => {
+
+    try {
+      const response = await axiosInstance.post('/content/upload-content/confirm/', { key, ...metadata }, {
+        timeout: 15000,
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      return response.data;
+    } catch (err) {
+      console.error('[S3 upload] Confirm failed:', err.response?.status, err.response?.data || err.message);
+      throw err;
+    }
+  },
+
+  // Full S3 flow: presign -> upload to S3 -> confirm. Falls back to FormData upload if S3 not configured (e.g. dev).
+  uploadContentViaS3: async (file, metadata, onProgress) => {
+
+    try {
+      const presignData = await contentApi.uploadContentPresign({
+        filename: file.name,
+        file_size: file.size,
+        content_type: file.type || 'application/octet-stream',
+        media_type: metadata.media_type,
+        title: metadata.title,
+        author: metadata.author,
+        personalNote: metadata.personalNote,
+        is_visible: metadata.is_visible,
+        is_producer: metadata.is_producer,
+        has_spanish_subtitles: metadata.has_spanish_subtitles,
+        has_spanish_dubbing: metadata.has_spanish_dubbing
+      });
+      const uploadMetadata = await contentApi.uploadFileToS3(
+        file,
+        presignData.upload_mode ? presignData : presignData.upload_url,
+        onProgress
+      );
+      const result = await contentApi.uploadContentConfirm(presignData.key, {
+        media_type: metadata.media_type,
+        title: metadata.title,
+        author: metadata.author,
+        personalNote: metadata.personalNote,
+        is_visible: metadata.is_visible,
+        is_producer: metadata.is_producer,
+        has_spanish_subtitles: metadata.has_spanish_subtitles,
+        has_spanish_dubbing: metadata.has_spanish_dubbing,
+        file_size: file.size,
+        ...(uploadMetadata || {})
+      });
+
+      return result;
+    } catch (err) {
+      if (err.response?.status === 503) {
+        console.warn('[S3 upload] 503 received, falling back to FormData upload');
+        const formData = new FormData();
+        formData.append('file', file);
+        formData.append('media_type', metadata.media_type);
+        formData.append('title', metadata.title || '');
+        formData.append('author', metadata.author || '');
+        formData.append('personalNote', metadata.personalNote || '');
+        formData.append('is_visible', String(metadata.is_visible ?? true));
+        formData.append('is_producer', String(metadata.is_producer ?? false));
+        formData.append('has_spanish_subtitles', String(metadata.has_spanish_subtitles ?? false));
+        formData.append('has_spanish_dubbing', String(metadata.has_spanish_dubbing ?? false));
+        const fallbackResult = await contentApi.uploadContent(formData, { onUploadProgress: onProgress ? (e) => onProgress(e) : undefined });
+
+        return fallbackResult;
+      }
+      console.error('[S3 upload] Flow failed:', err.response?.status, err.message);
+      throw err;
+    }
+  },
+
+  // Legacy: single POST with FormData (used for URL-only or fallback)
+  uploadContent: async (contentData, options = {}) => {
+    try {
+      const config = contentData instanceof FormData ?
+      {
+        timeout: options.timeout ?? 60000,
+        onUploadProgress: options.onUploadProgress
+      } :
+      { headers: { 'Content-Type': 'multipart/form-data' } };
+      const response = await axiosInstance.post('/content/upload-content/', contentData, config);
+      return response.data;
+    } catch (error) {
+      console.error('Error uploading content:', error);
+      if (error.response) console.error('Error response:', error.response.data);
+      throw error;
+    }
+  },
+
+  getContentDetails: async (contentId, context = null, contextId = null) => {
+    try {
+      let url = `/content/content_details/${contentId}/`;
+      if (context && contextId) {
+        url += `?context=${context}&id=${contextId}`;
+      }
+      const response = await axiosInstance.get(url);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching content details:', error);
+      throw error;
+    }
+  },
+
+  getContentPreview: async (contentId, context = null, contextId = null) => {
+    try {
+      let url = `/content/content_preview/${contentId}/`;
+      if (context && contextId) {
+        url += `?context=${context}&id=${contextId}`;
+      }
+      const response = await axiosInstance.get(url);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching content preview:', error);
+      throw error;
+    }
+  },
+
+  getUserCollections: async () => {
+    try {
+      const response = await axiosInstance.get('/content/collections/');
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching user collections:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * Paginated public collections (is_public + at least one visible item).
+   * @param {{ page?: number, page_size?: number, search?: string, owner?: number }} params
+   * @param {number} [params.owner] - filter by library owner's user id
+   */
+  getPublicCollections: async (params = {}) => {
+    try {
+      const searchParams = new URLSearchParams();
+      if (params.page != null) searchParams.set('page', String(params.page));
+      if (params.page_size != null) searchParams.set('page_size', String(params.page_size));
+      if (params.search) searchParams.set('search', params.search.trim());
+      if (params.owner != null && params.owner !== '') {
+        searchParams.set('owner', String(params.owner));
+      }
+      const qs = searchParams.toString();
+      const url = qs ? `/content/collections/public/?${qs}` : '/content/collections/public/';
+      const response = await axiosInstance.get(url);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching public collections:', error);
+      throw error;
+    }
+  },
+
+  createCollection: async (collectionData) => {
+    try {
+      const response = await axiosInstance.post('/content/collections/', collectionData);
+      return response.data;
+    } catch (error) {
+      console.error('Error creating collection:', error);
+      throw error;
+    }
+  },
+
+  getCollection: async (collectionId) => {
+    try {
+      const response = await axiosInstance.get(`/content/collections/${collectionId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching collection:', error.response || error);
+      throw error;
+    }
+  },
+
+  updateCollection: async (collectionId, collectionData) => {
+    try {
+      const response = await axiosInstance.patch(`/content/collections/${collectionId}/`, collectionData);
+      return response.data;
+    } catch (error) {
+      console.error('Error updating collection:', error.response || error);
+      throw error;
+    }
+  },
+
+  getCollectionContent: async (collectionId) => {
+    try {
+      const response = await axiosInstance.get(`/content/collections/${collectionId}/content/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching collection content:', error.response || error);
+      throw error;
+    }
+  },
+
+  addContentToCollection: async (collectionId, contentProfileIds) => {
+    try {
+      // Ensure contentProfileIds is an array
+      const ids = Array.isArray(contentProfileIds) ? contentProfileIds : [contentProfileIds];
+
+      const response = await axiosInstance.post(`/content/collections/${collectionId}/content/`, {
+        content_profile_ids: ids
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error adding content to collection:', error);
+      throw error;
+    }
+  },
+
+  removeContentFromCollection: async (contentProfileId) => {
+    try {
+      const response = await axiosInstance.patch(`/content/content-profiles/${contentProfileId}/`, {
+        collection: null
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error removing content from collection:', error);
+      throw error;
+    }
+  },
+
+  createTopic: async (topicData) => {
+    try {
+      const response = await axiosInstance.post('/content/topics/', topicData);
+      return response.data;
+    } catch (error) {
+      console.error('Error creating topic:', error);
+      throw error;
+    }
+  },
+
+  getTopicDetails: async (topicId, params = {}) => {
+    try {
+      const response = await axiosInstance.get(`/content/topics/${topicId}/`, { params });
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching topic details:', error);
+      throw error;
+    }
+  },
+
+  getTopicDetailsSimple: async (topicId) => {
+    try {
+      const response = await axiosInstance.get(`/content/topics/${topicId}/content-simple/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching topic details (simple):', error);
+      throw error;
+    }
+  },
+
+  updateTopicImage: async (topicId, formData) => {
+    try {
+      const response = await axiosInstance.patch(
+        `/content/topics/${topicId}/`,
+        formData,
+        {
+          headers: {
+            'Content-Type': 'multipart/form-data'
+          }
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error updating topic image:', error);
+      throw error;
+    }
+  },
+
+  getTopics: async () => {
+    try {
+      const response = await axiosInstance.get('/content/topics/');
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching topics:', error);
+      throw error;
+    }
+  },
+
+  addContentToTopic: async (topicId, contentProfileIds) => {
+    try {
+      const response = await axiosInstance.post(`/content/topics/${topicId}/content/`, {
+        content_profile_ids: contentProfileIds
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error adding content to topic:', error.response || error);
+      throw error;
+    }
+  },
+
+  removeContentFromTopic: async (topicId, contentIds) => {
+    try {
+      const response = await axiosInstance.patch(`/content/topics/${topicId}/content/`, {
+        content_ids: contentIds
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error removing content from topic:', error);
+      throw error;
+    }
+  },
+
+  getTopicContentByType: async (topicId, mediaType, params = {}) => {
+    try {
+      const response = await axiosInstance.get(`/content/topics/${topicId}/content/${mediaType}/`, {
+        params: {
+          page: params.page,
+          page_size: params.page_size
+        }
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching topic content by type:', error);
+      throw error;
+    }
+  },
+
+  getTopicTimeline: async (topicId) => {
+    try {
+      const response = await axiosInstance.get(`/content/topics/${topicId}/timeline/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching topic timeline:', error);
+      throw error;
+    }
+  },
+
+  createTopicTimelineEntry: async (topicId, entryData) => {
+    try {
+      const response = await axiosInstance.post(`/content/topics/${topicId}/timeline/`, entryData);
+      return response.data;
+    } catch (error) {
+      console.error('Error creating topic timeline entry:', error.response || error);
+      throw error;
+    }
+  },
+
+  updateTopicTimelineEntry: async (topicId, entryId, entryData) => {
+    try {
+      const response = await axiosInstance.patch(`/content/topics/${topicId}/timeline/${entryId}/`, entryData);
+      return response.data;
+    } catch (error) {
+      console.error('Error updating topic timeline entry:', error.response || error);
+      throw error;
+    }
+  },
+
+  deleteTopicTimelineEntry: async (topicId, entryId) => {
+    try {
+      const response = await axiosInstance.delete(`/content/topics/${topicId}/timeline/${entryId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error deleting topic timeline entry:', error.response || error);
+      throw error;
+    }
+  },
+
+  reorderTopicTimeline: async (topicId, entryIds) => {
+    try {
+      const response = await axiosInstance.post(`/content/topics/${topicId}/timeline/reorder/`, {
+        entry_ids: entryIds
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error reordering topic timeline:', error.response || error);
+      throw error;
+    }
+  },
+
+  getTopicBasicDetails: async (topicId) => {
+    try {
+      const response = await axiosInstance.get(`/content/topics/${topicId}/basic/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching topic basic details:', error);
+      throw error;
+    }
+  },
+
+  getRecentContent: async () => {
+    try {
+      const response = await axiosInstance.get('/content/recent-user-content/');
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching recent content:', error);
+      throw error;
+    }
+  },
+
+  updateContentProfile: async (profileId, profileData) => {
+    try {
+      const response = await axiosInstance.patch(
+        `/content/content-profiles/${profileId}/`,
+        profileData
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error updating content profile:', error);
+      throw error;
+    }
+  },
+
+  updateContentProfileContent: async (profileId, contentId) => {
+    try {
+      const response = await axiosInstance.put(
+        `/content/content-profiles/${profileId}/`,
+        { content_id: contentId }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error updating content profile content reference:', error);
+      throw error;
+    }
+  },
+
+  updateContent: async (contentId, contentData) => {
+    try {
+
+      const response = await axiosInstance.put(
+        `/content/content_update/${contentId}/`,
+        contentData
+      );
+
+      return response.data;
+    } catch (error) {
+      console.error('Error updating content:', error);
+      console.error('Error response:', error.response?.data);
+      throw error;
+    }
+  },
+
+  checkContentModification: async (contentId) => {
+    try {
+      const response = await axiosInstance.get(`/content/content_modification_check/${contentId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error checking content modification:', error);
+      throw error;
+    }
+  },
+
+  deleteContent: async (contentId) => {
+    try {
+      await axiosInstance.delete(`/content/content_details/${contentId}/`);
+    } catch (error) {
+      console.error('Error deleting content:', error);
+      throw error;
+    }
+  },
+
+  createPublication: async (publicationData) => {
+    try {
+      const response = await axiosInstance.post('/content/publications/', publicationData);
+      return response.data;
+    } catch (error) {
+      console.error('Error creating publication:', error);
+      throw error;
+    }
+  },
+
+  getUserPublications: async () => {
+    try {
+      const response = await axiosInstance.get('/content/publications/');
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching user publications:', error);
+      throw error;
+    }
+  },
+
+  getUserPublicationsById: async (userId) => {
+    try {
+      const response = await axiosInstance.get(`/content/publications/user/${userId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching user publications:', error);
+      throw error;
+    }
+  },
+
+  getPublicationDetails: async (publicationId) => {
+    try {
+      const response = await axiosInstance.get(`/content/publications/${publicationId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching publication details:', error);
+      throw error;
+    }
+  },
+
+  updatePublication: async (publicationId, publicationData) => {
+    try {
+      const response = await axiosInstance.put(`/content/publications/${publicationId}/`, publicationData);
+      return response.data;
+    } catch (error) {
+      console.error('Error updating publication:', error);
+      throw error;
+    }
+  },
+
+  deletePublication: async (publicationId) => {
+    try {
+      const response = await axiosInstance.delete(`/content/publications/${publicationId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error deleting publication:', error);
+      throw error;
+    }
+  },
+
+  getContentReferences: async (contentId) => {
+    try {
+      const response = await axiosInstance.get(`/content/references/${contentId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching content references:', error);
+      throw error;
+    }
+  },
+
+  updateTopic: async (topicId, topicData) => {
+    try {
+      const response = await axiosInstance.patch(`/content/topics/${topicId}/`, topicData);
+      return response.data;
+    } catch (error) {
+      console.error('Error updating topic:', error);
+      throw error;
+    }
+  },
+
+  deleteTopic: async (topicId) => {
+    try {
+      await axiosInstance.delete(`/content/topics/${topicId}/`);
+    } catch (error) {
+      console.error('Error deleting topic:', error);
+      throw error;
+    }
+  },
+
+  addTopicModerators: async (topicId, usernames) => {
+    try {
+      const response = await axiosInstance.post(`/content/topics/${topicId}/moderators/`, {
+        usernames: usernames
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error adding topic moderators:', error);
+      throw error;
+    }
+  },
+
+  removeTopicModerators: async (topicId, usernames) => {
+    try {
+      const response = await axiosInstance.delete(`/content/topics/${topicId}/moderators/`, {
+        data: { usernames: usernames }
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error removing topic moderators:', error);
+      throw error;
+    }
+  },
+
+  searchUsersByUsername: async (query) => {
+    try {
+      const response = await axiosInstance.get('/content/users/search/', {
+        params: { q: query || '' }
+      });
+      return response.data?.results ?? [];
+    } catch (error) {
+      console.error('Error searching users:', error.response || error);
+      return [];
+    }
+  },
+
+  inviteTopicModerator: async (topicId, username, message = '') => {
+    try {
+      const response = await axiosInstance.post(`/content/topics/${topicId}/moderators/invite/`, {
+        username: username,
+        message: message
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error inviting topic moderator:', error.response || error);
+      throw error;
+    }
+  },
+
+  getTopicModeratorInvitations: async (topicId) => {
+    try {
+      const response = await axiosInstance.get(`/content/topics/${topicId}/moderators/invitations/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching topic moderator invitations:', error.response || error);
+      throw error;
+    }
+  },
+
+  acceptTopicModeratorInvitation: async (topicId, invitationId) => {
+    try {
+      const response = await axiosInstance.post(`/content/topics/${topicId}/moderators/invitations/${invitationId}/accept/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error accepting topic moderator invitation:', error.response || error);
+      throw error;
+    }
+  },
+
+  declineTopicModeratorInvitation: async (topicId, invitationId) => {
+    try {
+      const response = await axiosInstance.post(`/content/topics/${topicId}/moderators/invitations/${invitationId}/decline/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error declining topic moderator invitation:', error.response || error);
+      throw error;
+    }
+  },
+
+  getUserTopics: async (type = null) => {
+    try {
+      const url = type ? `/content/user/topics/?type=${type}` : '/content/user/topics/';
+      const response = await axiosInstance.get(url);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching user topics:', error.response || error);
+      throw error;
+    }
+  },
+
+  getUserTopicInvitations: async (status = 'PENDING') => {
+    try {
+      const response = await axiosInstance.get(`/content/user/topics/invitations/?status=${status}`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching user topic invitations:', error.response || error);
+      throw error;
+    }
+  },
+
+  // Content Suggestions API methods
+  createContentSuggestion: async (topicId, contentId, message = '') => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/topics/${topicId}/content-suggestions/create/`,
+        { content_id: contentId, message: message }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error creating content suggestion:', error.response || error);
+      throw error;
+    }
+  },
+
+  getTopicContentSuggestions: async (topicId, filters = {}) => {
+    try {
+      const params = new URLSearchParams();
+      if (filters.status) params.append('status', filters.status);
+      if (filters.is_duplicate !== undefined) params.append('is_duplicate', filters.is_duplicate);
+
+      const url = `/content/topics/${topicId}/content-suggestions${params.toString() ? '?' + params.toString() : ''}`;
+      const response = await axiosInstance.get(url);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching topic content suggestions:', error.response || error);
+      throw error;
+    }
+  },
+
+  acceptContentSuggestion: async (topicId, suggestionId) => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/topics/${topicId}/content-suggestions/${suggestionId}/accept/`
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error accepting content suggestion:', error.response || error);
+      throw error;
+    }
+  },
+
+  rejectContentSuggestion: async (topicId, suggestionId, rejectionReason) => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/topics/${topicId}/content-suggestions/${suggestionId}/reject/`,
+        { rejection_reason: rejectionReason }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error rejecting content suggestion:', error.response || error);
+      throw error;
+    }
+  },
+
+  getUserContentSuggestions: async (filters = {}) => {
+    try {
+      const params = new URLSearchParams();
+      if (filters.status) params.append('status', filters.status);
+      if (filters.topic_id) params.append('topic_id', filters.topic_id);
+
+      const url = `/content/user/content-suggestions${params.toString() ? '?' + params.toString() : ''}`;
+      const response = await axiosInstance.get(url);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching user content suggestions:', error.response || error);
+      throw error;
+    }
+  },
+  deleteContentSuggestion: async (topicId, suggestionId) => {
+    try {
+      const response = await axiosInstance.delete(
+        `/content/topics/${topicId}/content-suggestions/${suggestionId}/`
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error deleting content suggestion:', error.response || error);
+      throw error;
+    }
+  },
+
+  // File Suggestions API methods (URL -> optional file attachment)
+  createFileSuggestion: async (contentId, formData, options = {}) => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/content/${contentId}/file-suggestions/`,
+        formData,
+        {
+          timeout: options.timeout ?? 30000,
+          onUploadProgress: options.onUploadProgress
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error creating file suggestion:', error.response || error);
+      throw error;
+    }
+  },
+
+  /** Presign for large file suggestions (direct S3 PUT, no multipart timeout through Django). */
+  fileSuggestionPresign: async (contentId, metadata) => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/content/${contentId}/file-suggestions/presign/`,
+        metadata,
+        {
+          timeout: 60000,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error presigning file suggestion:', error.response || error);
+      throw error;
+    }
+  },
+
+  /** After S3 PUT, register the FileSuggestion row (small JSON request). */
+  fileSuggestionConfirm: async (contentId, payload) => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/content/${contentId}/file-suggestions/confirm/`,
+        payload,
+        {
+          timeout: 120000,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error confirming file suggestion:', error.response || error);
+      throw error;
+    }
+  },
+
+  /** Presign for original uploader to attach a file (no FileSuggestion). */
+  ownerAttachPresign: async (contentId, metadata) => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/content/${contentId}/owner-attach/presign/`,
+        metadata,
+        {
+          timeout: 60000,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error presigning owner attach:', error.response || error);
+      throw error;
+    }
+  },
+
+  /** After S3 PUT, persist key on FileDetails (uploader only). */
+  ownerAttachConfirm: async (contentId, payload) => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/content/${contentId}/owner-attach/confirm/`,
+        payload,
+        {
+          timeout: 120000,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error confirming owner attach:', error.response || error);
+      throw error;
+    }
+  },
+
+  createOwnerContentFileAttach: async (contentId, formData, options = {}) => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/content/${contentId}/owner-attach/`,
+        formData,
+        {
+          timeout: options.timeout ?? 30000,
+          onUploadProgress: options.onUploadProgress
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error attaching owner file:', error.response || error);
+      throw error;
+    }
+  },
+
+  /**
+   * Large-friendly flow: presign -> PUT to S3 (XHR progress) -> confirm.
+   * If S3 is not configured (503), falls back to multipart POST with no timeout.
+   */
+  uploadFileSuggestionViaS3: async (contentId, file, message = '', onProgress) => {
+    try {
+      const presignData = await contentApi.fileSuggestionPresign(contentId, {
+        filename: file.name,
+        file_size: file.size,
+        content_type: file.type || 'application/octet-stream'
+      });
+      const uploadMetadata = await contentApi.uploadFileToS3(
+        file,
+        presignData.upload_mode ? presignData : presignData.upload_url,
+        onProgress
+      );
+      return await contentApi.fileSuggestionConfirm(contentId, {
+        key: presignData.key,
+        file_size: file.size,
+        message: message || '',
+        ...(uploadMetadata || {})
+      });
+    } catch (err) {
+      if (err.response?.status === 503) {
+        console.warn('[File suggestion] S3 unavailable, using multipart fallback');
+        const formData = new FormData();
+        formData.append('file', file);
+        formData.append('message', message || '');
+        return await contentApi.createFileSuggestion(contentId, formData, {
+          timeout: 0,
+          onUploadProgress: onProgress ?
+          (e) => {
+            if (e.total) onProgress({ loaded: e.loaded, total: e.total });
+          } :
+          undefined
+        });
+      }
+      throw err;
+    }
+  },
+
+  /**
+   * Same as uploadFileSuggestionViaS3 but for the original uploader (no FileSuggestion, no message).
+   */
+  uploadOwnerContentFileViaS3: async (contentId, file, onProgress) => {
+    try {
+      const presignData = await contentApi.ownerAttachPresign(contentId, {
+        filename: file.name,
+        file_size: file.size,
+        content_type: file.type || 'application/octet-stream'
+      });
+      const uploadMetadata = await contentApi.uploadFileToS3(
+        file,
+        presignData.upload_mode ? presignData : presignData.upload_url,
+        onProgress
+      );
+      return await contentApi.ownerAttachConfirm(contentId, {
+        key: presignData.key,
+        file_size: file.size,
+        ...(uploadMetadata || {})
+      });
+    } catch (err) {
+      if (err.response?.status === 503) {
+        console.warn('[Owner attach] S3 unavailable, using multipart fallback');
+        const formData = new FormData();
+        formData.append('file', file);
+        return await contentApi.createOwnerContentFileAttach(contentId, formData, {
+          timeout: 0,
+          onUploadProgress: onProgress ?
+          (e) => {
+            if (e.total) onProgress({ loaded: e.loaded, total: e.total });
+          } :
+          undefined
+        });
+      }
+      throw err;
+    }
+  },
+
+  listFileSuggestions: async (contentId) => {
+    try {
+      const response = await axiosInstance.get(
+        `/content/content/${contentId}/file-suggestions/list/`
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error listing file suggestions:', error.response || error);
+      throw error;
+    }
+  },
+
+  acceptFileSuggestion: async (suggestionId) => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/file-suggestions/${suggestionId}/accept/`
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error accepting file suggestion:', error.response || error);
+      throw error;
+    }
+  },
+
+  rejectFileSuggestion: async (suggestionId, rejectionReason = '') => {
+    try {
+      const response = await axiosInstance.post(
+        `/content/file-suggestions/${suggestionId}/reject/`,
+        { rejection_reason: rejectionReason }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error rejecting file suggestion:', error.response || error);
+      throw error;
+    }
+  },
+
+  createContentProfile: async (contentId, profileData) => {
+    try {
+      const response = await axiosInstance.post(`/content/content-profiles/`, {
+        content: contentId,
+        ...profileData
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error creating content profile:', error);
+      throw error;
+    }
+  },
+
+  fetchUrlMetadata: async (url) => {
+
+
+    try {
+      // First try server-side proxy if CORS allows
+      try {
+
+        const response = await axiosInstance.post('/content/preview-url/', { url });
+
+        return response.data;
+      } catch (error) {
+        // Log the full error for debugging
+
+
+        // If we got an error message from the server, use it
+        if (error.response?.data?.error) {
+          throw new Error(error.response.data.error);
+        }
+
+
+      }
+
+      // Only try client-side fetch for certain domains that we know support CORS
+      const allowedDomains = ['youtube.com', 'youtu.be', 'github.com', 'githubusercontent.com'];
+      const urlDomain = new URL(url).hostname;
+      const isAllowedDomain = allowedDomains.some((domain) => urlDomain.includes(domain));
+
+      if (!isAllowedDomain) {
+        throw new Error('No se puede obtener la vista previa para esta URL');
+      }
+
+      // Fallback to direct fetch if server fails
+
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error('Error al obtener los datos de la URL');
+      }
+
+      const contentType = (response.headers.get('content-type') || '').toLowerCase();
+      if (contentType.includes('application/pdf')) {
+        const parsedUrl = new URL(url);
+        const fileName = decodeURIComponent(parsedUrl.pathname.split('/').pop() || 'Documento PDF');
+        return {
+          title: fileName,
+          description: 'Documento PDF',
+          type: 'document',
+          siteName: parsedUrl.hostname
+        };
+      }
+
+      if (!contentType.includes('text/html')) {
+        throw new Error('La URL debe apuntar a una página web o PDF');
+      }
+
+      const html = await response.text();
+
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+
+      // Extract Open Graph metadata
+
+      const metadata = {
+        title: getMetaContent(doc, 'og:title') || doc.title,
+        description: getMetaContent(doc, 'og:description') || getMetaContent(doc, 'description'),
+        image: getMetaContent(doc, 'og:image'),
+        siteName: getMetaContent(doc, 'og:site_name'),
+        type: getMetaContent(doc, 'og:type') || 'website',
+        favicon: getFavicon(doc, url)
+      };
+
+
+      // Special handling for YouTube
+      if (url.includes('youtube.com') || url.includes('youtu.be')) {
+
+        const videoId = extractYouTubeId(url);
+        if (videoId) {
+
+          metadata.image = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
+          metadata.type = 'video';
+          metadata.siteName = 'YouTube';
+
+          try {
+
+            const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`;
+            const oembedResponse = await fetch(oembedUrl);
+            if (!oembedResponse.ok) {
+              throw new Error('Error al obtener los datos de YouTube');
+            }
+            const oembedData = await oembedResponse.json();
+            if (oembedData.title) {
+
+              metadata.title = oembedData.title;
+            }
+          } catch (e) {
+            console.warn('Failed to fetch YouTube oEmbed data:', e.message);
+          }
+        }
+      }
+
+      // Validate required fields
+      if (!metadata.title && !metadata.description && !metadata.image) {
+        throw new Error('No se pudo extraer la información de vista previa de esta URL');
+      }
+
+
+      return metadata;
+    } catch (error) {
+      // Log the full error for debugging
+      console.error('Error fetching URL metadata:', error);
+
+      // Return a user-friendly error message
+      throw new Error(error.message || 'Error al obtener los datos de la URL');
+    }
+  }
 };
 
 // Helper functions
 function getMetaContent(doc, property) {
-    // Try Open Graph meta first
-    const ogMeta = doc.querySelector(`meta[property="${property}"]`);
-    if (ogMeta) return ogMeta.getAttribute('content');
+  // Try Open Graph meta first
+  const ogMeta = doc.querySelector(`meta[property="${property}"]`);
+  if (ogMeta) return ogMeta.getAttribute('content');
 
-    // Try name attribute as fallback
-    const nameMeta = doc.querySelector(`meta[name="${property}"]`);
-    if (nameMeta) return nameMeta.getAttribute('content');
+  // Try name attribute as fallback
+  const nameMeta = doc.querySelector(`meta[name="${property}"]`);
+  if (nameMeta) return nameMeta.getAttribute('content');
 
-    return null;
+  return null;
 }
 
 function getFavicon(doc, url) {
-    // Try standard favicon locations
-    const links = Array.from(doc.querySelectorAll('link[rel*="icon"]'));
-    if (links.length > 0) {
-        // Sort by size preference if specified
-        links.sort((a, b) => {
-            const sizeA = parseInt(a.getAttribute('sizes')?.split('x')[0] || '0');
-            const sizeB = parseInt(b.getAttribute('sizes')?.split('x')[0] || '0');
-            return sizeB - sizeA;
-        });
-        const href = links[0].getAttribute('href');
-        if (href) {
-            return href.startsWith('http') ? href : new URL(href, url).href;
-        }
+  // Try standard favicon locations
+  const links = Array.from(doc.querySelectorAll('link[rel*="icon"]'));
+  if (links.length > 0) {
+    // Sort by size preference if specified
+    links.sort((a, b) => {
+      const sizeA = parseInt(a.getAttribute('sizes')?.split('x')[0] || '0');
+      const sizeB = parseInt(b.getAttribute('sizes')?.split('x')[0] || '0');
+      return sizeB - sizeA;
+    });
+    const href = links[0].getAttribute('href');
+    if (href) {
+      return href.startsWith('http') ? href : new URL(href, url).href;
     }
+  }
 
-    // Fallback to default favicon location
-    const urlObj = new URL(url);
-    return `${urlObj.protocol}//${urlObj.hostname}/favicon.ico`;
+  // Fallback to default favicon location
+  const urlObj = new URL(url);
+  return `${urlObj.protocol}//${urlObj.hostname}/favicon.ico`;
 }
 
 function extractYouTubeId(url) {
-    const patterns = [
-        /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&?/]+)/,
-        /^[^&?/]+$/  // Direct video ID
-    ];
+  const patterns = [
+  /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&?/]+)/,
+  /^[^&?/]+$/ // Direct video ID
+  ];
 
-    for (const pattern of patterns) {
-        const match = url.match(pattern);
-        if (match) return match[1];
-    }
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) return match[1];
+  }
 
-    return null;
+  return null;
 }
 
 export default contentApi;

--- a/frontend/src/api/eventsApi.js
+++ b/frontend/src/api/eventsApi.js
@@ -22,7 +22,7 @@ export const invalidateEventDetailCache = (eventId) => {
 
 /** Synchronous cache read — lets detail pages render without resetting to loading. */
 export const peekEventDetailCache = (eventId) =>
-  eventDetailCache.get(String(eventId)) ?? null;
+eventDetailCache.get(String(eventId)) ?? null;
 
 export const fetchEvents = async () => {
   try {
@@ -43,9 +43,9 @@ export const createEvent = async (eventData) => {
 };
 
 export const fetchEventById = async (
-  eventId,
-  { bypassCache = false, signal } = {},
-) => {
+eventId,
+{ bypassCache = false, signal } = {}) =>
+{
   const id = String(eventId);
 
   if (!bypassCache && eventDetailCache.has(id)) {
@@ -154,7 +154,7 @@ export const getUserCreatedEventsById = async (userId) => {
   try {
     // Use the events endpoint with owner filter
     const response = await axiosInstance.get(`/events/?owner=${userId}`);
-    console.log('Events by owner response:', response.data);
+
     return response.data;
   } catch (error) {
     fail(error, 'Error fetching user created events by ID');

--- a/frontend/src/api/knowledgePathsApi.js
+++ b/frontend/src/api/knowledgePathsApi.js
@@ -1,275 +1,263 @@
 import axiosInstance from './axiosConfig';
 
 const knowledgePathsApi = {
-    createKnowledgePath: async (knowledgePathData) => {
-        try {
-            console.log('knowledgePathsApi.createKnowledgePath - Input data:', knowledgePathData);
-            
-            // Check if there's an image file to upload
-            const hasImage = knowledgePathData.image instanceof File;
-            console.log('knowledgePathsApi.createKnowledgePath - Has image:', hasImage);
-            
-            let response;
-            if (hasImage) {
-                // Use FormData for file upload
-                const formData = new FormData();
-                if (knowledgePathData.title !== undefined) formData.append('title', knowledgePathData.title);
-                if (knowledgePathData.description !== undefined) formData.append('description', knowledgePathData.description);
-                // Ensure visibility updates work even when uploading an image
-                if (knowledgePathData.is_visible !== undefined) formData.append('is_visible', String(knowledgePathData.is_visible));
-                formData.append('image', knowledgePathData.image);
-                
-                console.log('knowledgePathsApi.createKnowledgePath - Using FormData');
-                console.log('knowledgePathsApi.createKnowledgePath - FormData contents:');
-                for (let [key, value] of formData.entries()) {
-                    console.log(`${key}:`, value);
-                }
-                
-                response = await axiosInstance.post('/knowledge_paths/create/', formData, {
-                    headers: {
-                        'Content-Type': 'multipart/form-data'
-                    }
-                });
-            } else {
-                // Use JSON for regular creation
-                const { image, ...jsonData } = knowledgePathData;
-                console.log('knowledgePathsApi.createKnowledgePath - Using JSON data:', jsonData);
-                response = await axiosInstance.post('/knowledge_paths/create/', jsonData);
-            }
-            
-            console.log('knowledgePathsApi.createKnowledgePath - Response:', response.data);
-            return response.data;
-        } catch (error) {
-            console.error('Error creating knowledge path:', error);
-            console.error('Error response:', error.response?.data);
-            throw error;
-        }
-    },
+  createKnowledgePath: async (knowledgePathData) => {
+    try {
 
-    getKnowledgePath: async (pathId) => {
-        try {
-            const response = await axiosInstance.get(`/knowledge_paths/${pathId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching knowledge path:', error);
-            throw error;
-        }
-    },
 
-    deleteKnowledgePath: async (pathId) => {
-        try {
-            await axiosInstance.delete(`/content/knowledge-paths/${pathId}/`);
-        } catch (error) {
-            console.error('Error deleting knowledge path:', error);
-            throw error;
-        }
-    },
+      // Check if there's an image file to upload
+      const hasImage = knowledgePathData.image instanceof File;
 
-    updateKnowledgePath: async (pathId, knowledgePathData) => {
-        try {
-            console.log('knowledgePathsApi.updateKnowledgePath - Input data:', knowledgePathData);
-            
-            // Check if there's an image file to upload
-            const hasImage = knowledgePathData.image instanceof File;
-            console.log('knowledgePathsApi.updateKnowledgePath - Has image:', hasImage);
-            
-            let response;
-            if (hasImage) {
-                // Use FormData for file upload
-                const formData = new FormData();
-                formData.append('title', knowledgePathData.title);
-                formData.append('description', knowledgePathData.description);
-                formData.append('image', knowledgePathData.image);
-                if (knowledgePathData.image_focal_x !== undefined) formData.append('image_focal_x', String(knowledgePathData.image_focal_x));
-                if (knowledgePathData.image_focal_y !== undefined) formData.append('image_focal_y', String(knowledgePathData.image_focal_y));
-                if (knowledgePathData.is_visible !== undefined) formData.append('is_visible', String(knowledgePathData.is_visible));
-                
-                console.log('knowledgePathsApi.updateKnowledgePath - Using FormData');
-                console.log('knowledgePathsApi.updateKnowledgePath - FormData contents:');
-                for (let [key, value] of formData.entries()) {
-                    console.log(`${key}:`, value);
-                }
-                
-                response = await axiosInstance.put(`/knowledge_paths/${pathId}/`, formData, {
-                    headers: {
-                        'Content-Type': 'multipart/form-data'
-                    }
-                });
-            } else {
-                // Use JSON for regular updates (including focal-only updates)
-                const { image, ...jsonData } = knowledgePathData;
-                console.log('knowledgePathsApi.updateKnowledgePath - Using JSON data:', jsonData);
-                response = await axiosInstance.put(`/knowledge_paths/${pathId}/`, jsonData);
-            }
-            
-            console.log('knowledgePathsApi.updateKnowledgePath - Response:', response.data);
-            return response.data;
-        } catch (error) {
-            console.error('Error updating knowledge path:', error);
-            console.error('Error response:', error.response?.data);
-            throw error;
-        }
-    },
 
-    addNode: async (pathId, nodeData) => {
-        try {
-            console.log('Sending request to add node:', { pathId, nodeData });
-            const response = await axiosInstance.post(`/knowledge_paths/${pathId}/nodes/`, {
-                content_profile_id: nodeData.content_profile_id,
-                title: nodeData.title,
-                description: nodeData.description
-            });
-            console.log('Response from add node:', response.data);
-            return response.data;
-        } catch (error) {
-            console.error('Error adding node:', error);
-            throw error;
-        }
-    },
+      let response;
+      if (hasImage) {
+        // Use FormData for file upload
+        const formData = new FormData();
+        if (knowledgePathData.title !== undefined) formData.append('title', knowledgePathData.title);
+        if (knowledgePathData.description !== undefined) formData.append('description', knowledgePathData.description);
+        // Ensure visibility updates work even when uploading an image
+        if (knowledgePathData.is_visible !== undefined) formData.append('is_visible', String(knowledgePathData.is_visible));
+        formData.append('image', knowledgePathData.image);
 
-    getKnowledgePaths: async (page = 1, pageSize = 9) => {
-        try {
-            const response = await axiosInstance.get('/knowledge_paths/', {
-                params: {
-                    page,
-                    page_size: pageSize
-                }
-            });
+        response = await axiosInstance.post('/knowledge_paths/create/', formData, {
+          headers: {
+            'Content-Type': 'multipart/form-data'
+          }
+        });
+      } else {
+        // Use JSON for regular creation
+        const { image, ...jsonData } = knowledgePathData;
 
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching knowledge paths:', error);
-            throw error;
-        }
-    },
+        response = await axiosInstance.post('/knowledge_paths/create/', jsonData);
+      }
 
-    getUserKnowledgePaths: async (page = 1, pageSize = 9) => {
-        try {
-            const response = await axiosInstance.get('/knowledge_paths/my/', {
-                params: {
-                    page,
-                    page_size: pageSize
-                }
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching user knowledge paths:', error);
-            throw error;
-        }
-    },
 
-    getUserEngagedKnowledgePaths: async (page = 1, pageSize = 9) => {
-        try {
-            const response = await axiosInstance.get('/knowledge_paths/engaged/', {
-                params: {
-                    page,
-                    page_size: pageSize
-                }
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching user engaged knowledge paths:', error);
-            throw error;
-        }
-    },
+      return response.data;
+    } catch (error) {
+      console.error('Error creating knowledge path:', error);
+      console.error('Error response:', error.response?.data);
+      throw error;
+    }
+  },
 
-    getUserKnowledgePathsById: async (userId, page = 1, pageSize = 9) => {
-        try {
-            const response = await axiosInstance.get(`/knowledge_paths/user/${userId}/`, {
-                params: {
-                    page,
-                    page_size: pageSize
-                }
-            });
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching knowledge paths by user ID:', error);
-            throw error;
-        }
-    },
+  getKnowledgePath: async (pathId) => {
+    try {
+      const response = await axiosInstance.get(`/knowledge_paths/${pathId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching knowledge path:', error);
+      throw error;
+    }
+  },
 
-    removeNode: async (pathId, nodeId) => {
-        try {
-            console.log('Sending request to remove node:', { pathId, nodeId });
-            const response = await axiosInstance.delete(`/knowledge_paths/${pathId}/nodes/${nodeId}/`);
-            console.log('Response from remove node:', response.data);
-            return response.data;
-        } catch (error) {
-            console.error('Error removing node:', error);
-            throw error;
-        }
-    },
+  deleteKnowledgePath: async (pathId) => {
+    try {
+      await axiosInstance.delete(`/content/knowledge-paths/${pathId}/`);
+    } catch (error) {
+      console.error('Error deleting knowledge path:', error);
+      throw error;
+    }
+  },
 
-    getKnowledgePathBasic: async (pathId) => {
-        try {
-            const response = await axiosInstance.get(`/knowledge_paths/${pathId}/basic/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching basic knowledge path:', error);
-            throw error;
-        }
-    },
+  updateKnowledgePath: async (pathId, knowledgePathData) => {
+    try {
 
-    getNode: async (pathId, nodeId) => {
-        try {
-            const response = await axiosInstance.get(`/knowledge_paths/${pathId}/nodes/${nodeId}/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching node:', error);
-            throw error;
-        }
-    },
 
-    getNodeContent: async (contentProfileId) => {
-        if (!contentProfileId) {
-            return null;
-        }
-        try {
-            const response = await axiosInstance.get(`/content/content-profiles/${contentProfileId}/detail/`);
-            return response.data;
-        } catch (error) {
-            console.error('Error fetching node content:', error);
-            throw error;
-        }
-    },
+      // Check if there's an image file to upload
+      const hasImage = knowledgePathData.image instanceof File;
 
-    updateNode: async (pathId, nodeId, nodeData) => {
-        try {
-            const response = await axiosInstance.put(`/knowledge_paths/${pathId}/nodes/${nodeId}/`, nodeData);
-            return response.data;
-        } catch (error) {
-            console.error('Error updating node:', error);
-            throw error;
-        }
-    },
 
-    reorderNodes: async (pathId, nodeOrders) => {
-        try {
-            const response = await axiosInstance.put(
-                `/knowledge_paths/${pathId}/nodes/reorder/`,
-                { node_orders: nodeOrders }
-            );
-            return response.data;
-        } catch (error) {
-            console.error('Error reordering nodes:', error);
-            throw error;
-        }
-    },
+      let response;
+      if (hasImage) {
+        // Use FormData for file upload
+        const formData = new FormData();
+        formData.append('title', knowledgePathData.title);
+        formData.append('description', knowledgePathData.description);
+        formData.append('image', knowledgePathData.image);
+        if (knowledgePathData.image_focal_x !== undefined) formData.append('image_focal_x', String(knowledgePathData.image_focal_x));
+        if (knowledgePathData.image_focal_y !== undefined) formData.append('image_focal_y', String(knowledgePathData.image_focal_y));
+        if (knowledgePathData.is_visible !== undefined) formData.append('is_visible', String(knowledgePathData.is_visible));
 
-    markNodeCompleted: async (pathId, nodeId) => {
-        try {
-            console.log('Sending node completion request:', { pathId, nodeId });
-            const response = await axiosInstance.post(`/knowledge_paths/${pathId}/nodes/${nodeId}/`);
-            console.log('Node completion API response:', response.data);
-            return response.data;
-        } catch (error) {
-            console.error('Error in markNodeCompleted API call:', error);
-            console.error('Error response:', error.response?.data);
-            throw error;
-        }
-    },
+        response = await axiosInstance.put(`/knowledge_paths/${pathId}/`, formData, {
+          headers: {
+            'Content-Type': 'multipart/form-data'
+          }
+        });
+      } else {
+        // Use JSON for regular updates (including focal-only updates)
+        const { image, ...jsonData } = knowledgePathData;
 
-    // Add other knowledge path-related API calls here as needed
+        response = await axiosInstance.put(`/knowledge_paths/${pathId}/`, jsonData);
+      }
+
+
+      return response.data;
+    } catch (error) {
+      console.error('Error updating knowledge path:', error);
+      console.error('Error response:', error.response?.data);
+      throw error;
+    }
+  },
+
+  addNode: async (pathId, nodeData) => {
+    try {
+
+      const response = await axiosInstance.post(`/knowledge_paths/${pathId}/nodes/`, {
+        content_profile_id: nodeData.content_profile_id,
+        title: nodeData.title,
+        description: nodeData.description
+      });
+
+      return response.data;
+    } catch (error) {
+      console.error('Error adding node:', error);
+      throw error;
+    }
+  },
+
+  getKnowledgePaths: async (page = 1, pageSize = 9) => {
+    try {
+      const response = await axiosInstance.get('/knowledge_paths/', {
+        params: {
+          page,
+          page_size: pageSize
+        }
+      });
+
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching knowledge paths:', error);
+      throw error;
+    }
+  },
+
+  getUserKnowledgePaths: async (page = 1, pageSize = 9) => {
+    try {
+      const response = await axiosInstance.get('/knowledge_paths/my/', {
+        params: {
+          page,
+          page_size: pageSize
+        }
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching user knowledge paths:', error);
+      throw error;
+    }
+  },
+
+  getUserEngagedKnowledgePaths: async (page = 1, pageSize = 9) => {
+    try {
+      const response = await axiosInstance.get('/knowledge_paths/engaged/', {
+        params: {
+          page,
+          page_size: pageSize
+        }
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching user engaged knowledge paths:', error);
+      throw error;
+    }
+  },
+
+  getUserKnowledgePathsById: async (userId, page = 1, pageSize = 9) => {
+    try {
+      const response = await axiosInstance.get(`/knowledge_paths/user/${userId}/`, {
+        params: {
+          page,
+          page_size: pageSize
+        }
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching knowledge paths by user ID:', error);
+      throw error;
+    }
+  },
+
+  removeNode: async (pathId, nodeId) => {
+    try {
+
+      const response = await axiosInstance.delete(`/knowledge_paths/${pathId}/nodes/${nodeId}/`);
+
+      return response.data;
+    } catch (error) {
+      console.error('Error removing node:', error);
+      throw error;
+    }
+  },
+
+  getKnowledgePathBasic: async (pathId) => {
+    try {
+      const response = await axiosInstance.get(`/knowledge_paths/${pathId}/basic/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching basic knowledge path:', error);
+      throw error;
+    }
+  },
+
+  getNode: async (pathId, nodeId) => {
+    try {
+      const response = await axiosInstance.get(`/knowledge_paths/${pathId}/nodes/${nodeId}/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching node:', error);
+      throw error;
+    }
+  },
+
+  getNodeContent: async (contentProfileId) => {
+    if (!contentProfileId) {
+      return null;
+    }
+    try {
+      const response = await axiosInstance.get(`/content/content-profiles/${contentProfileId}/detail/`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching node content:', error);
+      throw error;
+    }
+  },
+
+  updateNode: async (pathId, nodeId, nodeData) => {
+    try {
+      const response = await axiosInstance.put(`/knowledge_paths/${pathId}/nodes/${nodeId}/`, nodeData);
+      return response.data;
+    } catch (error) {
+      console.error('Error updating node:', error);
+      throw error;
+    }
+  },
+
+  reorderNodes: async (pathId, nodeOrders) => {
+    try {
+      const response = await axiosInstance.put(
+        `/knowledge_paths/${pathId}/nodes/reorder/`,
+        { node_orders: nodeOrders }
+      );
+      return response.data;
+    } catch (error) {
+      console.error('Error reordering nodes:', error);
+      throw error;
+    }
+  },
+
+  markNodeCompleted: async (pathId, nodeId) => {
+    try {
+
+      const response = await axiosInstance.post(`/knowledge_paths/${pathId}/nodes/${nodeId}/`);
+
+      return response.data;
+    } catch (error) {
+      console.error('Error in markNodeCompleted API call:', error);
+      console.error('Error response:', error.response?.data);
+      throw error;
+    }
+  }
+
+  // Add other knowledge path-related API calls here as needed
 };
 
-export default knowledgePathsApi; 
+export default knowledgePathsApi;

--- a/frontend/src/api/profilesApi.js
+++ b/frontend/src/api/profilesApi.js
@@ -43,7 +43,7 @@ const getUserProfile = async () => {
   } catch (error) {
     return null;
   }
-}
+};
 
 const getProfileById = async (profileId) => {
   try {
@@ -58,8 +58,8 @@ const updateProfile = async (formData) => {
   try {
     const response = await axiosInstance.put('/profiles/user_profile/', formData, {
       headers: {
-        'Content-Type': 'multipart/form-data',
-      },
+        'Content-Type': 'multipart/form-data'
+      }
     });
     return response.data;
   } catch (error) {
@@ -70,10 +70,10 @@ const updateProfile = async (formData) => {
 const apiLogout = async () => {
   try {
     const response = await axiosInstance.post('/profiles/logout/');
-    
+
     // Clear axios headers after successful logout
     delete axiosInstance.defaults.headers.common['Authorization'];
-    
+
     return response;
   } catch (error) {
     // Even if the API call fails, clear the headers
@@ -85,13 +85,13 @@ const apiLogout = async () => {
 const apiLogin = async ({ username, password }) => {
   try {
     const response = await axiosInstance.post('/profiles/login/', { username, password });
-    
+
     // Make sure we have an access token
     if (response.data.access_token) {
       // Set the token in the axios instance
       axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${response.data.access_token}`;
     }
-    
+
     return response;
   } catch (error) {
     throw error;
@@ -101,13 +101,13 @@ const apiLogin = async ({ username, password }) => {
 const apiRegister = async (userData) => {
   try {
     const response = await axiosInstance.post('/profiles/register/', userData);
-    
+
     // Make sure we have an access token
     if (response.data.access_token) {
       // Set the token in the axios instance
       axiosInstance.defaults.headers.common['Authorization'] = `Bearer ${response.data.access_token}`;
     }
-    
+
     return response;
   } catch (error) {
     throw error;
@@ -122,9 +122,9 @@ async function setCsrfToken() {
       axiosInstance.defaults.headers.common['X-CSRFToken'] = csrftoken;
     }
   } catch (error) {
+
     // Error initializing CSRF token
-  }
-}
+  }}
 
 const refreshToken = async () => {
   try {
@@ -148,12 +148,12 @@ const socialLogin = async (credential) => {
 };
 
 const getNotifications = async (showAll = false) => {
-  console.log('getNotifications called');
+
   try {
-    console.log('Making API request to /profiles/notifications/');
+
     const url = showAll ? '/profiles/notifications/?show_all=true' : '/profiles/notifications/';
     const response = await axiosInstance.get(url);
-    console.log('Notifications API response:', response.data);
+
     return response.data.notifications;
   } catch (error) {
     console.error('Error in getNotifications:', error);
@@ -172,11 +172,11 @@ const getUnreadNotificationsCount = async () => {
 };
 
 const markNotificationAsRead = async (notificationId) => {
-  console.log('markNotificationAsRead called for ID:', notificationId);
+
   try {
-    console.log('Making API request to mark notification as read');
+
     const response = await axiosInstance.post(`/profiles/notifications/${notificationId}/mark-as-read/`);
-    console.log('Mark as read API response:', response.data);
+
     return response.data;
   } catch (error) {
     console.error('Error in markNotificationAsRead:', error);
@@ -185,11 +185,11 @@ const markNotificationAsRead = async (notificationId) => {
 };
 
 const deleteNotification = async (notificationId) => {
-  console.log('deleteNotification called for ID:', notificationId);
+
   try {
-    console.log('Making API request to delete notification');
+
     const response = await axiosInstance.delete(`/profiles/notifications/${notificationId}/delete/`);
-    console.log('Delete notification API response:', response.data);
+
     return response.data;
   } catch (error) {
     console.error('Error in deleteNotification:', error);
@@ -198,11 +198,11 @@ const deleteNotification = async (notificationId) => {
 };
 
 const cleanupNotifications = async () => {
-  console.log('cleanupNotifications called');
+
   try {
-    console.log('Making API request to cleanup notifications');
+
     const response = await axiosInstance.delete('/profiles/notifications/cleanup/');
-    console.log('Cleanup notifications API response:', response.data);
+
     return response.data;
   } catch (error) {
     console.error('Error in cleanupNotifications:', error);
@@ -211,11 +211,11 @@ const cleanupNotifications = async () => {
 };
 
 const markAllNotificationsAsRead = async () => {
-  console.log('markAllNotificationsAsRead called');
+
   try {
-    console.log('Making API request to mark all notifications as read');
+
     const response = await axiosInstance.post('/profiles/notifications/mark-all-as-read/');
-    console.log('Mark all as read API response:', response.data);
+
     return response.data;
   } catch (error) {
     console.error('Error in markAllNotificationsAsRead:', error);
@@ -297,7 +297,7 @@ const changePassword = async (oldPassword, newPassword, confirmPassword) => {
 const submitNewsletterSubscription = async (email) => {
   try {
     const response = await axiosInstance.post('/profiles/newsletter/subscribe/', {
-      email,
+      email
     });
     return response.data;
   } catch (error) {
@@ -306,15 +306,15 @@ const submitNewsletterSubscription = async (email) => {
   }
 };
 
-export { 
-  getUserProfile, 
-  apiLogout, 
-  setCsrfToken, 
-  apiLogin, 
-  checkAuth, 
-  getProfileById, 
-  updateProfile, 
-  apiRegister, 
+export {
+  getUserProfile,
+  apiLogout,
+  setCsrfToken,
+  apiLogin,
+  checkAuth,
+  getProfileById,
+  updateProfile,
+  apiRegister,
   refreshToken,
   socialLogin,
   getNotifications,
@@ -329,5 +329,4 @@ export {
   deleteAcceptedCrypto,
   submitSuggestion,
   changePassword,
-  submitNewsletterSubscription,
-};
+  submitNewsletterSubscription };

--- a/frontend/src/api/quizzesApi.js
+++ b/frontend/src/api/quizzesApi.js
@@ -1,18 +1,9 @@
 import axiosInstance from './axiosConfig';
 
-const quizApi = {  
+const quizApi = {
   createQuiz: async (pathId, quizData) => {
     try {
-      console.log('Creating quiz with data:', {
-        path_id: pathId,
-        node_id: quizData.precedingNodeId,
-        quiz: {
-          title: quizData.title,
-          description: quizData.description,
-          max_attempts_per_day: quizData.max_attempts_per_day,
-          questions: quizData.questions
-        }
-      });
+
 
       const quizResponse = await axiosInstance.post(`/quizzes/quiz-create/`, {
         path_id: pathId,
@@ -21,11 +12,11 @@ const quizApi = {
           title: quizData.title,
           description: quizData.description,
           max_attempts_per_day: quizData.max_attempts_per_day,
-          questions: quizData.questions.map(question => ({
+          questions: quizData.questions.map((question) => ({
             text: question.text,
             question_type: question.questionType,
             image: question.image,
-            options: question.options.map(option => ({
+            options: question.options.map((option) => ({
               text: option.text,
               is_correct: option.isCorrect
             }))
@@ -33,7 +24,7 @@ const quizApi = {
         }
       });
 
-      console.log('Quiz creation response:', quizResponse.data);
+
       return quizResponse.data;
     } catch (error) {
       console.error('Quiz creation error:', {
@@ -62,20 +53,17 @@ const quizApi = {
         description: quizData.description,
         node: quizData.precedingNodeId,
         max_attempts_per_day: quizData.max_attempts_per_day,
-        questions: quizData.questions.map(question => ({
+        questions: quizData.questions.map((question) => ({
           text: question.text,
           question_type: question.questionType,
-          options: question.options.map(option => ({
+          options: question.options.map((option) => ({
             text: option.text,
             is_correct: option.isCorrect
           }))
         }))
       };
 
-      console.log('Making updateQuiz request with data:', requestData);
-      console.log('max_attempts_per_day value:', requestData.max_attempts_per_day);
-      console.log('max_attempts_per_day type:', typeof requestData.max_attempts_per_day);
-      
+
       const response = await axiosInstance.put(`/quizzes/quiz-detail/${quizId}/`, requestData);
       return response.data;
     } catch (error) {
@@ -107,13 +95,10 @@ const quizApi = {
 
   submitQuiz: async (quizId, data) => {
     try {
-      console.log('Making quiz submission request:', {
-        url: `/quizzes/quiz/${quizId}/submit/`,
-        data
-      });
+
 
       const response = await axiosInstance.post(`/quizzes/quiz/${quizId}/submit/`, data);
-      console.log('Successful response data:', response.data);
+
       return response.data;
 
     } catch (error) {
@@ -123,4 +108,4 @@ const quizApi = {
   }
 };
 
-export default quizApi; 
+export default quizApi;

--- a/frontend/src/components/AddToLibraryModal.jsx
+++ b/frontend/src/components/AddToLibraryModal.jsx
@@ -1,150 +1,150 @@
 import React, { useState } from 'react';
 import {
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
-    Button,
-    TextField,
-    Box,
-    IconButton,
-    Tooltip
-} from '@mui/material';
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Box,
+  IconButton,
+  Tooltip } from
+'@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import contentApi from '../api/contentApi';
 
 const AddToLibraryModal = ({ content, onSuccess, buttonProps = {} }) => {
-    const [openModal, setOpenModal] = useState(false);
-    const [formData, setFormData] = useState({
-        title: '',
-        author: '',
-        personalNote: ''
+  const [openModal, setOpenModal] = useState(false);
+  const [formData, setFormData] = useState({
+    title: '',
+    author: '',
+    personalNote: ''
+  });
+
+  const handleOpen = (event) => {
+    if (event) {
+      event.stopPropagation();
+    }
+
+    // Handle different content structures:
+    // 1. From ContentDetailsTopic: content.selected_profile.title/author
+    // 2. From PublicationDetail: content.title/author (profile data)
+    // 3. Fallback to original content data
+    const title = content?.selected_profile?.title ||
+    content?.title ||
+    content?.content?.original_title ||
+    content?.original_title || '';
+
+    const author = content?.selected_profile?.author ||
+    content?.author ||
+    content?.content?.original_author ||
+    content?.original_author || '';
+
+    setFormData({
+      title: title,
+      author: author,
+      personalNote: ''
     });
+    setOpenModal(true);
+  };
 
-    const handleOpen = (event) => {
-        if (event) {
-            event.stopPropagation();
-        }
-        
-        // Handle different content structures:
-        // 1. From ContentDetailsTopic: content.selected_profile.title/author
-        // 2. From PublicationDetail: content.title/author (profile data)
-        // 3. Fallback to original content data
-        const title = content?.selected_profile?.title || 
-                     content?.title || 
-                     content?.content?.original_title || 
-                     content?.original_title || '';
-        
-        const author = content?.selected_profile?.author || 
-                      content?.author || 
-                      content?.content?.original_author || 
-                      content?.original_author || '';
-        
-        setFormData({
-            title: title,
-            author: author,
-            personalNote: ''
-        });
-        setOpenModal(true);
-    };
+  const handleClose = () => {
+    setOpenModal(false);
+  };
 
-    const handleClose = () => {
-        setOpenModal(false);
-    };
+  const handleFormChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value
+    }));
+  };
 
-    const handleFormChange = (e) => {
-        const { name, value } = e.target;
-        setFormData(prev => ({
-            ...prev,
-            [name]: value
-        }));
-    };
+  const handleSubmit = async () => {
+    try {
+      // Get the correct content ID based on the content structure
+      // For ContentDetailsTopic: content.id is the Content ID
+      // For PublicationDetail: content.id is the ContentProfile ID, content.content.id is the Content ID
+      const contentId = content?.content?.id || content?.id;
 
-    const handleSubmit = async () => {
-        try {
-            // Get the correct content ID based on the content structure
-            // For ContentDetailsTopic: content.id is the Content ID
-            // For PublicationDetail: content.id is the ContentProfile ID, content.content.id is the Content ID
-            const contentId = content?.content?.id || content?.id;
-            
-            if (!contentId) {
-                console.error('AddToLibraryModal: No content ID found in content object:', content);
-                return;
-            }
-            
-            console.log('AddToLibraryModal: Creating content profile for content ID:', contentId);
-            await contentApi.createContentProfile(contentId, formData);
-            handleClose();
-            if (onSuccess) {
-                onSuccess();
-            }
-        } catch (error) {
-            console.error('Error adding to library:', error);
-        }
-    };
+      if (!contentId) {
+        console.error('AddToLibraryModal: No content ID found in content object:', content);
+        return;
+      }
 
-    return (
-        <>
+
+      await contentApi.createContentProfile(contentId, formData);
+      handleClose();
+      if (onSuccess) {
+        onSuccess();
+      }
+    } catch (error) {
+      console.error('Error adding to library:', error);
+    }
+  };
+
+  return (
+    <>
             <Tooltip title="Agregar a mi Biblioteca">
-                {buttonProps?.variant ? (
-                    // Show as a button with text when buttonProps are provided
-                    <Button
-                        onClick={handleOpen}
-                        startIcon={<AddIcon />}
-                        {...buttonProps}
-                    >
+                {buttonProps?.variant ?
+        // Show as a button with text when buttonProps are provided
+        <Button
+          onClick={handleOpen}
+          startIcon={<AddIcon />}
+          {...buttonProps}>
+          
                         Agregar a mi Biblioteca
-                    </Button>
-                ) : (
-                    // Show as an icon button (default behavior)
-                    <IconButton
-                        onClick={handleOpen}
-                        color="primary"
-                        size="small"
-                        {...buttonProps}
-                    >
+                    </Button> :
+
+        // Show as an icon button (default behavior)
+        <IconButton
+          onClick={handleOpen}
+          color="primary"
+          size="small"
+          {...buttonProps}>
+          
                         <AddIcon />
                     </IconButton>
-                )}
+        }
             </Tooltip>
 
-            <Dialog 
-                open={openModal} 
-                onClose={handleClose} 
-                maxWidth="sm" 
-                fullWidth
-                keepMounted={false}
-                disablePortal={false}
-                aria-labelledby="add-to-library-dialog-title"
-            >
+            <Dialog
+        open={openModal}
+        onClose={handleClose}
+        maxWidth="sm"
+        fullWidth
+        keepMounted={false}
+        disablePortal={false}
+        aria-labelledby="add-to-library-dialog-title">
+        
                 <DialogTitle id="add-to-library-dialog-title">Agregar a mi Biblioteca</DialogTitle>
                 <DialogContent>
                     <Box sx={{ pt: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
                         <TextField
-                            name="title"
-                            label="Título"
-                            value={formData.title}
-                            onChange={handleFormChange}
-                            fullWidth
-                            required
-                        />
+              name="title"
+              label="Título"
+              value={formData.title}
+              onChange={handleFormChange}
+              fullWidth
+              required />
+            
                         <TextField
-                            name="author"
-                            label="Autor"
-                            value={formData.author}
-                            onChange={handleFormChange}
-                            fullWidth
-                        />
+              name="author"
+              label="Autor"
+              value={formData.author}
+              onChange={handleFormChange}
+              fullWidth />
+            
                         <TextField
-                            name="personalNote"
-                            label="Nota personal"
-                            value={formData.personalNote}
-                            onChange={handleFormChange}
-                            multiline
-                            rows={4}
-                            fullWidth
-                            placeholder="Agrega tus pensamientos o notas sobre este contenido..."
-                        />
+              name="personalNote"
+              label="Nota personal"
+              value={formData.personalNote}
+              onChange={handleFormChange}
+              multiline
+              rows={4}
+              fullWidth
+              placeholder="Agrega tus pensamientos o notas sobre este contenido..." />
+            
                     </Box>
                 </DialogContent>
                 <DialogActions>
@@ -154,8 +154,8 @@ const AddToLibraryModal = ({ content, onSuccess, buttonProps = {} }) => {
                     </Button>
                 </DialogActions>
             </Dialog>
-        </>
-    );
+        </>);
+
 };
 
-export default AddToLibraryModal; 
+export default AddToLibraryModal;

--- a/frontend/src/components/SocialLogin.jsx
+++ b/frontend/src/components/SocialLogin.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
@@ -28,59 +28,59 @@ const ErrorMessage = styled.div`
  * Handles Google OAuth login
  */
 const SocialLogin = () => {
-    const navigate = useNavigate();
-    const { updateAuthState } = useContext(AuthContext);
-    const [error, setError] = useState(null);
+  const navigate = useNavigate();
+  const { updateAuthState } = useContext(AuthContext);
+  const [error, setError] = useState(null);
 
-    const handleCredentialResponse = useCallback(async (response) => {
-        console.log('Google OAuth response received:', response);
-        setError(null);
+  const handleCredentialResponse = useCallback(async (response) => {
 
-        try {
-            // Check if user had previous session data before login using utilities
-            const storedUser = getUserFromLocalStorage();
-            const wasAuthenticated = isAuthenticated();
-            const hadAccessToken = getAccessTokenFromLocalStorage() !== null;
-            const hadPreviousSession = (storedUser !== null) || wasAuthenticated || hadAccessToken;
-            
-            console.log('Attempting to login with Google credential...');
-            const data = await socialLogin(response.credential);
-            console.log('Social login successful, raw response data:', data);
-            
-            if (!data || !data.id || !data.username || !data.email) {
-                console.error('Invalid user data structure:', data);
-                throw new Error('Invalid user data received from server');
-            }
-            
-            // Mark if this is a returning user
-            if (hadPreviousSession) {
-                sessionStorage.setItem('had_previous_session', 'true');
-            }
-            
-            updateAuthState(data, data.access_token);
-            navigate('/profiles/login_successful');
-        } catch (error) {
-            console.error('Google login failed:', error);
-            setError(error.message || 'Failed to login with Google');
-        }
-    }, [updateAuthState, navigate]);
+    setError(null);
 
-    return (
-        <SocialLoginContainer>
+    try {
+      // Check if user had previous session data before login using utilities
+      const storedUser = getUserFromLocalStorage();
+      const wasAuthenticated = isAuthenticated();
+      const hadAccessToken = getAccessTokenFromLocalStorage() !== null;
+      const hadPreviousSession = storedUser !== null || wasAuthenticated || hadAccessToken;
+
+
+      const data = await socialLogin(response.credential);
+
+
+      if (!data || !data.id || !data.username || !data.email) {
+        console.error('Invalid user data structure:', data);
+        throw new Error('Invalid user data received from server');
+      }
+
+      // Mark if this is a returning user
+      if (hadPreviousSession) {
+        sessionStorage.setItem('had_previous_session', 'true');
+      }
+
+      updateAuthState(data, data.access_token);
+      navigate('/profiles/login_successful');
+    } catch (error) {
+      console.error('Google login failed:', error);
+      setError(error.message || 'Failed to login with Google');
+    }
+  }, [updateAuthState, navigate]);
+
+  return (
+    <SocialLoginContainer>
             {error && <ErrorMessage>{error}</ErrorMessage>}
             <GoogleLogin
-                onSuccess={handleCredentialResponse}
-                onError={(error) => {
-                    console.error('Google OAuth error:', error);
-                    setError('Failed to initialize Google login');
-                }}
-                theme="filled_blue"
-                shape="rectangular"
-                text="continue_with"
-                locale="en"
-            />
-        </SocialLoginContainer>
-    );
+        onSuccess={handleCredentialResponse}
+        onError={(error) => {
+          console.error('Google OAuth error:', error);
+          setError('Failed to initialize Google login');
+        }}
+        theme="filled_blue"
+        shape="rectangular"
+        text="continue_with"
+        locale="en" />
+      
+        </SocialLoginContainer>);
+
 };
 
-export default SocialLogin; 
+export default SocialLogin;

--- a/frontend/src/content/CollectionAddContent.jsx
+++ b/frontend/src/content/CollectionAddContent.jsx
@@ -4,59 +4,51 @@ import LibrarySelectMultiple from './LibrarySelectMultiple';
 import contentApi from '../api/contentApi';
 
 const CollectionAddContent = () => {
-    const { collectionId } = useParams();
-    const navigate = useNavigate();
+  const { collectionId } = useParams();
+  const navigate = useNavigate();
 
-    useEffect(() => {
-        console.log('CollectionAddContent mounted with collectionId:', collectionId);
-    }, [collectionId]);
+  useEffect(() => {
 
-    const handleCancel = () => {
-        navigate(`/content/collections/${collectionId}`);
-    };
+  }, [collectionId]);
 
-    const handleSave = async (selectedContentProfileIds) => {
-        try {
-            console.log('Saving content to collection:', {
-                collectionId,
-                selectedContentProfileIds
-            });
-            // Make a single API call with all selected content profile IDs
-            await contentApi.addContentToCollection(collectionId, selectedContentProfileIds);
-            navigate(`/content/collections/${collectionId}`);
-        } catch (error) {
-            console.error('Failed to add content to collection:', error);
-            throw error;
-        }
-    };
+  const handleCancel = () => {
+    navigate(`/content/collections/${collectionId}`);
+  };
 
-    const filterContent = (content) => {
-        // Filter out content that's already in this collection
-        const contentCollectionId =
-            content?.collection && typeof content.collection === 'object'
-                ? content.collection.id
-                : content?.collection;
-        const isInCollection = contentCollectionId === parseInt(collectionId, 10);
-        console.log('CollectionAddContent filtering content:', {
-            contentId: content.id,
-            contentTitle: content.title,
-            collectionId: collectionId,
-            isInCollection,
-            contentCollection: content.collection,
-            contentStructure: JSON.stringify(content, null, 2)
-        });
-        return !isInCollection;
-    };
+  const handleSave = async (selectedContentProfileIds) => {
+    try {
 
-    return (
-        <LibrarySelectMultiple
-            title="Add Content to Collection"
-            description="Select content from your library to add to this collection"
-            onCancel={handleCancel}
-            onSave={handleSave}
-            filterFunction={filterContent}
-        />
-    );
+
+      // Make a single API call with all selected content profile IDs
+      await contentApi.addContentToCollection(collectionId, selectedContentProfileIds);
+      navigate(`/content/collections/${collectionId}`);
+    } catch (error) {
+      console.error('Failed to add content to collection:', error);
+      throw error;
+    }
+  };
+
+  const filterContent = (content) => {
+    // Filter out content that's already in this collection
+    const contentCollectionId =
+    content?.collection && typeof content.collection === 'object' ?
+    content.collection.id :
+    content?.collection;
+    const isInCollection = contentCollectionId === parseInt(collectionId, 10);
+
+
+    return !isInCollection;
+  };
+
+  return (
+    <LibrarySelectMultiple
+      title="Add Content to Collection"
+      description="Select content from your library to add to this collection"
+      onCancel={handleCancel}
+      onSave={handleSave}
+      filterFunction={filterContent} />);
+
+
 };
 
-export default CollectionAddContent; 
+export default CollectionAddContent;

--- a/frontend/src/content/CollectionEditContent.jsx
+++ b/frontend/src/content/CollectionEditContent.jsx
@@ -1,25 +1,25 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { 
-    Box, 
-    Typography, 
-    IconButton, 
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
-    Paper,
-    Button,
-    Alert,
-    Chip,
-    Link as MuiLink,
-    Divider,
-    TextField,
-    FormControlLabel,
-    Switch,
-} from '@mui/material';
+import {
+  Box,
+  Typography,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Button,
+  Alert,
+  Chip,
+  Link as MuiLink,
+  Divider,
+  TextField,
+  FormControlLabel,
+  Switch } from
+'@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import AddIcon from '@mui/icons-material/Add';
@@ -30,258 +30,247 @@ import contentApi from '../api/contentApi';
 import LibrarySelectMultiple from './LibrarySelectMultiple';
 
 const CollectionEditContent = () => {
-    const { collectionId } = useParams();
-    const navigate = useNavigate();
-    const location = useLocation();
-    const [collectionData, setCollectionData] = useState(null);
-    const [collectionName, setCollectionName] = useState('');
-    const [editingName, setEditingName] = useState(false);
-    const [tempCollectionName, setTempCollectionName] = useState('');
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
-    const [saving, setSaving] = useState(false);
-    const [savingName, setSavingName] = useState(false);
-    const [savingPrivacy, setSavingPrivacy] = useState(false);
-    const [isPublic, setIsPublic] = useState(false);
-    const [showAddContent, setShowAddContent] = useState(false);
+  const { collectionId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [collectionData, setCollectionData] = useState(null);
+  const [collectionName, setCollectionName] = useState('');
+  const [editingName, setEditingName] = useState(false);
+  const [tempCollectionName, setTempCollectionName] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [savingName, setSavingName] = useState(false);
+  const [savingPrivacy, setSavingPrivacy] = useState(false);
+  const [isPublic, setIsPublic] = useState(false);
+  const [showAddContent, setShowAddContent] = useState(false);
 
-    useEffect(() => {
-        const fetchCollectionData = async () => {
-            try {
-                const [collectionInfo, contentData] = await Promise.all([
-                    contentApi.getCollection(collectionId),
-                    contentApi.getCollectionContent(collectionId)
-                ]);
-
-                if (collectionInfo.is_owner === false) {
-                    navigate(`/content/collections/${collectionId}`, { replace: true, state: location.state });
-                    setLoading(false);
-                    return;
-                }
-
-                setCollectionName(collectionInfo.name || '');
-                setIsPublic(!!collectionInfo.is_public);
-                setCollectionData(contentData || []);
-                setLoading(false);
-            } catch (err) {
-                console.error('Error fetching collection data:', err);
-                setError('Error al obtener los datos de la colección');
-                setLoading(false);
-            }
-        };
-
-        fetchCollectionData();
-    }, [collectionId, navigate]);
-
-    const handleContentRemove = async (contentProfileId) => {
-        console.log('Removing content profile:', contentProfileId);
-        try {
-            setSaving(true);
-            await contentApi.removeContentFromCollection(contentProfileId);
-            console.log('Content removed successfully');
-            setCollectionData(prev => prev.filter(content => content.id !== contentProfileId));
-            setSaving(false);
-        } catch (err) {
-            console.error('Error removing content:', err);
-            setError('Error al eliminar contenido de la colección');
-            setSaving(false);
-        }
-    };
-
-    const handleCancelAdd = () => {
-        console.log('Canceling add content');
-        setShowAddContent(false);
-    };
-
-    const handleSaveAdd = async (selectedContentProfileIds) => {
-        console.log('Saving selected content profiles:', selectedContentProfileIds);
-        try {
-            setSaving(true);
-            // Make a single API call with all selected content profile IDs
-            await contentApi.addContentToCollection(collectionId, selectedContentProfileIds);
-            console.log('All content added successfully');
-            // Refresh collection content
-            const data = await contentApi.getCollectionContent(collectionId);
-            console.log('Refreshed collection content:', data);
-            setCollectionData(data);
-            setShowAddContent(false);
-            setSaving(false);
-        } catch (error) {
-            console.error('Error adding content:', error);
-            setError('Error al agregar contenido a la colección');
-            setSaving(false);
-        }
-    };
-
-    const handleStartEditName = () => {
-        setTempCollectionName(collectionName);
-        setEditingName(true);
-    };
-
-    const handleCancelEditName = () => {
-        setEditingName(false);
-        setTempCollectionName('');
-    };
-
-    const handleSaveName = async () => {
-        if (!tempCollectionName.trim()) {
-            setError('El nombre de la colección no puede estar vacío');
-            return;
-        }
-
-        try {
-            setSavingName(true);
-            const updatedCollection = await contentApi.updateCollection(collectionId, {
-                name: tempCollectionName.trim()
-            });
-            setCollectionName(updatedCollection.name);
-            setEditingName(false);
-            setSavingName(false);
-        } catch (err) {
-            console.error('Error updating collection name:', err);
-            setError('Error al actualizar el nombre de la colección');
-            setSavingName(false);
-        }
-    };
-
-    const handleTogglePublic = async (event) => {
-        const next = event.target.checked;
-        try {
-            setSavingPrivacy(true);
-            setError(null);
-            const updated = await contentApi.updateCollection(collectionId, { is_public: next });
-            setIsPublic(!!updated.is_public);
-        } catch (err) {
-            console.error('Error updating collection visibility:', err);
-            setError('No se pudo actualizar la visibilidad de la colección');
-        } finally {
-            setSavingPrivacy(false);
-        }
-    };
-
-    const filterContent = (content) => {
-        // Filter out content that's already in this collection
-        const isInCollection = content.collection === parseInt(collectionId);
-        console.log('CollectionEditContent filtering content:', {
-            contentId: content.id,
-            contentTitle: content.title,
-            collectionId: collectionId,
-            contentCollection: content.collection,
-            isInCollection,
-            contentStructure: JSON.stringify(content, null, 2)
-        });
-        return !isInCollection;
-    };
-
-    if (loading) {
-        console.log('Component is loading...');
-        return <Typography>Cargando contenido de la colección...</Typography>;
-    }
-    if (error) {
-        console.log('Component has error:', error);
-        return <Alert severity="error">{error}</Alert>;
-    }
-    if (!collectionData) {
-        console.log('No collection data available');
-        return <Alert severity="error">Colección no encontrada</Alert>;
-    }
-
-    if (showAddContent) {
-        console.log('Showing add content view');
-        return (
-            <LibrarySelectMultiple
-                title="Agregar contenido a la colección"
-                description="Selecciona contenido de tu biblioteca para agregar a esta colección"
-                onCancel={handleCancelAdd}
-                onSave={handleSaveAdd}
-                filterFunction={filterContent}
-                contextName={collectionName}
-            />
+  useEffect(() => {
+    const fetchCollectionData = async () => {
+      try {
+        const [collectionInfo, contentData] = await Promise.all([
+        contentApi.getCollection(collectionId),
+        contentApi.getCollectionContent(collectionId)]
         );
+
+        if (collectionInfo.is_owner === false) {
+          navigate(`/content/collections/${collectionId}`, { replace: true, state: location.state });
+          setLoading(false);
+          return;
+        }
+
+        setCollectionName(collectionInfo.name || '');
+        setIsPublic(!!collectionInfo.is_public);
+        setCollectionData(contentData || []);
+        setLoading(false);
+      } catch (err) {
+        console.error('Error fetching collection data:', err);
+        setError('Error al obtener los datos de la colección');
+        setLoading(false);
+      }
+    };
+
+    fetchCollectionData();
+  }, [collectionId, navigate]);
+
+  const handleContentRemove = async (contentProfileId) => {
+
+    try {
+      setSaving(true);
+      await contentApi.removeContentFromCollection(contentProfileId);
+
+      setCollectionData((prev) => prev.filter((content) => content.id !== contentProfileId));
+      setSaving(false);
+    } catch (err) {
+      console.error('Error removing content:', err);
+      setError('Error al eliminar contenido de la colección');
+      setSaving(false);
+    }
+  };
+
+  const handleCancelAdd = () => {
+
+    setShowAddContent(false);
+  };
+
+  const handleSaveAdd = async (selectedContentProfileIds) => {
+
+    try {
+      setSaving(true);
+      // Make a single API call with all selected content profile IDs
+      await contentApi.addContentToCollection(collectionId, selectedContentProfileIds);
+
+      // Refresh collection content
+      const data = await contentApi.getCollectionContent(collectionId);
+
+      setCollectionData(data);
+      setShowAddContent(false);
+      setSaving(false);
+    } catch (error) {
+      console.error('Error adding content:', error);
+      setError('Error al agregar contenido a la colección');
+      setSaving(false);
+    }
+  };
+
+  const handleStartEditName = () => {
+    setTempCollectionName(collectionName);
+    setEditingName(true);
+  };
+
+  const handleCancelEditName = () => {
+    setEditingName(false);
+    setTempCollectionName('');
+  };
+
+  const handleSaveName = async () => {
+    if (!tempCollectionName.trim()) {
+      setError('El nombre de la colección no puede estar vacío');
+      return;
     }
 
-    console.log('Rendering collection content view:', {
-        collectionId,
-        collectionName,
-        contentCount: collectionData.length
-    });
+    try {
+      setSavingName(true);
+      const updatedCollection = await contentApi.updateCollection(collectionId, {
+        name: tempCollectionName.trim()
+      });
+      setCollectionName(updatedCollection.name);
+      setEditingName(false);
+      setSavingName(false);
+    } catch (err) {
+      console.error('Error updating collection name:', err);
+      setError('Error al actualizar el nombre de la colección');
+      setSavingName(false);
+    }
+  };
+
+  const handleTogglePublic = async (event) => {
+    const next = event.target.checked;
+    try {
+      setSavingPrivacy(true);
+      setError(null);
+      const updated = await contentApi.updateCollection(collectionId, { is_public: next });
+      setIsPublic(!!updated.is_public);
+    } catch (err) {
+      console.error('Error updating collection visibility:', err);
+      setError('No se pudo actualizar la visibilidad de la colección');
+    } finally {
+      setSavingPrivacy(false);
+    }
+  };
+
+  const filterContent = (content) => {
+    // Filter out content that's already in this collection
+    const isInCollection = content.collection === parseInt(collectionId);
+
+
+    return !isInCollection;
+  };
+
+  if (loading) {
+
+    return <Typography>Cargando contenido de la colección...</Typography>;
+  }
+  if (error) {
+
+    return <Alert severity="error">{error}</Alert>;
+  }
+  if (!collectionData) {
+
+    return <Alert severity="error">Colección no encontrada</Alert>;
+  }
+
+  if (showAddContent) {
 
     return (
-        <Box sx={{ pt: 12, px: 3, maxWidth: 1200, mx: 'auto' }}>
+      <LibrarySelectMultiple
+        title="Agregar contenido a la colección"
+        description="Selecciona contenido de tu biblioteca para agregar a esta colección"
+        onCancel={handleCancelAdd}
+        onSave={handleSaveAdd}
+        filterFunction={filterContent}
+        contextName={collectionName} />);
+
+
+  }
+
+
+  return (
+    <Box sx={{ pt: 12, px: 3, maxWidth: 1200, mx: 'auto' }}>
             <Paper sx={{ p: 3 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 3, flexWrap: 'wrap', gap: 2 }}>
-                    <IconButton 
-                        onClick={() =>
-                            navigate(`/content/collections/${collectionId}`, { replace: true, state: location.state })
-                        }
-                        sx={{ mr: 1 }}
-                    >
+                    <IconButton
+            onClick={() =>
+            navigate(`/content/collections/${collectionId}`, { replace: true, state: location.state })
+            }
+            sx={{ mr: 1 }}>
+            
                         <ArrowBackIcon />
                     </IconButton>
                     <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1, gap: 1, minWidth: 300 }}>
-                        {editingName ? (
-                            <>
+                        {editingName ?
+            <>
                                 <TextField
-                                    value={tempCollectionName}
-                                    onChange={(e) => setTempCollectionName(e.target.value)}
-                                    variant="outlined"
-                                    size="small"
-                                    sx={{ flexGrow: 1 }}
-                                    disabled={savingName}
-                                    autoFocus
-                                />
+                value={tempCollectionName}
+                onChange={(e) => setTempCollectionName(e.target.value)}
+                variant="outlined"
+                size="small"
+                sx={{ flexGrow: 1 }}
+                disabled={savingName}
+                autoFocus />
+              
                                 <IconButton
-                                    onClick={handleSaveName}
-                                    disabled={savingName}
-                                    color="primary"
-                                >
+                onClick={handleSaveName}
+                disabled={savingName}
+                color="primary">
+                
                                     <SaveIcon />
                                 </IconButton>
                                 <IconButton
-                                    onClick={handleCancelEditName}
-                                    disabled={savingName}
-                                >
+                onClick={handleCancelEditName}
+                disabled={savingName}>
+                
                                     <CancelIcon />
                                 </IconButton>
-                            </>
-                        ) : (
-                            <>
+                            </> :
+
+            <>
                                 <Typography variant="h4" sx={{ flexGrow: 1 }}>
                                     {collectionName}
                                 </Typography>
                                 <IconButton
-                                    onClick={handleStartEditName}
-                                    size="small"
-                                    sx={{ ml: 1 }}
-                                >
+                onClick={handleStartEditName}
+                size="small"
+                sx={{ ml: 1 }}>
+                
                                     <EditIcon fontSize="small" />
                                 </IconButton>
                             </>
-                        )}
+            }
                     </Box>
                     <Button
-                        variant="contained"
-                        color="primary"
-                        startIcon={<AddIcon />}
-                        onClick={() => setShowAddContent(true)}
-                        sx={{ ml: 'auto' }}
-                    >
+            variant="contained"
+            color="primary"
+            startIcon={<AddIcon />}
+            onClick={() => setShowAddContent(true)}
+            sx={{ ml: 'auto' }}>
+            
                         Agregar contenido de tu biblioteca
                     </Button>
                 </Box>
 
                 <Box sx={{ mb: 2 }}>
                     <FormControlLabel
-                        control={
-                            <Switch
-                                checked={isPublic}
-                                onChange={handleTogglePublic}
-                                disabled={savingPrivacy}
-                                color="primary"
-                            />
-                        }
-                        label={
-                            <Box>
+            control={
+            <Switch
+              checked={isPublic}
+              onChange={handleTogglePublic}
+              disabled={savingPrivacy}
+              color="primary" />
+
+            }
+            label={
+            <Box>
                                 <Typography variant="body2" component="span" display="block">
                                     Colección pública
                                 </Typography>
@@ -289,8 +278,8 @@ const CollectionEditContent = () => {
                                     Visible en la biblioteca para otros usuarios (solo ítems con visibilidad en búsqueda).
                                 </Typography>
                             </Box>
-                        }
-                    />
+            } />
+          
                 </Box>
 
                 <Divider sx={{ my: 3 }} />
@@ -311,67 +300,67 @@ const CollectionEditContent = () => {
                             </TableRow>
                         </TableHead>
                         <TableBody>
-                            {collectionData.map((content) => (
-                                <TableRow 
-                                    key={content.id}
-                                    hover
-                                    sx={{ cursor: 'pointer' }}
-                                >
+                            {collectionData.map((content) =>
+              <TableRow
+                key={content.id}
+                hover
+                sx={{ cursor: 'pointer' }}>
+                
                                     <TableCell>{content.title || 'Sin título'}</TableCell>
                                     <TableCell>
-                                        <Chip 
-                                            label={content.content.media_type} 
-                                            size="small"
-                                            color="primary"
-                                        />
+                                        <Chip
+                    label={content.content.media_type}
+                    size="small"
+                    color="primary" />
+                  
                                     </TableCell>
                                     <TableCell>{content.author || 'Desconocido'}</TableCell>
                                     <TableCell>
                                         <MuiLink
-                                            href={`/content/${content.content.id}`}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            sx={{ 
-                                                display: 'flex', 
-                                                alignItems: 'center',
-                                                gap: 0.5,
-                                                color: 'primary.main',
-                                                textDecoration: 'none',
-                                                '&:hover': {
-                                                    textDecoration: 'underline'
-                                                }
-                                            }}
-                                        >
+                    href={`/content/${content.content.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      color: 'primary.main',
+                      textDecoration: 'none',
+                      '&:hover': {
+                        textDecoration: 'underline'
+                      }
+                    }}>
+                    
                                             Ver
                                             <OpenInNewIcon fontSize="small" />
                                         </MuiLink>
                                     </TableCell>
                                     <TableCell>
                                         <Button
-                                            variant="outlined"
-                                            color="error"
-                                            size="small"
-                                            onClick={() => handleContentRemove(content.id)}
-                                            disabled={saving}
-                                        >
+                    variant="outlined"
+                    color="error"
+                    size="small"
+                    onClick={() => handleContentRemove(content.id)}
+                    disabled={saving}>
+                    
                                             Eliminar
                                         </Button>
                                     </TableCell>
                                 </TableRow>
-                            ))}
-                            {collectionData.length === 0 && (
-                                <TableRow>
+              )}
+                            {collectionData.length === 0 &&
+              <TableRow>
                                     <TableCell colSpan={5} align="center">
                                         No hay contenido en esta colección
                                     </TableCell>
                                 </TableRow>
-                            )}
+              }
                         </TableBody>
                     </Table>
                 </TableContainer>
             </Paper>
-        </Box>
-    );
+        </Box>);
+
 };
 
-export default CollectionEditContent; 
+export default CollectionEditContent;

--- a/frontend/src/content/ContentDisplay.jsx
+++ b/frontend/src/content/ContentDisplay.jsx
@@ -15,8 +15,8 @@ import {
   IconButton,
   Tooltip,
   Snackbar,
-  Alert,
-} from "@mui/material";
+  Alert } from
+"@mui/material";
 import { useNavigate, Link } from "react-router-dom";
 import { resolveMediaUrl } from "../utils/fileUtils";
 import DescriptionIcon from "@mui/icons-material/Description";
@@ -42,8 +42,8 @@ import VoteComponent from "../votes/VoteComponent";
 import {
   SequentialThumbnail,
   buildListingThumbnailSources,
-  buildMediaPreviewThumbnailSources,
-} from "./ContentListingThumbnail";
+  buildMediaPreviewThumbnailSources } from
+"./ContentListingThumbnail";
 
 const ContentDisplay = ({
   content,
@@ -58,13 +58,13 @@ const ContentDisplay = ({
   additionalActions,
   topicId = null,
   showSuggestFileButton = false,
-  onSuggestFile = null,
+  onSuggestFile = null
 }) => {
   const [renderError, setRenderError] = useState(null);
   const [snackbar, setSnackbar] = useState({
     open: false,
     message: "",
-    severity: "success",
+    severity: "success"
   });
   const navigate = useNavigate();
 
@@ -92,24 +92,15 @@ const ContentDisplay = ({
   const customThumbnail = selectedProfileThumbnail || previewProfileThumbnail;
   /** Downsized WebP when available; falls back to full custom thumbnail or OG. */
   const customThumbnailForDisplay =
-    selectedProfileThumbnailPreview ||
-    previewProfileThumbnailPreview ||
-    customThumbnail;
+  selectedProfileThumbnailPreview ||
+  previewProfileThumbnailPreview ||
+  customThumbnail;
   const hasFileAvailable = Boolean(
     fileDetails?.file || content?.has_file_available || contentData?.has_file_available
   );
 
   // Debug logging for preview mode (moved after variable declarations)
-  if (variant === "preview") {
-    console.log("ContentDisplay Preview Mode - Content Data:", {
-      id: content.id,
-      title: title,
-      author: author,
-      personal_note: content.personal_note,
-      contentData: contentData,
-      hasNestedContent: !!content.content,
-    });
-  }
+
 
   // Helper function to format date
   const formatDate = (dateString) => {
@@ -160,7 +151,7 @@ const ContentDisplay = ({
         "drive.google.com": "Google Drive",
         "docs.google.com": "Google Docs",
         "twitch.tv": "Twitch",
-        "tiktok.com": "TikTok",
+        "tiktok.com": "TikTok"
       };
       if (map[hostname]) return map[hostname];
       const parts = hostname.split(".").filter(Boolean);
@@ -187,16 +178,16 @@ const ContentDisplay = ({
       VIDEO: "Video",
       AUDIO: "Audio",
       IMAGE: "Imagen",
-      TEXT: "Texto",
+      TEXT: "Texto"
     };
     const label = labels[mt] || (mt ? mt.charAt(0) + mt.slice(1).toLowerCase() : "Contenido");
     const iconSx = { fontSize: 28, color: "primary.main", opacity: 0.9 };
     let icon = <DescriptionIcon sx={iconSx} />;
-    if (mt === "VIDEO") icon = <VideocamIcon sx={iconSx} />;
-    else if (mt === "AUDIO") icon = <AudiotrackIcon sx={iconSx} />;
-    else if (mt === "IMAGE") icon = <ImageIcon sx={iconSx} />;
-    else if (mt === "TEXT")
-      icon = contentExternalUrl ? <LinkIcon sx={iconSx} /> : <ArticleIcon sx={iconSx} />;
+    if (mt === "VIDEO") icon = <VideocamIcon sx={iconSx} />;else
+    if (mt === "AUDIO") icon = <AudiotrackIcon sx={iconSx} />;else
+    if (mt === "IMAGE") icon = <ImageIcon sx={iconSx} />;else
+    if (mt === "TEXT")
+    icon = contentExternalUrl ? <LinkIcon sx={iconSx} /> : <ArticleIcon sx={iconSx} />;
 
     return (
       <Box
@@ -209,15 +200,15 @@ const ContentDisplay = ({
           borderRadius: 1,
           bgcolor: "action.hover",
           width: "fit-content",
-          maxWidth: "100%",
-        }}
-      >
+          maxWidth: "100%"
+        }}>
+        
         {icon}
         <Typography variant="body2" fontWeight={600} color="text.primary">
           {label}
         </Typography>
-      </Box>
-    );
+      </Box>);
+
   };
 
   const getFileUrlFromContent = () => {
@@ -238,7 +229,7 @@ const ContentDisplay = ({
   const getMediaTypeIcon = (content) => {
     const iconProps = {
       fontSize: "large",
-      sx: { opacity: 0.7, color: "text.secondary" },
+      sx: { opacity: 0.7, color: "text.secondary" }
     };
 
     // Use media_type from serializer
@@ -289,15 +280,7 @@ const ContentDisplay = ({
     const fileUrl = getFileUrlFromContent();
 
     // Debug logging for detailed mode
-    if (variant === "detailed") {
-      console.log("ContentDisplay Detailed Mode - renderContentByType:", {
-        mediaType: mediaTypeUpper,
-        fileUrl: fileUrl,
-        hasFileDetails: !!fileDetails,
-        fileDetails: fileDetails,
-        contentData: contentData,
-      });
-    }
+
 
     // Function to handle content clicks
     const handleContentClick = () => {
@@ -308,10 +291,29 @@ const ContentDisplay = ({
     const isClickable = Boolean(fileUrl);
 
     switch (mediaTypeUpper) {
-      case "IMAGE": {
-        const thumbUrl = customThumbnailForDisplay || fileUrl;
-        if (!thumbUrl) {
-          console.warn("No file URL found for image content:", contentData);
+      case "IMAGE":{
+          const thumbUrl = customThumbnailForDisplay || fileUrl;
+          if (!thumbUrl) {
+            console.warn("No file URL found for image content:", contentData);
+            return (
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  width: "100%",
+                  height: 200,
+                  bgcolor: "grey.100",
+                  borderRadius: 0.5
+                }}>
+                
+              <Typography color="text.secondary">
+                Archivo de imagen no disponible
+              </Typography>
+            </Box>);
+
+          }
+
           return (
             <Box
               sx={{
@@ -319,82 +321,63 @@ const ContentDisplay = ({
                 justifyContent: "center",
                 alignItems: "center",
                 width: "100%",
-                height: 200,
-                bgcolor: "grey.100",
-                borderRadius: 0.5,
-              }}
-            >
-              <Typography color="text.secondary">
-                Archivo de imagen no disponible
-              </Typography>
-            </Box>
-          );
-        }
-
-        return (
-          <Box
-            sx={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              width: "100%",
-              maxHeight: maxImageHeight,
-              overflow: "hidden",
-              borderRadius: 1,
-              border: "1px solid",
-              borderColor: "divider",
-              cursor: isClickable ? "pointer" : "default",
-              "&:hover": isClickable
-                ? {
-                    boxShadow: 2,
-                    borderColor: "primary.main",
-                  }
-                : {},
-            }}
-            onClick={isClickable ? handleContentClick : undefined}
-            title={isClickable ? "Haz clic para abrir la imagen en una nueva pestaña" : undefined}
-          >
-            <img
-              src={thumbUrl}
-              alt={title || contentData.original_title || "Content image"}
-              loading={variant === "detailed" ? "eager" : "lazy"}
-              fetchPriority={variant === "detailed" ? "high" : undefined}
-              style={{
-                maxWidth: "100%",
                 maxHeight: maxImageHeight,
-                objectFit: "contain",
+                overflow: "hidden",
+                borderRadius: 1,
+                border: "1px solid",
+                borderColor: "divider",
+                cursor: isClickable ? "pointer" : "default",
+                "&:hover": isClickable ?
+                {
+                  boxShadow: 2,
+                  borderColor: "primary.main"
+                } :
+                {}
               }}
-              onError={(e) => {
-                console.error(
-                  "Image failed to load in detailed mode:",
-                  thumbUrl
-                );
-                e.target.style.display = "none";
-                e.target.nextSibling.style.display = "flex";
-              }}
-            />
+              onClick={isClickable ? handleContentClick : undefined}
+              title={isClickable ? "Haz clic para abrir la imagen en una nueva pestaña" : undefined}>
+              
+            <img
+                src={thumbUrl}
+                alt={title || contentData.original_title || "Content image"}
+                loading={variant === "detailed" ? "eager" : "lazy"}
+                fetchPriority={variant === "detailed" ? "high" : undefined}
+                style={{
+                  maxWidth: "100%",
+                  maxHeight: maxImageHeight,
+                  objectFit: "contain"
+                }}
+                onError={(e) => {
+                  console.error(
+                    "Image failed to load in detailed mode:",
+                    thumbUrl
+                  );
+                  e.target.style.display = "none";
+                  e.target.nextSibling.style.display = "flex";
+                }} />
+              
             <Box
-              sx={{
-                display: "none",
-                justifyContent: "center",
-                alignItems: "center",
-                width: "100%",
-                height: 200,
-                bgcolor: "grey.100",
-                color: "text.secondary",
-              }}
-            >
+                sx={{
+                  display: "none",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  width: "100%",
+                  height: 200,
+                  bgcolor: "grey.100",
+                  color: "text.secondary"
+                }}>
+                
               <Typography color="text.primary">Error al cargar la imagen</Typography>
             </Box>
-          </Box>
-        );
-      }
+          </Box>);
+
+        }
       case "VIDEO":
         if (!fileUrl || !fileDetails?.file) {
           const previewSources = buildMediaPreviewThumbnailSources({
             customThumbnailForDisplay,
             ogImage: fileDetails?.og_image,
-            mediaType: mediaTypeUpper,
+            mediaType: mediaTypeUpper
           });
           if (previewSources.length > 0) {
             return (
@@ -409,21 +392,21 @@ const ContentDisplay = ({
                   borderRadius: 0.5,
                   overflow: "hidden",
                   border: "1px solid",
-                  borderColor: "divider",
-                }}
-              >
+                  borderColor: "divider"
+                }}>
+                
                 <SequentialThumbnail
                   sources={previewSources}
                   loading={variant === "detailed" ? "eager" : "lazy"}
                   fetchPriority={variant === "detailed" ? "high" : undefined}
                   fallback={
-                    <Typography color="text.secondary">
+                  <Typography color="text.secondary">
                       Archivo de video no disponible
                     </Typography>
-                  }
-                />
-              </Box>
-            );
+                  } />
+                
+              </Box>);
+
           }
           return (
             <Box
@@ -434,14 +417,14 @@ const ContentDisplay = ({
                 width: "100%",
                 height: 200,
                 bgcolor: "grey.100",
-                borderRadius: 0.5,
-              }}
-            >
+                borderRadius: 0.5
+              }}>
+              
               <Typography color="text.secondary">
                 Archivo de video no disponible
               </Typography>
-            </Box>
-          );
+            </Box>);
+
         }
 
         return (
@@ -449,20 +432,20 @@ const ContentDisplay = ({
             sx={{
               width: "100%",
               maxWidth: "800px",
-              mx: "auto",
-            }}
-          >
+              mx: "auto"
+            }}>
+            
             <video controls style={{ width: "100%" }} src={fileUrl}>
               Tu navegador no admite la etiqueta de video.
             </video>
-          </Box>
-        );
+          </Box>);
+
       case "AUDIO":
         if (!fileUrl || !fileDetails?.file) {
           const previewSources = buildMediaPreviewThumbnailSources({
             customThumbnailForDisplay,
             ogImage: fileDetails?.og_image,
-            mediaType: mediaTypeUpper,
+            mediaType: mediaTypeUpper
           });
           if (previewSources.length > 0) {
             return (
@@ -477,21 +460,21 @@ const ContentDisplay = ({
                   borderRadius: 0.5,
                   overflow: "hidden",
                   border: "1px solid",
-                  borderColor: "divider",
-                }}
-              >
+                  borderColor: "divider"
+                }}>
+                
                 <SequentialThumbnail
                   sources={previewSources}
                   loading={variant === "detailed" ? "eager" : "lazy"}
                   fetchPriority={variant === "detailed" ? "high" : undefined}
                   fallback={
-                    <Typography color="text.secondary">
+                  <Typography color="text.secondary">
                       Archivo de audio no disponible
                     </Typography>
-                  }
-                />
-              </Box>
-            );
+                  } />
+                
+              </Box>);
+
           }
           return (
             <Box
@@ -502,14 +485,14 @@ const ContentDisplay = ({
                 width: "100%",
                 height: 100,
                 bgcolor: "grey.100",
-                borderRadius: 0.5,
-              }}
-            >
+                borderRadius: 0.5
+              }}>
+              
               <Typography color="text.secondary">
                 Archivo de audio no disponible
               </Typography>
-            </Box>
-          );
+            </Box>);
+
         }
 
         return (
@@ -517,14 +500,14 @@ const ContentDisplay = ({
             sx={{
               width: "100%",
               maxWidth: "600px",
-              mx: "auto",
-            }}
-          >
+              mx: "auto"
+            }}>
+            
             <audio controls style={{ width: "100%" }} src={fileUrl}>
               Tu navegador no admite la etiqueta de audio.
             </audio>
-          </Box>
-        );
+          </Box>);
+
       case "TEXT":
         if (contentExternalUrl && String(contentExternalUrl).trim()) {
           const resolvedExternal = resolveMediaUrl(contentExternalUrl);
@@ -543,12 +526,12 @@ const ContentDisplay = ({
                 "&:hover": {
                   boxShadow: 2,
                   borderColor: "primary.main",
-                  bgcolor: "grey.100",
-                },
+                  bgcolor: "grey.100"
+                }
               }}
               onClick={() => window.open(resolvedExternal, "_blank")}
-              title="Haz clic para abrir la URL en una nueva pestaña"
-            >
+              title="Haz clic para abrir la URL en una nueva pestaña">
+              
               <Typography variant="body1" color="text.primary">
                 Contenido URL:{" "}
                 <a
@@ -557,15 +540,15 @@ const ContentDisplay = ({
                   rel="noopener noreferrer"
                   style={{
                     color: "primary.main",
-                    textDecoration: "none",
+                    textDecoration: "none"
                   }}
-                  onClick={(e) => e.stopPropagation()}
-                >
+                  onClick={(e) => e.stopPropagation()}>
+                  
                   {contentExternalUrl}
                 </a>
               </Typography>
-            </Box>
-          );
+            </Box>);
+
         } else {
           return (
             <Box
@@ -576,14 +559,14 @@ const ContentDisplay = ({
                 width: "100%",
                 height: 100,
                 bgcolor: "grey.100",
-                borderRadius: 0.5,
-              }}
-            >
+                borderRadius: 0.5
+              }}>
+              
               <Typography color="text.secondary">
                 No hay contenido de texto disponible
               </Typography>
-            </Box>
-          );
+            </Box>);
+
         }
       default:
         return (
@@ -595,14 +578,14 @@ const ContentDisplay = ({
               width: "100%",
               height: 100,
               bgcolor: "grey.100",
-              borderRadius: 1,
-            }}
-          >
+              borderRadius: 1
+            }}>
+            
             <Typography color="text.secondary">
               Tipo de medio no soportado: {mediaTypeUpper}
             </Typography>
-          </Box>
-        );
+          </Box>);
+
     }
   };
 
@@ -618,77 +601,77 @@ const ContentDisplay = ({
               display: "grid",
               gridTemplateColumns: {
                 xs: "1fr", // Single column on mobile
-                md: "1fr 1fr", // Two columns on medium+ screens
+                md: "1fr 1fr" // Two columns on medium+ screens
               },
               gap: 3,
-              mt: 2,
-            }}
-          >
+              mt: 2
+            }}>
+            
             {/* File Information */}
             <Box>
               <Typography
                 variant="subtitle2"
                 color="text.secondary"
-                gutterBottom
-              >
+                gutterBottom>
+                
                 Información del archivo
               </Typography>
               <Stack spacing={1.5}>
                 {renderMediaTypeRow()}
 
-                {!hasFileAvailable && (
-                  <Typography variant="body2" color="text.secondary">
-                    {contentExternalUrl && String(contentExternalUrl).trim()
-                      ? "No hay archivo descargable relacionado; solo enlace externo."
-                      : "No hay archivo relacionado."}
+                {!hasFileAvailable &&
+                <Typography variant="body2" color="text.secondary">
+                    {contentExternalUrl && String(contentExternalUrl).trim() ?
+                  "No hay archivo descargable relacionado; solo enlace externo." :
+                  "No hay archivo relacionado."}
                   </Typography>
-                )}
+                }
 
-                {fileDetails?.file && (
-                  <Box
-                    sx={{
-                      display: "flex",
-                      flexWrap: "wrap",
-                      alignItems: "center",
-                      gap: 1,
-                    }}
-                  >
+                {fileDetails?.file &&
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    alignItems: "center",
+                    gap: 1
+                  }}>
+                  
                     <StorageIcon fontSize="small" color="action" />
                     <Typography variant="body2" color="text.primary">
                       Archivo:
                     </Typography>
                     <Button
-                      size="small"
-                      variant="outlined"
-                      onClick={() =>
-                        window.open(resolveMediaUrl(fileDetails.url ?? fileDetails.file), "_blank")
-                      }
-                    >
+                    size="small"
+                    variant="outlined"
+                    onClick={() =>
+                    window.open(resolveMediaUrl(fileDetails.url ?? fileDetails.file), "_blank")
+                    }>
+                    
                       Descargar archivo
                     </Button>
                   </Box>
-                )}
+                }
 
-                {hasFileAvailable && fileDetails?.file_size != null && Number.isFinite(Number(fileDetails.file_size)) && (
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                {hasFileAvailable && fileDetails?.file_size != null && Number.isFinite(Number(fileDetails.file_size)) &&
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                     <StorageIcon fontSize="small" color="action" />
                     <Typography variant="body2" color="text.primary">
                       Tamaño del archivo:{" "}
-                      {Number(fileDetails.file_size) === 0
-                        ? "0 bytes"
-                        : formatFileSize(Number(fileDetails.file_size))}
+                      {Number(fileDetails.file_size) === 0 ?
+                    "0 bytes" :
+                    formatFileSize(Number(fileDetails.file_size))}
                     </Typography>
                   </Box>
-                )}
+                }
 
-                {profile?.created_at && (
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                {profile?.created_at &&
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                     <CalendarTodayIcon fontSize="small" color="action" />
                     <Typography variant="body2" color="text.primary">
                       Perfil creado el: {formatDateTime(profile.created_at)}
                     </Typography>
                   </Box>
-                )}
+                }
 
                 {(() => {
                   const copyTarget = getCopyUrlTarget();
@@ -700,73 +683,73 @@ const ContentDisplay = ({
                         display: "flex",
                         alignItems: "center",
                         gap: 1,
-                        flexWrap: "wrap",
-                      }}
-                    >
+                        flexWrap: "wrap"
+                      }}>
+                      
                       <LinkIcon fontSize="small" color="action" />
                       <Button
                         size="small"
                         variant="text"
                         onClick={() => handleCopyUrl(copyTarget)}
-                        sx={{ textTransform: "none" }}
-                      >
+                        sx={{ textTransform: "none" }}>
+                        
                         {`Copiar URL - ${site}`}
                       </Button>
-                    </Box>
-                  );
+                    </Box>);
+
                 })()}
               </Stack>
             </Box>
 
             {/* Shared By */}
-            {profile?.user_username && (
-              <Box>
+            {profile?.user_username &&
+            <Box>
                 <Typography
-                  variant="subtitle2"
-                  color="text.secondary"
-                  gutterBottom
-                >
+                variant="subtitle2"
+                color="text.secondary"
+                gutterBottom>
+                
                   Compartido por
                 </Typography>
                 <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                   <PersonIcon fontSize="small" color="action" />
-                  {profile?.user ? (
-                    <Link
-                      to={`/profiles/user_profile/${profile.user}`}
-                      style={{
-                        textDecoration: "none",
-                        color: "inherit",
-                      }}
-                    >
+                  {profile?.user ?
+                <Link
+                  to={`/profiles/user_profile/${profile.user}`}
+                  style={{
+                    textDecoration: "none",
+                    color: "inherit"
+                  }}>
+                  
                       <Typography
-                        variant="body2"
-                        color="primary"
-                        sx={{
-                          "&:hover": {
-                            textDecoration: "underline",
-                          },
-                        }}
-                      >
+                    variant="body2"
+                    color="primary"
+                    sx={{
+                      "&:hover": {
+                        textDecoration: "underline"
+                      }
+                    }}>
+                    
                         {profile.user_username}
                       </Typography>
-                    </Link>
-                  ) : (
-                    <Typography variant="body2" color="text.primary">
+                    </Link> :
+
+                <Typography variant="body2" color="text.primary">
                       {profile.user_username}
                     </Typography>
-                  )}
+                }
                 </Box>
               </Box>
-            )}
+            }
 
             {/* Vote Information */}
-            {contentData.vote_count !== undefined && (
-              <Box>
+            {contentData.vote_count !== undefined &&
+            <Box>
                 <Typography
-                  variant="subtitle2"
-                  color="text.secondary"
-                  gutterBottom
-                >
+                variant="subtitle2"
+                color="text.secondary"
+                gutterBottom>
+                
                   Participación
                 </Typography>
                 <Stack spacing={1}>
@@ -778,34 +761,34 @@ const ContentDisplay = ({
                   </Box>
                 </Stack>
               </Box>
-            )}
+            }
 
-            {(contentData.has_spanish_subtitles || contentData.has_spanish_dubbing) && (
-              <Box>
+            {(contentData.has_spanish_subtitles || contentData.has_spanish_dubbing) &&
+            <Box>
                 <Typography
-                  variant="subtitle2"
-                  color="text.secondary"
-                  gutterBottom
-                >
+                variant="subtitle2"
+                color="text.secondary"
+                gutterBottom>
+                
                   Accesibilidad en español
                 </Typography>
                 <Stack spacing={1}>
-                  {contentData.has_spanish_subtitles && (
-                    <Typography variant="body2" color="text.primary">
+                  {contentData.has_spanish_subtitles &&
+                <Typography variant="body2" color="text.primary">
                       Subtitulado en español
                     </Typography>
-                  )}
-                  {contentData.has_spanish_dubbing && (
-                    <Typography variant="body2" color="text.primary">
+                }
+                  {contentData.has_spanish_dubbing &&
+                <Typography variant="body2" color="text.primary">
                       Doblado al español
                     </Typography>
-                  )}
+                }
                 </Stack>
               </Box>
-            )}
+            }
           </Box>
-        </Box>
-      );
+        </Box>);
+
     }
     return null;
   };
@@ -816,8 +799,8 @@ const ContentDisplay = ({
         return (
           <Typography color="error" align="center" sx={{ p: 2 }}>
             {renderError}
-          </Typography>
-        );
+          </Typography>);
+
       }
 
       switch (variant) {
@@ -829,38 +812,38 @@ const ContentDisplay = ({
                 "&:hover": { bgcolor: "action.hover" },
                 cursor: onClick ? "pointer" : "default",
                 borderRadius: 0.5,
-                position: "relative",
+                position: "relative"
               }}
-              onClick={onClick}
-            >
+              onClick={onClick}>
+              
               {/* Remove button in top-left corner */}
-              {onRemove && (
-                <IconButton
-                  size="small"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRemove();
-                  }}
-                  sx={{
-                    position: "absolute",
-                    top: 4,
-                    left: 4,
-                    zIndex: 10,
-                    bgcolor: "background.paper",
-                    color: "text.primary",
-                    boxShadow: 1,
-                    "&:hover": {
-                      bgcolor: "error.main",
-                      color: "error.contrastText",
-                    },
-                    width: 24,
-                    height: 24,
-                  }}
-                  aria-label="Quitar contenido"
-                >
+              {onRemove &&
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove();
+                }}
+                sx={{
+                  position: "absolute",
+                  top: 4,
+                  left: 4,
+                  zIndex: 10,
+                  bgcolor: "background.paper",
+                  color: "text.primary",
+                  boxShadow: 1,
+                  "&:hover": {
+                    bgcolor: "error.main",
+                    color: "error.contrastText"
+                  },
+                  width: 24,
+                  height: 24
+                }}
+                aria-label="Quitar contenido">
+                
                   <CloseIcon fontSize="small" />
                 </IconButton>
-              )}
+              }
               <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
                 <Box
                   sx={{
@@ -870,9 +853,9 @@ const ContentDisplay = ({
                     width: 40,
                     height: 40,
                     borderRadius: "50%",
-                    bgcolor: "background.default",
-                  }}
-                >
+                    bgcolor: "background.default"
+                  }}>
+                  
                   {getMediaTypeIcon(content)}
                 </Box>
                 <Box sx={{ overflow: "hidden", flex: 1 }}>
@@ -881,37 +864,37 @@ const ContentDisplay = ({
                     noWrap
                     sx={{
                       color: "text.primary",
-                      fontWeight: "medium",
-                    }}
-                  >
+                      fontWeight: "medium"
+                    }}>
+                    
                     {title}
                   </Typography>
-                  {author && (
-                    <Typography
-                      variant="body2"
-                      color="text.secondary"
-                      noWrap
-                      sx={{ fontSize: "0.8rem", mb: 0.5 }}
-                    >
+                  {author &&
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    noWrap
+                    sx={{ fontSize: "0.8rem", mb: 0.5 }}>
+                    
                       Por {author}
                     </Typography>
-                  )}
+                  }
                   <Typography
                     variant="caption"
                     color="text.secondary"
-                    sx={{ fontSize: "0.75rem" }}
-                  >
+                    sx={{ fontSize: "0.75rem" }}>
+                    
                     {contentData.media_type}
                   </Typography>
                 </Box>
-                {showActions && additionalActions && (
-                  <Box onClick={(e) => e.stopPropagation()}>
+                {showActions && additionalActions &&
+                <Box onClick={(e) => e.stopPropagation()}>
                     {additionalActions}
                   </Box>
-                )}
+                }
               </Box>
-            </Box>
-          );
+            </Box>);
+
 
         case "preview":
           // Fallback for malformed content data
@@ -924,14 +907,14 @@ const ContentDisplay = ({
                   borderColor: "error.main",
                   borderRadius: 0.5,
                   backgroundColor: "error.light",
-                  color: "error.contrastText",
-                }}
-              >
+                  color: "error.contrastText"
+                }}>
+                
                 <Typography variant="body2" color="text.primary">
                   Datos de contenido inválidos proporcionados
                 </Typography>
-              </Box>
-            );
+              </Box>);
+
           }
 
           return (
@@ -959,35 +942,35 @@ const ContentDisplay = ({
                 }
               }}
               title={
-                contentExternalUrl && String(contentExternalUrl).trim()
-                  ? "Haz clic para abrir el enlace en una nueva pestaña"
-                  : fileDetails?.file
-                  ? "Haz clic para abrir el archivo en una nueva pestaña"
-                  : "Haz clic para ver el contenido"
+              contentExternalUrl && String(contentExternalUrl).trim() ?
+              "Haz clic para abrir el enlace en una nueva pestaña" :
+              fileDetails?.file ?
+              "Haz clic para abrir el archivo en una nueva pestaña" :
+              "Haz clic para ver el contenido"
               }
               sx={{
                 cursor: "pointer",
                 display: "flex",
                 flexDirection: {
                   xs: "column", // Stack vertically on mobile
-                  sm: "row",    // Side by side on small screens and up
+                  sm: "row" // Side by side on small screens and up
                 },
                 alignItems: {
                   xs: "stretch", // Stretch to full width on mobile
-                  sm: "flex-start", // Align to start on larger screens
+                  sm: "flex-start" // Align to start on larger screens
                 },
                 gap: {
                   xs: 2, // Smaller gap on mobile
-                  sm: 2, // Standard gap on larger screens
+                  sm: 2 // Standard gap on larger screens
                 },
                 p: {
                   xs: 1.5, // Less padding on mobile
-                  sm: 2,   // Standard padding on larger screens
+                  sm: 2 // Standard padding on larger screens
                 },
                 "&:hover": {
                   backgroundColor: "action.hover",
                   borderRadius: 0.5,
-                  boxShadow: 2,
+                  boxShadow: 2
                 },
                 position: "relative",
                 border: "1px solid",
@@ -995,19 +978,19 @@ const ContentDisplay = ({
                 borderRadius: 0.5,
                 minHeight: 100,
                 transition: "all 0.2s ease-in-out",
-                backgroundColor: "background.paper",
-              }}
-            >
+                backgroundColor: "background.paper"
+              }}>
+              
               {/* Media Preview Section */}
               <Box
                 sx={{
                   width: {
-                    xs: "100%",     // Full width on mobile
-                    sm: 160,        // Fixed width on larger screens
+                    xs: "100%", // Full width on mobile
+                    sm: 160 // Fixed width on larger screens
                   },
                   height: {
-                    xs: 200,        // Taller on mobile for better proportions
-                    sm: 160,        // Standard height on larger screens
+                    xs: 200, // Taller on mobile for better proportions
+                    sm: 160 // Standard height on larger screens
                   },
                   display: "flex",
                   alignItems: "center",
@@ -1021,38 +1004,38 @@ const ContentDisplay = ({
                   boxShadow: 1,
                   "& img": {
                     transition: "transform 0.2s ease-in-out",
-                    cursor: "pointer",
+                    cursor: "pointer"
                   },
                   "&:hover img": {
-                    transform: "scale(1.05)",
-                  },
-                }}
-              >
+                    transform: "scale(1.05)"
+                  }
+                }}>
+                
                 <SequentialThumbnail
                   sources={buildListingThumbnailSources({
                     customThumbnailForDisplay,
                     hasImageFile:
-                      contentData.media_type?.toUpperCase() === "IMAGE" &&
-                      fileDetails?.file,
+                    contentData.media_type?.toUpperCase() === "IMAGE" &&
+                    fileDetails?.file,
                     fileDetails,
                     favicon,
                     mediaType: contentData.media_type,
                     title,
-                    resolveMediaUrl,
+                    resolveMediaUrl
                   })}
                   fallback={getMediaTypeIcon(contentData)}
-                  loading="lazy"
-                />
+                  loading="lazy" />
+                
               </Box>
 
               {/* Content Information Section */}
-              <Box sx={{ 
-                flex: 1, 
+              <Box sx={{
+                flex: 1,
                 minWidth: 0,
                 // Ensure content takes full width on mobile
                 width: {
                   xs: "100%",
-                  sm: "auto",
+                  sm: "auto"
                 }
               }}>
                 <Typography
@@ -1062,68 +1045,68 @@ const ContentDisplay = ({
                     color: "text.primary",
                     mb: 0.5,
                     fontSize: {
-                      xs: "1rem",    // Slightly smaller on mobile
-                      sm: "1.1rem",  // Standard size on larger screens
-                    },
-                  }}
-                >
+                      xs: "1rem", // Slightly smaller on mobile
+                      sm: "1.1rem" // Standard size on larger screens
+                    }
+                  }}>
+                  
                   {title || "Contenido sin título"}
                 </Typography>
 
-                {showAuthor && author && (
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ mb: 1 }}
-                  >
+                {showAuthor && author &&
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mb: 1 }}>
+                  
                     By {author}
                   </Typography>
-                )}
+                }
 
                 {/* Open Graph Description */}
-                {fileDetails?.og_description && (
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{
-                      mb: 1,
-                      display: "-webkit-box",
-                      WebkitLineClamp: {
-                        xs: 3,  // Show more lines on mobile
-                        sm: 2,  // Standard 2 lines on larger screens
-                      },
-                      WebkitBoxOrient: "vertical",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      lineHeight: 1.4,
-                    }}
-                  >
+                {fileDetails?.og_description &&
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{
+                    mb: 1,
+                    display: "-webkit-box",
+                    WebkitLineClamp: {
+                      xs: 3, // Show more lines on mobile
+                      sm: 2 // Standard 2 lines on larger screens
+                    },
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    lineHeight: 1.4
+                  }}>
+                  
                     {fileDetails.og_description}
                   </Typography>
-                )}
+                }
 
                 {/* Personal Note */}
-                {profile?.personal_note && (
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{
-                      mb: 1,
-                      fontStyle: "italic",
-                      display: "-webkit-box",
-                      WebkitLineClamp: {
-                        xs: 3,  // Show more lines on mobile
-                        sm: 2,  // Standard 2 lines on larger screens
-                      },
-                      WebkitBoxOrient: "vertical",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      lineHeight: 1.4,
-                    }}
-                  >
+                {profile?.personal_note &&
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{
+                    mb: 1,
+                    fontStyle: "italic",
+                    display: "-webkit-box",
+                    WebkitLineClamp: {
+                      xs: 3, // Show more lines on mobile
+                      sm: 2 // Standard 2 lines on larger screens
+                    },
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    lineHeight: 1.4
+                  }}>
+                  
                     "{profile.personal_note}"
                   </Typography>
-                )}
+                }
 
                 {/* Metadata Row */}
                 <Box
@@ -1137,102 +1120,102 @@ const ContentDisplay = ({
                     "& .MuiChip-root": {
                       fontSize: {
                         xs: "0.75rem",
-                        sm: "0.875rem",
-                      },
-                    },
-                  }}
-                >
+                        sm: "0.875rem"
+                      }
+                    }
+                  }}>
+                  
                   {/* Media Type Badge */}
                   <Chip
                     label={contentData.media_type || "UNKNOWN"}
                     size="small"
                     variant="outlined"
-                    color="primary"
-                  />
+                    color="primary" />
+                  
 
                   {/* Date - Priority: file upload date > content creation date */}
-                  {(fileDetails?.uploaded_at || contentData.created_at) && (
-                    <Chip
-                      icon={<CalendarTodayIcon />}
-                      label={formatDate(
-                        fileDetails?.uploaded_at || contentData.created_at
-                      )}
-                      size="small"
-                      variant="outlined"
-                    />
-                  )}
+                  {(fileDetails?.uploaded_at || contentData.created_at) &&
+                  <Chip
+                    icon={<CalendarTodayIcon />}
+                    label={formatDate(
+                      fileDetails?.uploaded_at || contentData.created_at
+                    )}
+                    size="small"
+                    variant="outlined" />
 
-                  {contentData.has_spanish_subtitles && (
-                    <Chip
-                      label="Subtitulado en español"
-                      size="small"
-                      variant="outlined"
-                      color="success"
-                    />
-                  )}
+                  }
 
-                  {contentData.has_spanish_dubbing && (
-                    <Chip
-                      label="Doblado al español"
-                      size="small"
-                      variant="outlined"
-                      color="success"
-                    />
-                  )}
+                  {contentData.has_spanish_subtitles &&
+                  <Chip
+                    label="Subtitulado en español"
+                    size="small"
+                    variant="outlined"
+                    color="success" />
+
+                  }
+
+                  {contentData.has_spanish_dubbing &&
+                  <Chip
+                    label="Doblado al español"
+                    size="small"
+                    variant="outlined"
+                    color="success" />
+
+                  }
 
                   {/* Site Name for URLs */}
-                  {fileDetails?.og_site_name && (
-                    <Chip
-                      label={fileDetails.og_site_name}
-                      size="small"
-                      variant="outlined"
-                      color="secondary"
-                    />
-                  )}
+                  {fileDetails?.og_site_name &&
+                  <Chip
+                    label={fileDetails.og_site_name}
+                    size="small"
+                    variant="outlined"
+                    color="secondary" />
+
+                  }
 
                   {/* URL Indicator (external link only, not storage file URL) */}
-                  {contentExternalUrl && (
-                    <Chip
-                      icon={<LinkIcon />}
-                      label="URL"
-                      size="small"
-                      variant="outlined"
-                      color="info"
-                    />
-                  )}
+                  {contentExternalUrl &&
+                  <Chip
+                    icon={<LinkIcon />}
+                    label="URL"
+                    size="small"
+                    variant="outlined"
+                    color="info" />
 
-                  {hasFileAvailable && (
-                    <Chip
-                      icon={<StorageIcon />}
-                      label="Archivo Disponible"
-                      size="small"
-                      variant="outlined"
-                      color="info"
-                    />
-                  )}
+                  }
+
+                  {hasFileAvailable &&
+                  <Chip
+                    icon={<StorageIcon />}
+                    label="Archivo Disponible"
+                    size="small"
+                    variant="outlined"
+                    color="info" />
+
+                  }
                 </Box>
               </Box>
 
               {/* Additional Actions */}
-              {additionalActions && (
-                <Box
-                  sx={{ 
-                    flexShrink: 0, 
-                    alignSelf: {
-                      xs: "stretch",    // Full width on mobile
-                      sm: "flex-start", // Auto width on larger screens
-                    },
-                    // Position actions below content on mobile
-                    order: {
-                      xs: 3,  // After content on mobile
-                      sm: 2,  // After image on larger screens
-                    },
-                  }}
-                  data-action-button
-                >
+              {additionalActions &&
+              <Box
+                sx={{
+                  flexShrink: 0,
+                  alignSelf: {
+                    xs: "stretch", // Full width on mobile
+                    sm: "flex-start" // Auto width on larger screens
+                  },
+                  // Position actions below content on mobile
+                  order: {
+                    xs: 3, // After content on mobile
+                    sm: 2 // After image on larger screens
+                  }
+                }}
+                data-action-button>
+                
                   {additionalActions}
                 </Box>
-              )}
+              }
 
               {/* Details Link */}
               <Box
@@ -1244,11 +1227,11 @@ const ContentDisplay = ({
                   // Hide on very small screens to avoid overlap
                   display: {
                     xs: "none",
-                    sm: "block",
-                  },
+                    sm: "block"
+                  }
                 }}
-                data-action-button
-              >
+                data-action-button>
+                
                 <Tooltip title="Ver detalles (abre en nueva pestaña)">
                   <IconButton
                     size="small"
@@ -1263,16 +1246,16 @@ const ContentDisplay = ({
                       color: "text.secondary",
                       "&:hover": {
                         bgcolor: "action.hover",
-                        color: "text.primary",
-                      },
-                    }}
-                  >
+                        color: "text.primary"
+                      }
+                    }}>
+                    
                     <SearchIcon fontSize="small" />
                   </IconButton>
                 </Tooltip>
               </Box>
-            </Box>
-          );
+            </Box>);
+
 
         case "card":
           // Function to handle card clicks when no onClick prop is provided
@@ -1304,240 +1287,240 @@ const ContentDisplay = ({
                 "&:hover": {
                   boxShadow: 3,
                   transform: "translateY(-2px)",
-                  transition: "all 0.2s ease-in-out",
-                },
+                  transition: "all 0.2s ease-in-out"
+                }
               }}
               onClick={handleCardClick}
               title={
-                contentExternalUrl && String(contentExternalUrl).trim()
-                  ? "Haz clic para abrir el enlace en una nueva pestaña"
-                  : fileDetails?.file
-                  ? "Haz clic para abrir el archivo en una nueva pestaña"
-                  : "Haz clic para ver el contenido"
-              }
-            >
+              contentExternalUrl && String(contentExternalUrl).trim() ?
+              "Haz clic para abrir el enlace en una nueva pestaña" :
+              fileDetails?.file ?
+              "Haz clic para abrir el archivo en una nueva pestaña" :
+              "Haz clic para ver el contenido"
+              }>
+              
               <CardMedia
                 component="div"
                 sx={{
                   height: {
-                    xs: 180,  // Taller on mobile for better proportions
-                    sm: 140,  // Standard height on larger screens
+                    xs: 180, // Taller on mobile for better proportions
+                    sm: 140 // Standard height on larger screens
                   },
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  bgcolor: "background.paper",
-                }}
-              >
+                  bgcolor: "background.paper"
+                }}>
+                
                 <SequentialThumbnail
                   sources={buildListingThumbnailSources({
                     customThumbnailForDisplay,
                     hasImageFile:
-                      contentData.media_type?.toUpperCase() === "IMAGE" &&
-                      fileDetails?.file,
+                    contentData.media_type?.toUpperCase() === "IMAGE" &&
+                    fileDetails?.file,
                     fileDetails,
                     favicon,
                     mediaType: contentData.media_type,
                     title,
-                    resolveMediaUrl,
+                    resolveMediaUrl
                   })}
                   fallback={getMediaTypeIcon(contentData)}
-                  loading="lazy"
-                />
+                  loading="lazy" />
+                
               </CardMedia>
-              <CardContent sx={{ 
+              <CardContent sx={{
                 flexGrow: 1,
                 p: {
-                  xs: 1.5,  // Less padding on mobile
-                  sm: 2,    // Standard padding on larger screens
-                },
+                  xs: 1.5, // Less padding on mobile
+                  sm: 2 // Standard padding on larger screens
+                }
               }}>
-                {showTitle && (
-                  <Typography 
-                    gutterBottom 
-                    variant="h6" 
-                    component="div"
-                    color="text.primary"
-                    sx={{
-                      fontSize: {
-                        xs: "1.1rem",  // Slightly smaller on mobile
-                        sm: "1.25rem",  // Standard size on larger screens
-                      },
-                    }}
-                  >
+                {showTitle &&
+                <Typography
+                  gutterBottom
+                  variant="h6"
+                  component="div"
+                  color="text.primary"
+                  sx={{
+                    fontSize: {
+                      xs: "1.1rem", // Slightly smaller on mobile
+                      sm: "1.25rem" // Standard size on larger screens
+                    }
+                  }}>
+                  
                     {title}
                   </Typography>
-                )}
-                {showAuthor && author && (
-                  <Typography variant="body2" color="text.secondary">
+                }
+                {showAuthor && author &&
+                <Typography variant="body2" color="text.secondary">
                     By {author}
                   </Typography>
-                )}
-                {profile?.user_username && (
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ mt: 1, fontStyle: "italic" }}
-                  >
+                }
+                {profile?.user_username &&
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mt: 1, fontStyle: "italic" }}>
+                  
                     {profile.user_username}
                   </Typography>
-                )}
-                {profile?.personal_note && (
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ mt: 1 }}
-                  >
+                }
+                {profile?.personal_note &&
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mt: 1 }}>
+                  
                     {profile.personal_note}
                   </Typography>
-                )}
+                }
 
                 {/* Card Metadata */}
-                <Box sx={{ 
-                  mt: 2, 
-                  display: "flex", 
-                  flexWrap: "wrap", 
+                <Box sx={{
+                  mt: 2,
+                  display: "flex",
+                  flexWrap: "wrap",
                   gap: 1,
                   "& .MuiChip-root": {
                     fontSize: {
                       xs: "0.75rem",
-                      sm: "0.875rem",
-                    },
-                  },
+                      sm: "0.875rem"
+                    }
+                  }
                 }}>
                   {/* Date - Priority: file upload date > content creation date */}
-                  {(fileDetails?.uploaded_at || contentData.created_at) && (
-                    <Chip
-                      icon={<CalendarTodayIcon />}
-                      label={formatDate(
-                        fileDetails?.uploaded_at || contentData.created_at
-                      )}
-                      size="small"
-                      variant="outlined"
-                    />
-                  )}
-                  {profile?.collection_name && (
-                    <Chip
-                      icon={<FolderIcon />}
-                      label={profile.collection_name}
-                      size="small"
-                      variant="outlined"
-                    />
-                  )}
+                  {(fileDetails?.uploaded_at || contentData.created_at) &&
+                  <Chip
+                    icon={<CalendarTodayIcon />}
+                    label={formatDate(
+                      fileDetails?.uploaded_at || contentData.created_at
+                    )}
+                    size="small"
+                    variant="outlined" />
+
+                  }
+                  {profile?.collection_name &&
+                  <Chip
+                    icon={<FolderIcon />}
+                    label={profile.collection_name}
+                    size="small"
+                    variant="outlined" />
+
+                  }
                 </Box>
-                {contentData.vote_count !== undefined && topicId && (
-                  <Box sx={{ display: "flex", alignItems: "center", mt: 2 }} onClick={(e) => e.stopPropagation()}>
+                {contentData.vote_count !== undefined && topicId &&
+                <Box sx={{ display: "flex", alignItems: "center", mt: 2 }} onClick={(e) => e.stopPropagation()}>
                     <VoteComponent
-                      type="content"
-                      ids={{ topicId, contentId: contentData.id }}
-                      initialVoteCount={contentData.vote_count ?? 0}
-                      initialUserVote={contentData.user_vote ?? 0}
-                    />
+                    type="content"
+                    ids={{ topicId, contentId: contentData.id }}
+                    initialVoteCount={contentData.vote_count ?? 0}
+                    initialUserVote={contentData.user_vote ?? 0} />
+                  
                   </Box>
-                )}
+                }
               </CardContent>
-              {showActions && (
-                <CardActions sx={{
-                  p: {
-                    xs: 1.5,  // Less padding on mobile
-                    sm: 2,    // Standard padding on larger screens
-                  },
-                }}>
-                  {onEdit && (
-                    <Button
-                      size="small"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onEdit(e);
-                      }}
-                    >
+              {showActions &&
+              <CardActions sx={{
+                p: {
+                  xs: 1.5, // Less padding on mobile
+                  sm: 2 // Standard padding on larger screens
+                }
+              }}>
+                  {onEdit &&
+                <Button
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEdit(e);
+                  }}>
+                  
                       Editar
                     </Button>
-                  )}
-                  {onRemove && (
-                    <Button
-                      size="small"
-                      color="error"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onRemove(e);
-                      }}
-                    >
+                }
+                  {onRemove &&
+                <Button
+                  size="small"
+                  color="error"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemove(e);
+                  }}>
+                  
                       Eliminar
                     </Button>
-                  )}
-                  {additionalActions && (
-                    <Box onClick={(e) => e.stopPropagation()}>
+                }
+                  {additionalActions &&
+                <Box onClick={(e) => e.stopPropagation()}>
                       {additionalActions}
                     </Box>
-                  )}
+                }
                 </CardActions>
-              )}
-            </Card>
-          );
+              }
+            </Card>);
+
 
         case "detailed":
           return (
             <Paper
               variant="outlined"
-              sx={{ p: 2, bgcolor: "background.default", position: "relative" }}
-            >
+              sx={{ p: 2, bgcolor: "background.default", position: "relative" }}>
+              
               <Box>
                 <Typography variant="h6" gutterBottom color="text.primary">
                   {title}
                 </Typography>
-                {showAuthor && author && (
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    gutterBottom
-                  >
+                {showAuthor && author &&
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  gutterBottom>
+                  
                     By {author}
                   </Typography>
-                )}
+                }
 
                 {/* Original Content Information */}
                 {(contentData.original_title !== title ||
-                  contentData.original_author !== author) && (
-                  <Box
-                    sx={{
-                      mt: 2,
-                      p: 2,
-                      bgcolor: "grey.50",
-                      borderRadius: 0.5,
-                      border: "1px solid",
-                      borderColor: "divider",
-                    }}
-                  >
-                    {contentData.original_author && (
-                      <Typography variant="body2" color="text.primary">
+                contentData.original_author !== author) &&
+                <Box
+                  sx={{
+                    mt: 2,
+                    p: 2,
+                    bgcolor: "grey.50",
+                    borderRadius: 0.5,
+                    border: "1px solid",
+                    borderColor: "divider"
+                  }}>
+                  
+                    {contentData.original_author &&
+                  <Typography variant="body2" color="text.primary">
                         <strong>autor original:</strong>{" "}
                         {contentData.original_author}
                       </Typography>
-                    )}
+                  }
                   </Box>
-                )}
+                }
               </Box>
 
               {renderContentByType()}
 
-              {!hasFileAvailable && showSuggestFileButton && onSuggestFile && (
-                <Box sx={{ mt: 2 }}>
+              {!hasFileAvailable && showSuggestFileButton && onSuggestFile &&
+              <Box sx={{ mt: 2 }}>
                   <Button
-                    variant="outlined"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onSuggestFile();
-                    }}
-                  >
+                  variant="outlined"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSuggestFile();
+                  }}>
+                  
                     Sugerir archivo
                   </Button>
                 </Box>
-              )}
+              }
 
               {/* Personal Note */}
-              {profile?.personal_note && (
-                <Box sx={{ mt: 3 }}>
+              {profile?.personal_note &&
+              <Box sx={{ mt: 3 }}>
                   <Typography variant="h6" gutterBottom color="text.secondary">
                     Notas personales
                   </Typography>
@@ -1547,60 +1530,60 @@ const ContentDisplay = ({
                     </Typography>
                   </Box>
                 </Box>
-              )}
+              }
 
               {/* Metadata Section */}
               {renderMetadataSection()}
 
-              {showActions && (
-                <Box sx={{ mt: 2, display: "flex", gap: 1, flexWrap: "wrap" }}>
-                  {onEdit && (
-                    <Button
-                      size="small"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onEdit(e);
-                      }}
-                    >
+              {showActions &&
+              <Box sx={{ mt: 2, display: "flex", gap: 1, flexWrap: "wrap" }}>
+                  {onEdit &&
+                <Button
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEdit(e);
+                  }}>
+                  
                       Cambiar contenido
                     </Button>
-                  )}
-                  {onRemove && (
-                    <Button
-                      size="small"
-                      color="error"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onRemove(e);
-                      }}
-                    >
+                }
+                  {onRemove &&
+                <Button
+                  size="small"
+                  color="error"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemove(e);
+                  }}>
+                  
                       Eliminar
                     </Button>
-                  )}
-                  {additionalActions && (
-                    <Box onClick={(e) => e.stopPropagation()}>
+                }
+                  {additionalActions &&
+                <Box onClick={(e) => e.stopPropagation()}>
                       {additionalActions}
                     </Box>
-                  )}
+                }
                 </Box>
-              )}
-            </Paper>
-          );
+              }
+            </Paper>);
+
 
         default:
           return (
             <Typography color="error" align="center" sx={{ p: 2 }}>
               Variante desconocida: {variant}
-            </Typography>
-          );
+            </Typography>);
+
       }
     } catch (error) {
       console.error("Error in renderContent:", error);
       return (
         <Typography color="error" align="center" sx={{ p: 2 }}>
           Error al renderizar el contenido: {error.message}
-        </Typography>
-      );
+        </Typography>);
+
     }
   };
 
@@ -1612,26 +1595,26 @@ const ContentDisplay = ({
           open={snackbar.open}
           autoHideDuration={2500}
           onClose={handleCloseSnackbar}
-          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-        >
+          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}>
+          
           <Alert
             onClose={handleCloseSnackbar}
             severity={snackbar.severity}
             variant="filled"
-            sx={{ width: "100%" }}
-          >
+            sx={{ width: "100%" }}>
+            
             {snackbar.message}
           </Alert>
         </Snackbar>
-      </>
-    );
+      </>);
+
   } catch (error) {
     console.error("Fatal error in ContentDisplay:", error);
     return (
       <Typography color="error" align="center" sx={{ p: 2 }}>
         Error al mostrar el contenido: {error.message}
-      </Typography>
-    );
+      </Typography>);
+
   }
 };
 

--- a/frontend/src/content/ContentProfileEdit.jsx
+++ b/frontend/src/content/ContentProfileEdit.jsx
@@ -1,24 +1,24 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
-    Box,
-    Card,
-    TextField,
-    Button,
-    Typography,
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
-    Chip,
-    Divider,
-    FormControlLabel,
-    Switch,
-    Checkbox,
-    Grid,
-    Alert,
-    CircularProgress,
-} from '@mui/material';
+  Box,
+  Card,
+  TextField,
+  Button,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Chip,
+  Divider,
+  FormControlLabel,
+  Switch,
+  Checkbox,
+  Grid,
+  Alert,
+  CircularProgress } from
+'@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
 import { formatDate } from '../utils/dateUtils';
 import { resolveMediaUrl } from '../utils/fileUtils';
@@ -28,237 +28,230 @@ import ContentDisplay from './ContentDisplay';
 import OwnerContentFileUploadDialog from './OwnerContentFileUploadDialog';
 
 const ContentProfileEdit = () => {
-    const { contentId } = useParams();
-    const navigate = useNavigate();
-    const [content, setContent] = useState(null);
-    const [formData, setFormData] = useState({
-        title: '',
-        author: '',
-        personal_note: '',
-        is_visible: true,
-        is_producer: false,
-    });
-    const [thumbnailFile, setThumbnailFile] = useState(null);
-    const [thumbnailPreviewUrl, setThumbnailPreviewUrl] = useState(null);
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-    const [error, setError] = useState('');
-    const [attachFileDialogOpen, setAttachFileDialogOpen] = useState(false);
-    const [attachFileSuccess, setAttachFileSuccess] = useState('');
-    const [editUrlDialogOpen, setEditUrlDialogOpen] = useState(false);
-    const [clearUrlDialogOpen, setClearUrlDialogOpen] = useState(false);
-    const [urlDraft, setUrlDraft] = useState('');
-    const [urlDialogCheckLoading, setUrlDialogCheckLoading] = useState(false);
-    const [urlDialogSaveLoading, setUrlDialogSaveLoading] = useState(false);
-    const [urlDialogError, setUrlDialogError] = useState('');
-    const [urlSaveBlocked, setUrlSaveBlocked] = useState(false);
-    const { authState } = useContext(AuthContext);
+  const { contentId } = useParams();
+  const navigate = useNavigate();
+  const [content, setContent] = useState(null);
+  const [formData, setFormData] = useState({
+    title: '',
+    author: '',
+    personal_note: '',
+    is_visible: true,
+    is_producer: false
+  });
+  const [thumbnailFile, setThumbnailFile] = useState(null);
+  const [thumbnailPreviewUrl, setThumbnailPreviewUrl] = useState(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [error, setError] = useState('');
+  const [attachFileDialogOpen, setAttachFileDialogOpen] = useState(false);
+  const [attachFileSuccess, setAttachFileSuccess] = useState('');
+  const [editUrlDialogOpen, setEditUrlDialogOpen] = useState(false);
+  const [clearUrlDialogOpen, setClearUrlDialogOpen] = useState(false);
+  const [urlDraft, setUrlDraft] = useState('');
+  const [urlDialogCheckLoading, setUrlDialogCheckLoading] = useState(false);
+  const [urlDialogSaveLoading, setUrlDialogSaveLoading] = useState(false);
+  const [urlDialogError, setUrlDialogError] = useState('');
+  const [urlSaveBlocked, setUrlSaveBlocked] = useState(false);
+  const { authState } = useContext(AuthContext);
 
-    useEffect(() => {
-        const fetchContent = async () => {
-            try {
-                const data = await contentApi.getContentDetails(contentId, 'library', authState?.user?.id);
-                console.log('Content details:', data);
-                console.log('Media type:', data.media_type);
-                console.log('Content structure:', {
-                    id: data.id,
-                    media_type: data.media_type,
-                    original_title: data.original_title,
-                    selected_profile: data.selected_profile,
-                    content: data.content
-                });
-                setContent(data);
-                const profile = data.selected_profile;
-                setFormData({
-                    title: profile?.title || data.original_title || '',
-                    author: profile?.author || data.original_author || '',
-                    personal_note: profile?.personal_note || '',
-                    is_visible: profile?.is_visible ?? true,
-                    is_producer: profile?.is_producer ?? false,
-                });
-
-                // Thumbnail preview: first use the user's existing thumbnail, then fallback to og_image.
-                setThumbnailFile(null);
-                setThumbnailPreviewUrl(
-                    profile?.thumbnail || data.file_details?.og_image || null
-                );
-            } catch (err) {
-                setError('Error al cargar el contenido');
-                console.error(err);
-            }
-        };
-        fetchContent();
-    }, [contentId, authState?.user?.id]);
-
-    const reloadContent = async () => {
+  useEffect(() => {
+    const fetchContent = async () => {
+      try {
         const data = await contentApi.getContentDetails(contentId, 'library', authState?.user?.id);
+
+
         setContent(data);
         const profile = data.selected_profile;
-        setThumbnailPreviewUrl(
-            profile?.thumbnail || data.file_details?.og_image || null
-        );
-        return data;
-    };
-
-    const runSourceModificationCheck = async () => {
-        setUrlDialogError('');
-        setUrlSaveBlocked(false);
-        setUrlDialogCheckLoading(true);
-        try {
-            const check = await contentApi.checkContentModification(contentId);
-            if (!check?.can_modify) {
-                setUrlSaveBlocked(true);
-                setUrlDialogError(
-                    check?.message ||
-                        'No se puede modificar la fuente porque otros usuarios tienen este contenido en su biblioteca.'
-                );
-                return false;
-            }
-            return true;
-        } catch (err) {
-            setUrlSaveBlocked(true);
-            setUrlDialogError(
-                err.response?.data?.error ||
-                    err.message ||
-                    'No se pudo comprobar si se permite modificar la fuente.'
-            );
-            return false;
-        } finally {
-            setUrlDialogCheckLoading(false);
-        }
-    };
-
-    const openEditUrlDialog = async () => {
-        if (!content?.url) return;
-        setUrlDraft(content.url);
-        setEditUrlDialogOpen(true);
-        await runSourceModificationCheck();
-    };
-
-    const openClearUrlDialog = async () => {
-        if (!content?.url) return;
-        setClearUrlDialogOpen(true);
-        await runSourceModificationCheck();
-    };
-
-    const handleClearContentUrl = async () => {
-        setUrlDialogSaveLoading(true);
-        setUrlDialogError('');
-        try {
-            await contentApi.updateContent(contentId, { url: null });
-            await reloadContent();
-            setClearUrlDialogOpen(false);
-            setAttachFileSuccess('URL del contenido eliminada. El archivo adjunto se mantiene.');
-        } catch (err) {
-            const msg =
-                err.response?.data?.error ||
-                (typeof err.response?.data === 'string' ? err.response.data : null) ||
-                err.message ||
-                'No se pudo eliminar la URL.';
-            setUrlDialogError(typeof msg === 'string' ? msg : 'No se pudo eliminar la URL.');
-        } finally {
-            setUrlDialogSaveLoading(false);
-        }
-    };
-
-    const handleSaveContentUrl = async () => {
-        const trimmed = (urlDraft || '').trim();
-        if (!trimmed) {
-            setUrlDialogError('La URL no puede estar vacía.');
-            return;
-        }
-        setUrlDialogSaveLoading(true);
-        setUrlDialogError('');
-        try {
-            await contentApi.updateContent(contentId, { url: trimmed });
-            await reloadContent();
-            setEditUrlDialogOpen(false);
-            setAttachFileSuccess('URL del contenido actualizada correctamente.');
-        } catch (err) {
-            const msg =
-                err.response?.data?.error ||
-                (typeof err.response?.data === 'string' ? err.response.data : null) ||
-                err.message ||
-                'No se pudo guardar la URL.';
-            setUrlDialogError(typeof msg === 'string' ? msg : 'No se pudo guardar la URL.');
-        } finally {
-            setUrlDialogSaveLoading(false);
-        }
-    };
-
-    const handleChange = (e) => {
         setFormData({
-            ...formData,
-            [e.target.name]: e.target.value,
+          title: profile?.title || data.original_title || '',
+          author: profile?.author || data.original_author || '',
+          personal_note: profile?.personal_note || '',
+          is_visible: profile?.is_visible ?? true,
+          is_producer: profile?.is_producer ?? false
         });
+
+        // Thumbnail preview: first use the user's existing thumbnail, then fallback to og_image.
+        setThumbnailFile(null);
+        setThumbnailPreviewUrl(
+          profile?.thumbnail || data.file_details?.og_image || null
+        );
+      } catch (err) {
+        setError('Error al cargar el contenido');
+        console.error(err);
+      }
     };
+    fetchContent();
+  }, [contentId, authState?.user?.id]);
 
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        try {
-            if (!content.selected_profile?.id) {
-                setError('No se encontró el perfil de contenido');
-                return;
-            }
+  const reloadContent = async () => {
+    const data = await contentApi.getContentDetails(contentId, 'library', authState?.user?.id);
+    setContent(data);
+    const profile = data.selected_profile;
+    setThumbnailPreviewUrl(
+      profile?.thumbnail || data.file_details?.og_image || null
+    );
+    return data;
+  };
 
-            // If the user selected a new thumbnail, send multipart/form-data.
-            if (thumbnailFile) {
-                const fd = new FormData();
-                fd.append('title', formData.title ?? '');
-                fd.append('author', formData.author ?? '');
-                fd.append('personal_note', formData.personal_note ?? '');
-                fd.append('is_visible', String(!!formData.is_visible));
-                fd.append('is_producer', String(!!formData.is_producer));
-                fd.append('thumbnail', thumbnailFile);
-                await contentApi.updateContentProfile(content.selected_profile.id, fd);
-            } else {
-                await contentApi.updateContentProfile(content.selected_profile.id, formData);
-            }
+  const runSourceModificationCheck = async () => {
+    setUrlDialogError('');
+    setUrlSaveBlocked(false);
+    setUrlDialogCheckLoading(true);
+    try {
+      const check = await contentApi.checkContentModification(contentId);
+      if (!check?.can_modify) {
+        setUrlSaveBlocked(true);
+        setUrlDialogError(
+          check?.message ||
+          'No se puede modificar la fuente porque otros usuarios tienen este contenido en su biblioteca.'
+        );
+        return false;
+      }
+      return true;
+    } catch (err) {
+      setUrlSaveBlocked(true);
+      setUrlDialogError(
+        err.response?.data?.error ||
+        err.message ||
+        'No se pudo comprobar si se permite modificar la fuente.'
+      );
+      return false;
+    } finally {
+      setUrlDialogCheckLoading(false);
+    }
+  };
 
-            navigate(`/content/${contentId}/library?context=library&id=${authState?.user?.id}`);
-        } catch (err) {
-            if (err.response?.data?.error?.includes('producer')) {
-                setError('Debes reclamar ser el productor para cambiar la visibilidad');
-            } else {
-                setError('Error al actualizar el contenido');
-            }
-            console.error(err);
-        }
-    };
+  const openEditUrlDialog = async () => {
+    if (!content?.url) return;
+    setUrlDraft(content.url);
+    setEditUrlDialogOpen(true);
+    await runSourceModificationCheck();
+  };
 
-    const handleDelete = async () => {
-        try {
-            await contentApi.deleteContent(contentId);
-            navigate('/content/library_user');
-        } catch (err) {
-            setError('Error al eliminar el contenido');
-            console.error(err);
-        }
-    };
+  const openClearUrlDialog = async () => {
+    if (!content?.url) return;
+    setClearUrlDialogOpen(true);
+    await runSourceModificationCheck();
+  };
 
-    if (!content) return <div>Cargando...</div>;
+  const handleClearContentUrl = async () => {
+    setUrlDialogSaveLoading(true);
+    setUrlDialogError('');
+    try {
+      await contentApi.updateContent(contentId, { url: null });
+      await reloadContent();
+      setClearUrlDialogOpen(false);
+      setAttachFileSuccess('URL del contenido eliminada. El archivo adjunto se mantiene.');
+    } catch (err) {
+      const msg =
+      err.response?.data?.error || (
+      typeof err.response?.data === 'string' ? err.response.data : null) ||
+      err.message ||
+      'No se pudo eliminar la URL.';
+      setUrlDialogError(typeof msg === 'string' ? msg : 'No se pudo eliminar la URL.');
+    } finally {
+      setUrlDialogSaveLoading(false);
+    }
+  };
 
-    const hasAttachedFile = !!(content.has_file_available || content.file_details?.file);
-    const canAttachFileAsOwner = !!(content.is_original_uploader && content.url && !hasAttachedFile);
+  const handleSaveContentUrl = async () => {
+    const trimmed = (urlDraft || '').trim();
+    if (!trimmed) {
+      setUrlDialogError('La URL no puede estar vacía.');
+      return;
+    }
+    setUrlDialogSaveLoading(true);
+    setUrlDialogError('');
+    try {
+      await contentApi.updateContent(contentId, { url: trimmed });
+      await reloadContent();
+      setEditUrlDialogOpen(false);
+      setAttachFileSuccess('URL del contenido actualizada correctamente.');
+    } catch (err) {
+      const msg =
+      err.response?.data?.error || (
+      typeof err.response?.data === 'string' ? err.response.data : null) ||
+      err.message ||
+      'No se pudo guardar la URL.';
+      setUrlDialogError(typeof msg === 'string' ? msg : 'No se pudo guardar la URL.');
+    } finally {
+      setUrlDialogSaveLoading(false);
+    }
+  };
 
-    return (
-        <Box sx={{ maxWidth: 1400, margin: '0 auto', padding: 2, pt: 12 }}>
+  const handleChange = (e) => {
+    setFormData({
+      ...formData,
+      [e.target.name]: e.target.value
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      if (!content.selected_profile?.id) {
+        setError('No se encontró el perfil de contenido');
+        return;
+      }
+
+      // If the user selected a new thumbnail, send multipart/form-data.
+      if (thumbnailFile) {
+        const fd = new FormData();
+        fd.append('title', formData.title ?? '');
+        fd.append('author', formData.author ?? '');
+        fd.append('personal_note', formData.personal_note ?? '');
+        fd.append('is_visible', String(!!formData.is_visible));
+        fd.append('is_producer', String(!!formData.is_producer));
+        fd.append('thumbnail', thumbnailFile);
+        await contentApi.updateContentProfile(content.selected_profile.id, fd);
+      } else {
+        await contentApi.updateContentProfile(content.selected_profile.id, formData);
+      }
+
+      navigate(`/content/${contentId}/library?context=library&id=${authState?.user?.id}`);
+    } catch (err) {
+      if (err.response?.data?.error?.includes('producer')) {
+        setError('Debes reclamar ser el productor para cambiar la visibilidad');
+      } else {
+        setError('Error al actualizar el contenido');
+      }
+      console.error(err);
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await contentApi.deleteContent(contentId);
+      navigate('/content/library_user');
+    } catch (err) {
+      setError('Error al eliminar el contenido');
+      console.error(err);
+    }
+  };
+
+  if (!content) return <div>Cargando...</div>;
+
+  const hasAttachedFile = !!(content.has_file_available || content.file_details?.file);
+  const canAttachFileAsOwner = !!(content.is_original_uploader && content.url && !hasAttachedFile);
+
+  return (
+    <Box sx={{ maxWidth: 1400, margin: '0 auto', padding: 2, pt: 12 }}>
             <Box sx={{ mb: 3 }}>
                 <Typography variant="h4" gutterBottom>
                     Editar perfil de contenido
                 </Typography>
             </Box>
 
-            {attachFileSuccess && (
-                <Alert severity="success" sx={{ mb: 2 }} onClose={() => setAttachFileSuccess('')}>
+            {attachFileSuccess &&
+      <Alert severity="success" sx={{ mb: 2 }} onClose={() => setAttachFileSuccess('')}>
                     {attachFileSuccess}
                 </Alert>
-            )}
+      }
 
-            {error && (
-                <Typography color="error" sx={{ mb: 2 }}>
+            {error &&
+      <Typography color="error" sx={{ mb: 2 }}>
                     {error}
                 </Typography>
-            )}
+      }
 
             <Grid container spacing={3}>
                 {/* Left Side - Edit Form */}
@@ -269,11 +262,11 @@ const ContentProfileEdit = () => {
                         </Typography>
                         
                         <Box sx={{ mb: 2 }}>
-                            <Chip 
-                                label={content.media_type || content.content?.media_type || 'DESCONOCIDO'} 
-                                color="primary" 
-                                sx={{ mr: 1 }}
-                            />
+                            <Chip
+                label={content.media_type || content.content?.media_type || 'DESCONOCIDO'}
+                color="primary"
+                sx={{ mr: 1 }} />
+              
                             <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
                                 Subido: {formatDate(content.created_at)}
                             </Typography>
@@ -285,70 +278,70 @@ const ContentProfileEdit = () => {
                                 Miniatura (thumbnail)
                             </Typography>
 
-                            {thumbnailPreviewUrl ? (
-                                <Box
-                                    sx={{
-                                        width: "100%",
-                                        maxWidth: 320,
-                                        height: 160,
-                                        borderRadius: 1,
-                                        overflow: "hidden",
-                                        border: "1px solid",
-                                        borderColor: "divider",
-                                        bgcolor: "grey.50",
-                                        mb: 1,
-                                    }}
-                                >
+                            {thumbnailPreviewUrl ?
+              <Box
+                sx={{
+                  width: "100%",
+                  maxWidth: 320,
+                  height: 160,
+                  borderRadius: 1,
+                  overflow: "hidden",
+                  border: "1px solid",
+                  borderColor: "divider",
+                  bgcolor: "grey.50",
+                  mb: 1
+                }}>
+                
                                     <img
-                                        src={thumbnailPreviewUrl}
-                                        alt="Miniatura actual"
-                                        style={{
-                                            width: "100%",
-                                            height: "100%",
-                                            objectFit: "cover",
-                                            display: "block",
-                                        }}
-                                    />
-                                </Box>
-                            ) : (
-                                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  src={thumbnailPreviewUrl}
+                  alt="Miniatura actual"
+                  style={{
+                    width: "100%",
+                    height: "100%",
+                    objectFit: "cover",
+                    display: "block"
+                  }} />
+                
+                                </Box> :
+
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
                                     No hay miniatura disponible.
                                 </Typography>
-                            )}
+              }
 
                             <Button
-                                variant="outlined"
-                                component="label"
-                                size="small"
-                                sx={{ textTransform: "none" }}
-                            >
+                variant="outlined"
+                component="label"
+                size="small"
+                sx={{ textTransform: "none" }}>
+                
                                 Cambiar miniatura
                                 <input
-                                    type="file"
-                                    accept="image/*"
-                                    hidden
-                                    onChange={(e) => {
-                                        const file = e.target.files?.[0];
-                                        if (!file) return;
+                  type="file"
+                  accept="image/*"
+                  hidden
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (!file) return;
 
-                                        const maxBytes = 3 * 1024 * 1024;
-                                        if (file.size > maxBytes) {
-                                            setError('La miniatura no debe superar 3 MB.');
-                                            e.target.value = '';
-                                            return;
-                                        }
+                    const maxBytes = 3 * 1024 * 1024;
+                    if (file.size > maxBytes) {
+                      setError('La miniatura no debe superar 3 MB.');
+                      e.target.value = '';
+                      return;
+                    }
 
-                                        // Revoke previous blob preview (if any) to avoid memory leaks.
-                                        setThumbnailFile(file);
-                                        if (
-                                            typeof thumbnailPreviewUrl === "string" &&
-                                            thumbnailPreviewUrl.startsWith("blob:")
-                                        ) {
-                                            URL.revokeObjectURL(thumbnailPreviewUrl);
-                                        }
-                                        setThumbnailPreviewUrl(URL.createObjectURL(file));
-                                    }}
-                                />
+                    // Revoke previous blob preview (if any) to avoid memory leaks.
+                    setThumbnailFile(file);
+                    if (
+                    typeof thumbnailPreviewUrl === "string" &&
+                    thumbnailPreviewUrl.startsWith("blob:"))
+                    {
+                      URL.revokeObjectURL(thumbnailPreviewUrl);
+                    }
+                    setThumbnailPreviewUrl(URL.createObjectURL(file));
+                  }} />
+                
                             </Button>
 
                             <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1 }}>
@@ -357,193 +350,193 @@ const ContentProfileEdit = () => {
                         </Box>
 
                         {/* Archivo relacionado: título según exista archivo; acciones en la misma fila */}
-                        {(content.file_details || content?.can_suggest_file || canAttachFileAsOwner) && (
-                            <Box sx={{ mb: 3 }}>
+                        {(content.file_details || content?.can_suggest_file || canAttachFileAsOwner) &&
+            <Box sx={{ mb: 3 }}>
                                 <Box
-                                    sx={{
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        justifyContent: 'space-between',
-                                        gap: 1,
-                                        flexWrap: 'wrap',
-                                        mb: hasAttachedFile && content.file_details ? 1 : 0,
-                                    }}
-                                >
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 1,
+                  flexWrap: 'wrap',
+                  mb: hasAttachedFile && content.file_details ? 1 : 0
+                }}>
+                
                                     <Typography variant="subtitle2" component="div" sx={{ m: 0 }}>
-                                        {hasAttachedFile
-                                            ? 'Detalles del archivo:'
-                                            : 'No hay archivo relacionado'}
+                                        {hasAttachedFile ?
+                  'Detalles del archivo:' :
+                  'No hay archivo relacionado'}
                                     </Typography>
                                     <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                                        {canAttachFileAsOwner && (
-                                            <Button
-                                                variant="contained"
-                                                size="small"
-                                                onClick={() => {
-                                                    setAttachFileSuccess('');
-                                                    setAttachFileDialogOpen(true);
-                                                }}
-                                            >
+                                        {canAttachFileAsOwner &&
+                  <Button
+                    variant="contained"
+                    size="small"
+                    onClick={() => {
+                      setAttachFileSuccess('');
+                      setAttachFileDialogOpen(true);
+                    }}>
+                    
                                                 Subir archivo
                                             </Button>
-                                        )}
-                                        {content?.can_suggest_file && (
-                                            <Button
-                                                variant="outlined"
-                                                size="small"
-                                                onClick={() =>
-                                                    navigate(
-                                                        `/content/${contentId}/library?context=library&id=${authState?.user?.id}`
-                                                    )
-                                                }
-                                            >
+                  }
+                                        {content?.can_suggest_file &&
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() =>
+                    navigate(
+                      `/content/${contentId}/library?context=library&id=${authState?.user?.id}`
+                    )
+                    }>
+                    
                                                 Sugerir archivo
                                             </Button>
-                                        )}
+                  }
                                     </Box>
                                 </Box>
-                                {content.file_details && hasAttachedFile && (
-                                    <>
+                                {content.file_details && hasAttachedFile &&
+              <>
                                         <Typography variant="body2">
                                             Tamaño:{' '}
-                                            {content.file_details.file_size != null
-                                                ? `${(content.file_details.file_size / 1024 / 1024).toFixed(2)} MB`
-                                                : '—'}
+                                            {content.file_details.file_size != null ?
+                  `${(content.file_details.file_size / 1024 / 1024).toFixed(2)} MB` :
+                  '—'}
                                         </Typography>
                                         {(() => {
-                                            const downloadUrl = resolveMediaUrl(
-                                                content.url ?? content.file_details?.url ?? content.file_details?.file
-                                            );
-                                            return downloadUrl && content.file_details.file ? (
-                                                <Button
-                                                    variant="outlined"
-                                                    startIcon={<DownloadIcon />}
-                                                    href={downloadUrl}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    download
-                                                    sx={{ mt: 1 }}
-                                                >
+                  const downloadUrl = resolveMediaUrl(
+                    content.url ?? content.file_details?.url ?? content.file_details?.file
+                  );
+                  return downloadUrl && content.file_details.file ?
+                  <Button
+                    variant="outlined"
+                    startIcon={<DownloadIcon />}
+                    href={downloadUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    download
+                    sx={{ mt: 1 }}>
+                    
                                                     Descargar archivo
-                                                </Button>
-                                            ) : null;
-                                        })()}
+                                                </Button> :
+                  null;
+                })()}
                                     </>
-                                )}
+              }
                             </Box>
-                        )}
+            }
 
-                        {content.url && content.is_original_uploader && (
-                            <Box sx={{ mb: 3 }}>
+                        {content.url && content.is_original_uploader &&
+            <Box sx={{ mb: 3 }}>
                                 <Typography variant="subtitle2" gutterBottom>
                                     URL del contenido
                                 </Typography>
                                 <Typography
-                                    variant="body2"
-                                    color="text.secondary"
-                                    sx={{ wordBreak: 'break-all', mb: 1 }}
-                                >
+                variant="body2"
+                color="text.secondary"
+                sx={{ wordBreak: 'break-all', mb: 1 }}>
+                
                                     {content.url}
                                 </Typography>
-                                {hasAttachedFile ? (
-                                    <Button
-                                        variant="outlined"
-                                        size="small"
-                                        color="warning"
-                                        onClick={openClearUrlDialog}
-                                    >
+                                {hasAttachedFile ?
+              <Button
+                variant="outlined"
+                size="small"
+                color="warning"
+                onClick={openClearUrlDialog}>
+                
                                         Borrar URL
-                                    </Button>
-                                ) : (
-                                    <Button variant="outlined" size="small" onClick={openEditUrlDialog}>
+                                    </Button> :
+
+              <Button variant="outlined" size="small" onClick={openEditUrlDialog}>
                                         Cambiar URL
                                     </Button>
-                                )}
+              }
                             </Box>
-                        )}
+            }
 
                         <Divider sx={{ my: 3 }} />
 
                         {/* Edit Form */}
                         <form onSubmit={handleSubmit}>
                             <TextField
-                                fullWidth
-                                label="Título"
-                                name="title"
-                                value={formData.title}
-                                onChange={handleChange}
-                                margin="normal"
-                            />
+                fullWidth
+                label="Título"
+                name="title"
+                value={formData.title}
+                onChange={handleChange}
+                margin="normal" />
+              
                             <TextField
-                                fullWidth
-                                label="Autor"
-                                name="author"
-                                value={formData.author}
-                                onChange={handleChange}
-                                margin="normal"
-                                helperText={content.original_author && `Autor original: ${content.original_author}`}
-                            />
+                fullWidth
+                label="Autor"
+                name="author"
+                value={formData.author}
+                onChange={handleChange}
+                margin="normal"
+                helperText={content.original_author && `Autor original: ${content.original_author}`} />
+              
                             <TextField
-                                fullWidth
-                                label="Nota personal"
-                                name="personal_note"
-                                value={formData.personal_note}
-                                onChange={handleChange}
-                                margin="normal"
-                                multiline
-                                rows={4}
-                            />
+                fullWidth
+                label="Nota personal"
+                name="personal_note"
+                value={formData.personal_note}
+                onChange={handleChange}
+                margin="normal"
+                multiline
+                rows={4} />
+              
                             <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        checked={formData.is_producer}
-                                        onChange={(e) => setFormData({ ...formData, is_producer: e.target.checked })}
-                                        name="is_producer"
-                                    />
-                                }
-                                label="He producido este contenido"
-                                sx={{ mt: 2 }}
-                            />
-                            {formData.is_producer && (
-                                <>
+                control={
+                <Checkbox
+                  checked={formData.is_producer}
+                  onChange={(e) => setFormData({ ...formData, is_producer: e.target.checked })}
+                  name="is_producer" />
+
+                }
+                label="He producido este contenido"
+                sx={{ mt: 2 }} />
+              
+                            {formData.is_producer &&
+              <>
                                     <FormControlLabel
-                                        control={
-                                            <Switch
-                                                checked={formData.is_visible}
-                                                onChange={(e) => setFormData({ ...formData, is_visible: e.target.checked })}
-                                                name="is_visible"
-                                            />
-                                        }
-                                        label="Visible en los resultados de búsqueda"
-                                        sx={{ mt: 1, ml: 4 }}
-                                    />
+                  control={
+                  <Switch
+                    checked={formData.is_visible}
+                    onChange={(e) => setFormData({ ...formData, is_visible: e.target.checked })}
+                    name="is_visible" />
+
+                  }
+                  label="Visible en los resultados de búsqueda"
+                  sx={{ mt: 1, ml: 4 }} />
+                
                                     <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1, ml: 5 }}>
                                         Nota: Solo el productor del contenido puede hacerlo invisible en los resultados de búsqueda.
                                     </Typography>
                                 </>
-                            )}
+              }
 
                             <Box sx={{ mt: 3, display: 'flex', justifyContent: 'space-between' }}>
                                 <Button
-                                    variant="contained"
-                                    color="error"
-                                    onClick={() => setDeleteDialogOpen(true)}
-                                >
+                  variant="contained"
+                  color="error"
+                  onClick={() => setDeleteDialogOpen(true)}>
+                  
                                     Eliminar contenido
                                 </Button>
                                 <Box>
                                     <Button
-                                        variant="outlined"
-                                        onClick={() => navigate(`/content/${contentId}/library?context=library&id=${authState?.user?.id}`)}
-                                        sx={{ mr: 1 }}
-                                    >
+                    variant="outlined"
+                    onClick={() => navigate(`/content/${contentId}/library?context=library&id=${authState?.user?.id}`)}
+                    sx={{ mr: 1 }}>
+                    
                                         Cancelar
                                     </Button>
                                     <Button
-                                        variant="contained"
-                                        color="primary"
-                                        type="submit"
-                                    >
+                    variant="contained"
+                    color="primary"
+                    type="submit">
+                    
                                         Guardar cambios
                                     </Button>
                                 </Box>
@@ -558,20 +551,20 @@ const ContentProfileEdit = () => {
                         <Typography variant="h6" gutterBottom>
                             Vista previa del contenido
                         </Typography>
-                        <ContentDisplay 
-                            content={content}
-                            variant="detailed"
-                            maxImageHeight={400}
-                            showAuthor={true}
-                        />
+                        <ContentDisplay
+              content={content}
+              variant="detailed"
+              maxImageHeight={400}
+              showAuthor={true} />
+            
                     </Card>
                 </Grid>
             </Grid>
 
             <Dialog
-                open={deleteDialogOpen}
-                onClose={() => setDeleteDialogOpen(false)}
-            >
+        open={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}>
+        
                 <DialogTitle>Confirmar eliminación</DialogTitle>
                 <DialogContent>
                     ¿Estás seguro de que deseas eliminar este contenido? Esta acción no se puede deshacer.
@@ -585,13 +578,13 @@ const ContentProfileEdit = () => {
             </Dialog>
 
             <Dialog
-                open={clearUrlDialogOpen}
-                onClose={() =>
-                    !urlDialogSaveLoading && !urlDialogCheckLoading && setClearUrlDialogOpen(false)
-                }
-                maxWidth="sm"
-                fullWidth
-            >
+        open={clearUrlDialogOpen}
+        onClose={() =>
+        !urlDialogSaveLoading && !urlDialogCheckLoading && setClearUrlDialogOpen(false)
+        }
+        maxWidth="sm"
+        fullWidth>
+        
                 <DialogTitle>Borrar URL del contenido</DialogTitle>
                 <DialogContent>
                     <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
@@ -599,118 +592,118 @@ const ContentProfileEdit = () => {
                         seguirá disponible para descarga. Si otras personas usan este ítem, el
                         cambio las afecta.
                     </Typography>
-                    {urlDialogCheckLoading && (
-                        <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+                    {urlDialogCheckLoading &&
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
                             <CircularProgress size={32} />
                         </Box>
-                    )}
-                    {!urlDialogCheckLoading && urlDialogError && (
-                        <Alert severity="error" sx={{ mb: 2 }}>
+          }
+                    {!urlDialogCheckLoading && urlDialogError &&
+          <Alert severity="error" sx={{ mb: 2 }}>
                             {urlDialogError}
                         </Alert>
-                    )}
+          }
                 </DialogContent>
                 <DialogActions>
                     <Button
-                        onClick={() => setClearUrlDialogOpen(false)}
-                        disabled={urlDialogSaveLoading}
-                    >
+            onClick={() => setClearUrlDialogOpen(false)}
+            disabled={urlDialogSaveLoading}>
+            
                         Cancelar
                     </Button>
                     <Button
-                        variant="contained"
-                        color="warning"
-                        onClick={handleClearContentUrl}
-                        disabled={
-                            urlDialogSaveLoading ||
-                            urlDialogCheckLoading ||
-                            urlSaveBlocked
-                        }
-                    >
+            variant="contained"
+            color="warning"
+            onClick={handleClearContentUrl}
+            disabled={
+            urlDialogSaveLoading ||
+            urlDialogCheckLoading ||
+            urlSaveBlocked
+            }>
+            
                         {urlDialogSaveLoading ? 'Eliminando…' : 'Borrar URL'}
                     </Button>
                 </DialogActions>
             </Dialog>
 
             <Dialog
-                open={editUrlDialogOpen}
-                onClose={() =>
-                    !urlDialogSaveLoading && !urlDialogCheckLoading && setEditUrlDialogOpen(false)
-                }
-                maxWidth="sm"
-                fullWidth
-            >
+        open={editUrlDialogOpen}
+        onClose={() =>
+        !urlDialogSaveLoading && !urlDialogCheckLoading && setEditUrlDialogOpen(false)
+        }
+        maxWidth="sm"
+        fullWidth>
+        
                 <DialogTitle>Cambiar URL del contenido</DialogTitle>
                 <DialogContent>
                     <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                         La URL vive en el registro del contenido (no en tu perfil de biblioteca). Si otras
                         personas usan el mismo ítem, el cambio las afecta. Por favor, asegúrate que la url no esté rota.
                     </Typography>
-                    {urlDialogCheckLoading && (
-                        <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+                    {urlDialogCheckLoading &&
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
                             <CircularProgress size={32} />
                         </Box>
-                    )}
-                    {!urlDialogCheckLoading && (
-                        <>
-                            {urlDialogError && (
-                                <Alert severity="error" sx={{ mb: 2 }}>
+          }
+                    {!urlDialogCheckLoading &&
+          <>
+                            {urlDialogError &&
+            <Alert severity="error" sx={{ mb: 2 }}>
                                     {urlDialogError}
                                 </Alert>
-                            )}
+            }
                             <TextField
-                                fullWidth
-                                label="URL"
-                                value={urlDraft}
-                                onChange={(e) => setUrlDraft(e.target.value)}
-                                margin="normal"
-                                multiline
-                                minRows={2}
-                                disabled={urlSaveBlocked || urlDialogSaveLoading}
-                            />
+              fullWidth
+              label="URL"
+              value={urlDraft}
+              onChange={(e) => setUrlDraft(e.target.value)}
+              margin="normal"
+              multiline
+              minRows={2}
+              disabled={urlSaveBlocked || urlDialogSaveLoading} />
+            
                         </>
-                    )}
+          }
                 </DialogContent>
                 <DialogActions>
                     <Button
-                        onClick={() => setEditUrlDialogOpen(false)}
-                        disabled={urlDialogSaveLoading}
-                    >
+            onClick={() => setEditUrlDialogOpen(false)}
+            disabled={urlDialogSaveLoading}>
+            
                         Cancelar
                     </Button>
                     <Button
-                        variant="contained"
-                        onClick={handleSaveContentUrl}
-                        disabled={
-                            urlDialogSaveLoading ||
-                            urlDialogCheckLoading ||
-                            urlSaveBlocked
-                        }
-                    >
+            variant="contained"
+            onClick={handleSaveContentUrl}
+            disabled={
+            urlDialogSaveLoading ||
+            urlDialogCheckLoading ||
+            urlSaveBlocked
+            }>
+            
                         {urlDialogSaveLoading ? 'Guardando…' : 'Guardar'}
                     </Button>
                 </DialogActions>
             </Dialog>
 
             <OwnerContentFileUploadDialog
-                open={attachFileDialogOpen}
-                onClose={() => setAttachFileDialogOpen(false)}
-                contentId={contentId}
-                dialogTitle="Subir archivo correspondiente"
-                submitLabel="Adjuntar archivo"
-                introText="Este contenido tiene URL pero aún no tiene archivo descargable. Al adjuntar un archivo, quedará vinculado a este ítem."
-                onSuccess={async () => {
-                    setAttachFileSuccess('Archivo adjuntado correctamente.');
-                    setAttachFileDialogOpen(false);
-                    try {
-                        await reloadContent();
-                    } catch (e) {
-                        console.error(e);
-                    }
-                }}
-            />
-        </Box>
-    );
+        open={attachFileDialogOpen}
+        onClose={() => setAttachFileDialogOpen(false)}
+        contentId={contentId}
+        dialogTitle="Subir archivo correspondiente"
+        submitLabel="Adjuntar archivo"
+        introText="Este contenido tiene URL pero aún no tiene archivo descargable. Al adjuntar un archivo, quedará vinculado a este ítem."
+        onSuccess={async () => {
+          setAttachFileSuccess('Archivo adjuntado correctamente.');
+          setAttachFileDialogOpen(false);
+          try {
+            await reloadContent();
+          } catch (e) {
+            console.error(e);
+          }
+        }} />
+      
+        </Box>);
+
 };
 
-export default ContentProfileEdit; 
+export default ContentProfileEdit;

--- a/frontend/src/content/ContentSelector.jsx
+++ b/frontend/src/content/ContentSelector.jsx
@@ -12,7 +12,7 @@ const ContentSelector = ({
   showPreview = true,
   previewVariant = "detailed",
   onUploadingChange,
-  onPendingContentChange,
+  onPendingContentChange
 }) => {
   const [showContentOptions, setShowContentOptions] = useState(
     !selectedContent
@@ -34,7 +34,7 @@ const ContentSelector = ({
       onUploadingChange(uploading);
     }
   }, [onUploadingChange]);
-  
+
   const handleModeSelect = useCallback((mode) => {
     if (mode === 'library') {
       setShowContentModal(true);
@@ -42,7 +42,7 @@ const ContentSelector = ({
       setContentMode(mode);
     }
   }, []);
-  
+
   const handleCancelUpload = useCallback(() => {
     setContentMode(null);
     setIsUploading(false);
@@ -54,7 +54,7 @@ const ContentSelector = ({
   }, [onUploadingChange, onPendingContentChange]);
 
   const handleContentUpload = useCallback((uploadedContent) => {
-    console.log("Uploaded content received:", uploadedContent);
+
     onContentSelected(uploadedContent);
     setContentMode(null);
     setShowContentOptions(false);
@@ -67,7 +67,7 @@ const ContentSelector = ({
   }, [onContentSelected, onUploadingChange, onPendingContentChange]);
 
   const handleContentSelect = useCallback((selectedContent) => {
-    console.log("Selected content received:", selectedContent);
+
     onContentSelected(selectedContent);
     setShowContentModal(false);
     setShowContentOptions(false);
@@ -82,90 +82,90 @@ const ContentSelector = ({
 
   return (
     <Box>
-      {showContentOptions && !contentMode && (
-        <Paper elevation={2} sx={{ p: 4, mb: 4 }}>
+      {showContentOptions && !contentMode &&
+      <Paper elevation={2} sx={{ p: 4, mb: 4 }}>
           <Typography
-            variant="h6"
-            gutterBottom
-            align="center"
-            sx={{
-              fontSize: {
-                xs: "0.9rem",
-                sm: "1rem",
-                md: "1.25rem",
-              },
-              mb: 3,
-            }}
-          >
+          variant="h6"
+          gutterBottom
+          align="center"
+          sx={{
+            fontSize: {
+              xs: "0.9rem",
+              sm: "1rem",
+              md: "1.25rem"
+            },
+            mb: 3
+          }}>
+          
             Elegir fuente de contenido (Opcional)
           </Typography>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
             <Button
-              variant="contained"
-              color="primary"
-              onClick={() => handleModeSelect('library')}
-              disabled={isUploading}
-              size="large"
-              sx={{ 
-                textTransform: 'none',
-                py: 2,
-                fontSize: '1rem',
-                fontWeight: 500,
-                boxShadow: 2,
-                '&:hover': {
-                  boxShadow: 3,
-                  backgroundColor: 'primary.dark',
-                }
-              }}
-            >
+            variant="contained"
+            color="primary"
+            onClick={() => handleModeSelect('library')}
+            disabled={isUploading}
+            size="large"
+            sx={{
+              textTransform: 'none',
+              py: 2,
+              fontSize: '1rem',
+              fontWeight: 500,
+              boxShadow: 2,
+              '&:hover': {
+                boxShadow: 3,
+                backgroundColor: 'primary.dark'
+              }
+            }}>
+            
               Elegir de la biblioteca
             </Button>
             
             {/* Integrated Upload Mode Selection */}
             <Box>
               <ToggleButtonGroup
-                value={uploadMode}
-                exclusive
-                onChange={(e, newMode) => {
-                  if (newMode !== null) {
-                    // User clicked a button - set the mode and show form
-                    setUploadMode(newMode);
-                    setContentMode('upload');
-                  } else {
-                    // User clicked the selected button - still show the form with current mode
-                    setContentMode('upload');
-                  }
-                }}
-                fullWidth
-                sx={{
-                  '& .MuiToggleButton-root': {
-                    py: 2,
-                    px: 3,
-                    textTransform: 'none',
-                    fontSize: '1rem',
-                    fontWeight: 500,
-                    border: '2px solid',
-                    borderColor: 'divider',
-                    '&.Mui-selected': {
-                      backgroundColor: 'primary.main',
-                      color: 'primary.contrastText',
-                      borderColor: 'primary.main',
-                      boxShadow: 2,
-                      '&:hover': {
-                        backgroundColor: 'primary.dark',
-                        boxShadow: 3,
-                      }
-                    },
-                    '&:not(.Mui-selected)': {
-                      backgroundColor: 'background.paper',
-                      color: 'text.primary',
-                      '&:hover': {
-                        backgroundColor: 'action.hover',
-                      }
+              value={uploadMode}
+              exclusive
+              onChange={(e, newMode) => {
+                if (newMode !== null) {
+                  // User clicked a button - set the mode and show form
+                  setUploadMode(newMode);
+                  setContentMode('upload');
+                } else {
+                  // User clicked the selected button - still show the form with current mode
+                  setContentMode('upload');
+                }
+              }}
+              fullWidth
+              sx={{
+                '& .MuiToggleButton-root': {
+                  py: 2,
+                  px: 3,
+                  textTransform: 'none',
+                  fontSize: '1rem',
+                  fontWeight: 500,
+                  border: '2px solid',
+                  borderColor: 'divider',
+                  '&.Mui-selected': {
+                    backgroundColor: 'primary.main',
+                    color: 'primary.contrastText',
+                    borderColor: 'primary.main',
+                    boxShadow: 2,
+                    '&:hover': {
+                      backgroundColor: 'primary.dark',
+                      boxShadow: 3
+                    }
+                  },
+                  '&:not(.Mui-selected)': {
+                    backgroundColor: 'background.paper',
+                    color: 'text.primary',
+                    '&:hover': {
+                      backgroundColor: 'action.hover'
                     }
                   }
-                }}
-              >
+                }
+              }}>
+              
                 <ToggleButton value="url" aria-label="subir contenido desde url">
                   Desde URL
                 </ToggleButton>
@@ -176,50 +176,50 @@ const ContentSelector = ({
             </Box>
           </Box>
         </Paper>
-      )}
+      }
 
-      {contentMode === 'upload' && (
-        <Box sx={{ mb: 4 }}>
+      {contentMode === 'upload' &&
+      <Box sx={{ mb: 4 }}>
           <Button
-            variant="text"
-            onClick={handleCancelUpload}
-            sx={{ mb: 2, textTransform: 'none' }}
-            disabled={isUploading}
-          >
+          variant="text"
+          onClick={handleCancelUpload}
+          sx={{ mb: 2, textTransform: 'none' }}
+          disabled={isUploading}>
+          
             ← Cancelar
           </Button>
-          <UploadContentForm 
-            onContentUploaded={handleContentUpload}
-            onUploadingChange={handleUploadingChange}
-            onHasPendingContentChange={handlePendingContentChange}
-            initialUrlMode={uploadMode === 'url'}
-            showModeToggle={false}
-          />
+          <UploadContentForm
+          onContentUploaded={handleContentUpload}
+          onUploadingChange={handleUploadingChange}
+          onHasPendingContentChange={handlePendingContentChange}
+          initialUrlMode={uploadMode === 'url'}
+          showModeToggle={false} />
+        
         </Box>
-      )}
+      }
 
-      {selectedContent && showPreview && (
-        <ContentDisplay
-          content={selectedContent}
-          variant="simple"
-          showActions={true}
-          onRemove={handleRemoveContent}
-          onEdit={() => {
-            setShowContentOptions(true);
-            setContentMode(null);
-          }}
-        />
-      )}
+      {selectedContent && showPreview &&
+      <ContentDisplay
+        content={selectedContent}
+        variant="simple"
+        showActions={true}
+        onRemove={handleRemoveContent}
+        onEdit={() => {
+          setShowContentOptions(true);
+          setContentMode(null);
+        }} />
+
+      }
 
       <LibrarySelectSingle
         isOpen={showContentModal}
         onClose={() => setShowContentModal(false)}
         onSelect={handleContentSelect}
         isLoading={isUploading}
-        compact={true}
-      />
-    </Box>
-  );
+        compact={true} />
+      
+    </Box>);
+
 };
 
 export default memo(ContentSelector);

--- a/frontend/src/content/RecentUserContent.jsx
+++ b/frontend/src/content/RecentUserContent.jsx
@@ -12,9 +12,9 @@ const RecentUserContent = () => {
   useEffect(() => {
     const fetchRecentContent = async () => {
       try {
-        console.log('\n=== Fetching Recent Content ===');
+
         const data = await contentApi.getRecentContent();
-        console.log('Recent content data:', JSON.stringify(data, null, 2));
+
         setRecentContent(data);
         setLoading(false);
       } catch (err) {
@@ -35,16 +35,16 @@ const RecentUserContent = () => {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
         <CircularProgress />
-      </Box>
-    );
+      </Box>);
+
   }
 
   if (error) {
     return (
       <Typography color="error" align="center">
         {error}
-      </Typography>
-    );
+      </Typography>);
+
   }
 
   return (
@@ -61,21 +61,21 @@ const RecentUserContent = () => {
                 variant="simple"
                 showAuthor={false}
                 maxImageHeight={150}
-                onClick={() => handleContentClick(profile.content.id)}
-              />
-            </Grid>
-          );
+                onClick={() => handleContentClick(profile.content.id)} />
+              
+            </Grid>);
+
         })}
-        {recentContent.length === 0 && (
-          <Grid item xs={12}>
+        {recentContent.length === 0 &&
+        <Grid item xs={12}>
             <Typography color="text.secondary" align="center">
               No se encontró contenido reciente
             </Typography>
           </Grid>
-        )}
+        }
       </Grid>
-    </Box>
-  );
+    </Box>);
+
 };
 
-export default RecentUserContent; 
+export default RecentUserContent;

--- a/frontend/src/content/UploadContentForm.jsx
+++ b/frontend/src/content/UploadContentForm.jsx
@@ -4,12 +4,12 @@ import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 import axiosInstance from '../api/axiosConfig';
 import contentApi from '../api/contentApi';
-import { 
-  Grid, 
-  FormControlLabel, 
-  Switch, 
-  Checkbox, 
-  Typography, 
+import {
+  Grid,
+  FormControlLabel,
+  Switch,
+  Checkbox,
+  Typography,
   Paper,
   Button,
   Box,
@@ -32,8 +32,8 @@ import {
   ToggleButton,
   Snackbar,
   Collapse,
-  Chip
-} from '@mui/material';
+  Chip } from
+'@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -54,16 +54,16 @@ const URLPreview = ({ previewData, isLoading, error }) => {
           <Skeleton variant="text" />
           <Skeleton variant="text" />
         </CardContent>
-      </Card>
-    );
+      </Card>);
+
   }
 
   if (error) {
     return (
       <Alert severity="warning" sx={{ mt: 2, mb: 3, position: 'relative', zIndex: 1 }}>
         {error}
-      </Alert>
-    );
+      </Alert>);
+
   }
 
   if (!previewData) return null;
@@ -71,10 +71,10 @@ const URLPreview = ({ previewData, isLoading, error }) => {
   const isYouTube = previewData.siteName === 'YouTube' && previewData.type === 'video';
 
   return (
-    <Card sx={{ 
-      mt: 2, 
-      mb: 3, 
-      display: 'flex', 
+    <Card sx={{
+      mt: 2,
+      mb: 3,
+      display: 'flex',
       alignItems: 'start',
       position: 'relative',
       zIndex: 1,
@@ -83,85 +83,85 @@ const URLPreview = ({ previewData, isLoading, error }) => {
         boxShadow: 3
       }
     }}>
-      {previewData.image && (
-        <Box sx={{ position: 'relative', width: 140, minWidth: 140, height: 140 }}>
+      {previewData.image &&
+      <Box sx={{ position: 'relative', width: 140, minWidth: 140, height: 140 }}>
           <CardMedia
-            component="img"
-            sx={{ 
-              width: '100%', 
-              height: '100%', 
-              objectFit: 'cover'
-            }}
-            image={previewData.image}
-            alt={previewData.title || 'Preview image'}
-          />
-          {isYouTube && (
-            <Box
-              sx={{
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                transform: 'translate(-50%, -50%)',
-                width: 48,
-                height: 48,
-                bgcolor: 'rgba(0, 0, 0, 0.7)',
-                borderRadius: '50%',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center'
-              }}
-            >
+          component="img"
+          sx={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover'
+          }}
+          image={previewData.image}
+          alt={previewData.title || 'Preview image'} />
+        
+          {isYouTube &&
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: 48,
+            height: 48,
+            bgcolor: 'rgba(0, 0, 0, 0.7)',
+            borderRadius: '50%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}>
+          
               <Box
-                sx={{
-                  width: 0,
-                  height: 0,
-                  borderTop: '8px solid transparent',
-                  borderBottom: '8px solid transparent',
-                  borderLeft: '16px solid white',
-                  marginLeft: '4px'
-                }}
-              />
+            sx={{
+              width: 0,
+              height: 0,
+              borderTop: '8px solid transparent',
+              borderBottom: '8px solid transparent',
+              borderLeft: '16px solid white',
+              marginLeft: '4px'
+            }} />
+          
             </Box>
-          )}
+        }
         </Box>
-      )}
+      }
       <CardContent sx={{ flex: 1, minWidth: 0 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-          {previewData.favicon && (
-            <Avatar 
-              src={previewData.favicon} 
-              sx={{ width: 20, height: 20, mr: 1 }}
-            />
-          )}
-          {previewData.siteName && (
-            <Typography variant="caption" color="text.secondary" noWrap>
+          {previewData.favicon &&
+          <Avatar
+            src={previewData.favicon}
+            sx={{ width: 20, height: 20, mr: 1 }} />
+
+          }
+          {previewData.siteName &&
+          <Typography variant="caption" color="text.secondary" noWrap>
               {previewData.siteName}
             </Typography>
-          )}
+          }
         </Box>
-        {previewData.title && (
-          <Typography variant="subtitle1" component="div" gutterBottom noWrap>
+        {previewData.title &&
+        <Typography variant="subtitle1" component="div" gutterBottom noWrap>
             {previewData.title}
           </Typography>
-        )}
-        {previewData.description && (
-          <Typography 
-            variant="body2" 
-            color="text.secondary"
-            sx={{
-              display: '-webkit-box',
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: 'vertical',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis'
-            }}
-          >
+        }
+        {previewData.description &&
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis'
+          }}>
+          
             {previewData.description}
           </Typography>
-        )}
+        }
       </CardContent>
-    </Card>
-  );
+    </Card>);
+
 };
 
 // Create schema function that can access current form values
@@ -173,15 +173,15 @@ const createSchema = () => yup.object({
   }),
   url: yup.string().when('isUrlMode', {
     is: true,
-    then: () => yup.string()
-      .required('La URL es requerida')
-      .test('is-url', 'Debe ser una URL válida', function(value) {
-        if (!value) return true; // required check handles empty
-        // Normalize URL by adding https:// if missing
-        const normalized = value.match(/^https?:\/\//i) ? value : `https://${value}`;
-        // Use yup's url validation on normalized URL
-        return yup.string().url().isValidSync(normalized);
-      }),
+    then: () => yup.string().
+    required('La URL es requerida').
+    test('is-url', 'Debe ser una URL válida', function (value) {
+      if (!value) return true; // required check handles empty
+      // Normalize URL by adding https:// if missing
+      const normalized = value.match(/^https?:\/\//i) ? value : `https://${value}`;
+      // Use yup's url validation on normalized URL
+      return yup.string().url().isValidSync(normalized);
+    }),
     otherwise: () => yup.string().nullable()
   }),
   media_type: yup.string().when('isUrlMode', {
@@ -206,7 +206,7 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
   const [hasSavedSuccessfully, setHasSavedSuccessfully] = useState(false);
   const [isDragActive, setIsDragActive] = useState(false);
-  
+
   // Notify parent when uploading state changes
   useEffect(() => {
     if (onUploadingChange) {
@@ -224,7 +224,7 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
 
   // Determine initial isUrlMode value
   const initialIsUrlMode = initialUrlMode !== null ? initialUrlMode : !!initialData?.url;
-  
+
   const {
     register,
     handleSubmit,
@@ -269,9 +269,9 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
   useEffect(() => {
     if (typeof onHasPendingContentChange !== 'function') return;
     const hasPending = !hasSavedSuccessfully && (
-      (isUrlMode && url && String(url).trim() !== '') ||
-      (!isUrlMode && file && file[0])
-    );
+    isUrlMode && url && String(url).trim() !== '' ||
+    !isUrlMode && file && file[0]);
+
     onHasPendingContentChange(!!hasPending);
   }, [hasSavedSuccessfully, isUrlMode, url, file, onHasPendingContentChange]);
 
@@ -288,13 +288,13 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
   // Initialize form with initialData when in edit mode
   useEffect(() => {
     if (isEditMode && initialData) {
-      console.log('Initializing form with initialData:', initialData);
+
       const isUrlContent = !!initialData.url;
-      console.log('isUrlContent:', isUrlContent);
-      
+
+
       setIsUrlMode(isUrlContent);
       setValue('isUrlMode', isUrlContent);
-      
+
       // Set form values
       setValue('title', initialData.title || '');
       setValue('author', initialData.author || '');
@@ -302,23 +302,17 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
       setValue('url', initialData.url || '');
       setValue('has_spanish_subtitles', initialData.has_spanish_subtitles || false);
       setValue('has_spanish_dubbing', initialData.has_spanish_dubbing || false);
-      
-      console.log('Form values set:', {
-        title: initialData.title || '',
-        author: initialData.author || '',
-        media_type: initialData.media_type || '',
-        url: initialData.url || ''
-      });
-      
+
+
       // If it's URL content, fetch preview
       if (isUrlContent && initialData.url) {
-        contentApi.fetchUrlMetadata(initialData.url)
-          .then(metadata => {
-            setPreviewData(metadata);
-          })
-          .catch(error => {
-            console.error('Failed to fetch initial preview:', error);
-          });
+        contentApi.fetchUrlMetadata(initialData.url).
+        then((metadata) => {
+          setPreviewData(metadata);
+        }).
+        catch((error) => {
+          console.error('Failed to fetch initial preview:', error);
+        });
       }
     }
   }, [isEditMode, initialData, setValue]);
@@ -326,14 +320,13 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
   // Effect to fetch preview when URL changes
   useEffect(() => {
     if (!isUrlMode || !url) {
-      console.log('URL preview disabled or no URL provided');
+
       setPreviewData(null);
       setPreviewError(null); // Clear error when URL is cleared
       return;
     }
 
-    console.log('\n=== URL Preview Effect ===');
-    console.log('URL changed:', url);
+
     setPreviewError(null); // Clear error when URL changes
 
     // Helper function to normalize URL (add protocol if missing)
@@ -358,7 +351,7 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
     const fetchPreview = async () => {
       // Check if URL looks valid before attempting fetch
       if (!looksLikeUrl(url)) {
-        console.log('URL does not look valid, skipping preview');
+
         setPreviewError(null);
         return;
       }
@@ -369,7 +362,7 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
       try {
         // Normalize URL before fetching
         const normalizedUrl = normalizeUrl(url);
-        console.log('Fetching metadata for URL:', normalizedUrl);
+
 
         // Auto-detect YouTube and set media type to Video
         if (normalizedUrl && (normalizedUrl.includes('youtube.com') || normalizedUrl.includes('youtu.be'))) {
@@ -377,19 +370,19 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
         }
 
         const metadata = await contentApi.fetchUrlMetadata(normalizedUrl);
-        console.log('Received metadata:', metadata);
+
         setPreviewData(metadata);
-        setPreviewError(null);  // Clear any previous errors
+        setPreviewError(null); // Clear any previous errors
 
         // Auto-fill form fields if empty
         const currentTitle = watch('title');
         if (!currentTitle && metadata.title) {
-          console.log('Auto-filling title:', metadata.title);
+
           setValue('title', metadata.title);
         }
       } catch (error) {
         console.error('Preview fetch error:', error);
-        setPreviewData(null);  // Clear any previous preview data
+        setPreviewData(null); // Clear any previous preview data
         // Only show error if URL is still the same (url is captured in closure)
         // Check current URL value to ensure it hasn't changed
         const currentUrl = watch('url');
@@ -407,28 +400,23 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
   }, [url, isUrlMode]); // Removed setValue, trigger, watch from dependencies to avoid unnecessary re-runs
 
   const onSubmit = async (data) => {
-    console.log('\n=== Form Submit ===');
-    console.log('Form data:', data);
-    console.log('data.isUrlMode:', data.isUrlMode);
-    console.log('isUrlMode state:', isUrlMode);
-    console.log('isEditMode:', isEditMode);
-    console.log('contentId:', contentId);
-    
+
+
     // Use form data's isUrlMode if available, otherwise fall back to state
     const currentIsUrlMode = data.isUrlMode !== undefined ? data.isUrlMode : isUrlMode;
-    console.log('Using isUrlMode:', currentIsUrlMode);
-    
+
+
     setIsUploading(true);
     setUploadProgress(0);
     try {
-      
+
       if (isEditMode && contentId) {
         // Edit mode - update existing content
-        console.log('Edit mode - updating existing content');
-        
+
+
         if (!currentIsUrlMode) {
           // File upload in edit mode - create new content via S3 and update profile
-          console.log('File upload in edit mode - creating new content');
+
           const file = data.file[0];
           if (!file) {
             throw new Error('No se seleccionó ningún archivo');
@@ -450,21 +438,21 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
               is_producer: false
             },
             (e) => {
-              if (e.total) setUploadProgress(Math.round((e.loaded / e.total) * 100));
+              if (e.total) setUploadProgress(Math.round(e.loaded / e.total * 100));
             }
           );
-          console.log('New content created:', response);
-          
+
+
           // Update the existing content profile to reference the new content
           if (contentProfileId && response.content_id) {
             await contentApi.updateContentProfileContent(contentProfileId, response.content_id);
-            console.log('Content profile updated to reference new content');
+
           }
-          
+
           if (onContentUploaded) {
             onContentUploaded(response.content_profile);
           }
-          
+
           setHasSavedSuccessfully(true);
           setSnackbar({
             open: true,
@@ -473,12 +461,8 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
           });
         } else {
           // URL update - update existing content
-          console.log('URL update mode - updating existing content');
-          console.log('URL from form data:', data.url);
-          console.log('Media type from form data:', data.media_type);
-          console.log('Title from form data:', data.title);
-          console.log('Author from form data:', data.author);
-          
+
+
           const updateData = {
             media_type: data.media_type,
             original_title: data.title || '',
@@ -487,15 +471,15 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
             has_spanish_subtitles: data.has_spanish_subtitles ?? false,
             has_spanish_dubbing: data.has_spanish_dubbing ?? false
           };
-          
-          console.log('Update data being sent to API:', updateData);
+
+
           const response = await contentApi.updateContent(contentId, updateData);
-          console.log('Update Response:', response);
-          
+
+
           if (onContentUploaded) {
             onContentUploaded(response);
           }
-          
+
           setHasSavedSuccessfully(true);
           setSnackbar({
             open: true,
@@ -506,10 +490,10 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
       } else {
         // Create new content
         if (currentIsUrlMode) {
-          console.log('URL mode submission');
+
           const formData = new FormData();
-          const normalizedUrl = data.url && !data.url.match(/^https?:\/\//i)
-            ? `https://${data.url}` : data.url;
+          const normalizedUrl = data.url && !data.url.match(/^https?:\/\//i) ?
+          `https://${data.url}` : data.url;
           formData.append('url', normalizedUrl);
           formData.append('media_type', data.media_type);
           formData.append('is_producer', 'false');
@@ -525,10 +509,10 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
             formData.append('og_site_name', previewData.siteName || '');
           }
           const response = await contentApi.uploadContent(formData);
-          console.log('API Response:', response);
+
           if (onContentUploaded) onContentUploaded(response.content_profile);
         } else {
-          console.log('File mode submission - S3');
+
           const file = data.file[0];
           if (!file) throw new Error('No se seleccionó ningún archivo');
           const mediaType = getMediaType(file);
@@ -546,10 +530,10 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
               is_producer: data.is_producer ?? false
             },
             (e) => {
-              if (e.total) setUploadProgress(Math.round((e.loaded / e.total) * 100));
+              if (e.total) setUploadProgress(Math.round(e.loaded / e.total * 100));
             }
           );
-          console.log('API Response:', response);
+
           if (onContentUploaded) onContentUploaded(response.content_profile);
         }
 
@@ -566,9 +550,9 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
       console.error('Upload failed:', error);
       const backendError = error.response?.data?.error;
       const backendDetails = error.response?.data?.details;
-      const message = backendError
-        ? (backendDetails ? `${backendError}: ${backendDetails}` : backendError)
-        : (error.message || 'Error al subir contenido. Por favor, inténtalo de nuevo.');
+      const message = backendError ?
+      backendDetails ? `${backendError}: ${backendDetails}` : backendError :
+      error.message || 'Error al subir contenido. Por favor, inténtalo de nuevo.';
       setSnackbar({
         open: true,
         message,
@@ -583,19 +567,13 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
   // Update the mode toggle handlers
   const handleModeToggle = (newMode) => {
     setHasSavedSuccessfully(false);
-    console.log('handleModeToggle called with newMode:', newMode);
-    console.log('Current form values before reset:', {
-      title: watch('title'),
-      author: watch('author'),
-      url: watch('url'),
-      media_type: watch('media_type')
-    });
-    
+
+
     setIsUrlMode(newMode);
     setValue('isUrlMode', newMode);
     setPreviewData(null);
     setPreviewError(null);
-    
+
     // Preserve title, author, URL, and media_type when switching modes
     const currentTitle = watch('title');
     const currentAuthor = watch('author');
@@ -603,16 +581,8 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
     const currentMediaType = watch('media_type');
     const currentHasSpanishSubtitles = watch('has_spanish_subtitles');
     const currentHasSpanishDubbing = watch('has_spanish_dubbing');
-    
-    console.log('Values to preserve:', {
-      currentTitle,
-      currentAuthor,
-      currentUrl,
-      currentMediaType,
-      currentHasSpanishSubtitles,
-      currentHasSpanishDubbing
-    });
-    
+
+
     reset({
       title: currentTitle || '',
       author: currentAuthor || '',
@@ -621,12 +591,12 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
       is_producer: false,
       is_visible: true,
       isUrlMode: newMode,
-      url: newMode ? (currentUrl || '') : '',
+      url: newMode ? currentUrl || '' : '',
       file: null,
-      media_type: newMode ? (currentMediaType || '') : ''
+      media_type: newMode ? currentMediaType || '' : ''
     });
-    
-    console.log('Form reset completed');
+
+
   };
 
   // Register file input with ref callback
@@ -684,8 +654,8 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
 
   return (
     <Paper elevation={2} sx={{ p: 3, width: '100%' }}>
-      {showModeToggle && (
-        <>
+      {showModeToggle &&
+      <>
           <Typography variant="h6" gutterBottom sx={{ mb: 3 }}>
             {isEditMode ? 'Cambiar fuente del contenido' : 'Selecciona cómo agregar contenido'}
           </Typography>
@@ -693,41 +663,41 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
           {/* Toggle Buttons - Styled as option cards */}
           <Box sx={{ mb: 4 }}>
             <ToggleButtonGroup
-              value={isUrlMode ? 'url' : 'file'}
-              exclusive
-              onChange={(e, newMode) => {
-                if (newMode !== null) {
-                  handleModeToggle(newMode === 'url');
-                }
-              }}
-              fullWidth
-              sx={{
-                '& .MuiToggleButton-root': {
-                  py: 2.5,
-                  px: 3,
-                  textTransform: 'none',
-                  fontSize: '1rem',
-                  fontWeight: 500,
-                  border: '2px solid',
-                  borderColor: 'divider',
-                  '&.Mui-selected': {
-                    backgroundColor: 'primary.main',
-                    color: 'primary.contrastText',
-                    borderColor: 'primary.main',
-                    '&:hover': {
-                      backgroundColor: 'primary.dark',
-                    }
-                  },
-                  '&:not(.Mui-selected)': {
-                    backgroundColor: 'background.paper',
-                    color: 'text.primary',
-                    '&:hover': {
-                      backgroundColor: 'action.hover',
-                    }
+            value={isUrlMode ? 'url' : 'file'}
+            exclusive
+            onChange={(e, newMode) => {
+              if (newMode !== null) {
+                handleModeToggle(newMode === 'url');
+              }
+            }}
+            fullWidth
+            sx={{
+              '& .MuiToggleButton-root': {
+                py: 2.5,
+                px: 3,
+                textTransform: 'none',
+                fontSize: '1rem',
+                fontWeight: 500,
+                border: '2px solid',
+                borderColor: 'divider',
+                '&.Mui-selected': {
+                  backgroundColor: 'primary.main',
+                  color: 'primary.contrastText',
+                  borderColor: 'primary.main',
+                  '&:hover': {
+                    backgroundColor: 'primary.dark'
+                  }
+                },
+                '&:not(.Mui-selected)': {
+                  backgroundColor: 'background.paper',
+                  color: 'text.primary',
+                  '&:hover': {
+                    backgroundColor: 'action.hover'
                   }
                 }
-              }}
-            >
+              }
+            }}>
+            
               <ToggleButton value="url" aria-label="subir contenido desde url">
                 Desde URL
               </ToggleButton>
@@ -737,7 +707,7 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
             </ToggleButtonGroup>
           </Box>
         </>
-      )}
+      }
 
       <form onSubmit={handleSubmit(onSubmit, (errors) => {
         console.error('Form validation errors:', errors);
@@ -750,301 +720,301 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
         });
       })}>
         {/* File or URL Input */}
-        {!isUrlMode ? (
-          <FormControl fullWidth error={!!errors.file} sx={{ mb: 3 }}>
+        {!isUrlMode ?
+        <FormControl fullWidth error={!!errors.file} sx={{ mb: 3 }}>
             <Typography variant="subtitle2" gutterBottom sx={{ fontWeight: 500 }}>
               Archivo:
             </Typography>
             <Box
-              onClick={() => fileInputRef.current?.click()}
-              onDragOver={handleFileDragOver}
-              onDragEnter={handleFileDragEnter}
-              onDragLeave={handleFileDragLeave}
-              onDrop={handleFileDrop}
-              sx={{
-                border: '2px dashed',
-                borderRadius: 1,
-                p: 2,
-                cursor: isUploading ? 'default' : 'pointer',
-                borderColor: isDragActive ? 'primary.main' : 'divider',
-                backgroundColor: isDragActive ? 'action.hover' : 'background.paper',
-                transition: 'background-color 0.15s ease, border-color 0.15s ease',
-              }}
-            >
+            onClick={() => fileInputRef.current?.click()}
+            onDragOver={handleFileDragOver}
+            onDragEnter={handleFileDragEnter}
+            onDragLeave={handleFileDragLeave}
+            onDrop={handleFileDrop}
+            sx={{
+              border: '2px dashed',
+              borderRadius: 1,
+              p: 2,
+              cursor: isUploading ? 'default' : 'pointer',
+              borderColor: isDragActive ? 'primary.main' : 'divider',
+              backgroundColor: isDragActive ? 'action.hover' : 'background.paper',
+              transition: 'background-color 0.15s ease, border-color 0.15s ease'
+            }}>
+            
               <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
                 <Button
-                  variant="outlined"
-                  sx={{ textTransform: 'none' }}
-                  disabled={isUploading}
-                >
+                variant="outlined"
+                sx={{ textTransform: 'none' }}
+                disabled={isUploading}>
+                
                   Seleccionar archivo
                 </Button>
                 <input
-                  type="file"
-                  {...fileInputRest}
-                  ref={(e) => {
-                    fileInputRef.current = e;
-                    fileInputRegisterRef(e);
-                  }}
-                  onChange={(e) => {
-                    fileInputOnChange(e);
-                    setHasSavedSuccessfully(false);
-                  }}
-                  style={{ display: 'none' }}
-                />
+                type="file"
+                {...fileInputRest}
+                ref={(e) => {
+                  fileInputRef.current = e;
+                  fileInputRegisterRef(e);
+                }}
+                onChange={(e) => {
+                  fileInputOnChange(e);
+                  setHasSavedSuccessfully(false);
+                }}
+                style={{ display: 'none' }} />
+              
                 <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-word' }}>
                   {watch('file')?.[0]?.name ? watch('file')[0].name : 'Ningún archivo seleccionado'}
                 </Typography>
               </Stack>
               {watch('file')?.[0] && (() => {
-                const inferredType = getMediaType(watch('file')[0]);
-                return inferredType ? (
-                  <Box sx={{ mt: 1.5, display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              const inferredType = getMediaType(watch('file')[0]);
+              return inferredType ?
+              <Box sx={{ mt: 1.5, display: 'flex', alignItems: 'center', gap: 0.5 }}>
                     <Typography variant="caption" color="text.secondary">Tipo detectado:</Typography>
                     <Chip
-                      size="small"
-                      label={MEDIA_TYPE_LABELS[inferredType] ?? inferredType}
-                      color="primary"
-                      variant="outlined"
-                    />
-                  </Box>
-                ) : null;
-              })()}
+                  size="small"
+                  label={MEDIA_TYPE_LABELS[inferredType] ?? inferredType}
+                  color="primary"
+                  variant="outlined" />
+                
+                  </Box> :
+              null;
+            })()}
               <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
                 O arrastra y suelta un archivo aquí
               </Typography>
             </Box>
-            {errors.file && (
-              <FormHelperText error>
+            {errors.file &&
+          <FormHelperText error>
                 {errors.file.message}
               </FormHelperText>
-            )}
-          </FormControl>
-        ) : (
-          <>
+          }
+          </FormControl> :
+
+        <>
             <FormControl fullWidth sx={{ mb: 3 }}>
               <TextField
-                label="URL"
-                variant="outlined"
-                {...register('url')}
-                value={watch('url') || ''}
-                error={!!errors.url}
-                helperText={errors.url?.message}
-                disabled={isLoadingPreview}
-                inputProps={{ onInput: () => setHasSavedSuccessfully(false) }}
-              />
+              label="URL"
+              variant="outlined"
+              {...register('url')}
+              value={watch('url') || ''}
+              error={!!errors.url}
+              helperText={errors.url?.message}
+              disabled={isLoadingPreview}
+              inputProps={{ onInput: () => setHasSavedSuccessfully(false) }} />
+            
             </FormControl>
             
             {/* URL Preview/Error - Show immediately below URL field */}
-            <URLPreview 
-              previewData={previewData}
-              isLoading={isLoadingPreview}
-              error={previewError}
-            />
+            <URLPreview
+            previewData={previewData}
+            isLoading={isLoadingPreview}
+            error={previewError} />
+          
             
             {/* Media Type Selector for URL Content */}
             <FormControl fullWidth error={!!errors.media_type} sx={{ mb: 3 }}>
               <InputLabel id="media-type-label">Tipo de contenido</InputLabel>
               <Select
-                labelId="media-type-label"
-                label="Tipo de contenido"
-                {...register('media_type')}
-                value={watch('media_type')}
-                onChange={(e) => {
-                  setValue('media_type', e.target.value);
-                  setHasSavedSuccessfully(false);
-                }}
-              >
+              labelId="media-type-label"
+              label="Tipo de contenido"
+              {...register('media_type')}
+              value={watch('media_type')}
+              onChange={(e) => {
+                setValue('media_type', e.target.value);
+                setHasSavedSuccessfully(false);
+              }}>
+              
                 <MenuItem value="VIDEO">Video</MenuItem>
                 <MenuItem value="AUDIO">Audio</MenuItem>
                 <MenuItem value="TEXT">Texto</MenuItem>
                 <MenuItem value="IMAGE">Imagen</MenuItem>
               </Select>
-              {errors.media_type && (
-                <FormHelperText error>
+              {errors.media_type &&
+            <FormHelperText error>
                   {errors.media_type.message}
                 </FormHelperText>
-              )}
+            }
             </FormControl>
           </>
-        )}
+        }
 
         {/* Common Fields: collapsible for file+image, otherwise always visible */}
-        {!isUrlMode && getMediaType(watch('file')?.[0]) === 'IMAGE' ? (
-          <Box sx={{ mb: 2 }}>
+        {!isUrlMode && getMediaType(watch('file')?.[0]) === 'IMAGE' ?
+        <Box sx={{ mb: 2 }}>
             <Button
-              fullWidth
-              onClick={() => setTitleAuthorExpanded((e) => !e)}
-              endIcon={titleAuthorExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-              sx={{
-                justifyContent: 'space-between',
-                textTransform: 'none',
-                color: 'text.secondary',
-                py: 1,
-                '&:hover': { backgroundColor: 'action.hover' },
-              }}
-            >
+            fullWidth
+            onClick={() => setTitleAuthorExpanded((e) => !e)}
+            endIcon={titleAuthorExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            sx={{
+              justifyContent: 'space-between',
+              textTransform: 'none',
+              color: 'text.secondary',
+              py: 1,
+              '&:hover': { backgroundColor: 'action.hover' }
+            }}>
+            
               Título y autor (opcional)
             </Button>
             <Collapse in={titleAuthorExpanded}>
               <Box sx={{ pl: 0, pr: 0, pt: 0, pb: 1 }}>
                 <FormControl fullWidth sx={{ mb: 2 }}>
                   <TextField
-                    label="Autor"
-                    variant="outlined"
-                    {...register('author')}
-                    value={watch('author') || ''}
-                    onChange={(e) => {
-                      setValue('author', e.target.value);
-                      setHasSavedSuccessfully(false);
-                    }}
-                    error={!!errors.author}
-                    helperText={errors.author?.message}
-                  />
+                  label="Autor"
+                  variant="outlined"
+                  {...register('author')}
+                  value={watch('author') || ''}
+                  onChange={(e) => {
+                    setValue('author', e.target.value);
+                    setHasSavedSuccessfully(false);
+                  }}
+                  error={!!errors.author}
+                  helperText={errors.author?.message} />
+                
                 </FormControl>
                 <FormControl fullWidth sx={{ mb: 0 }}>
                   <TextField
-                    label="Título"
-                    variant="outlined"
-                    {...register('title')}
-                    value={watch('title') || ''}
-                    onChange={(e) => {
-                      setValue('title', e.target.value);
-                      setHasSavedSuccessfully(false);
-                    }}
-                    error={!!errors.title}
-                    helperText={errors.title?.message}
-                  />
+                  label="Título"
+                  variant="outlined"
+                  {...register('title')}
+                  value={watch('title') || ''}
+                  onChange={(e) => {
+                    setValue('title', e.target.value);
+                    setHasSavedSuccessfully(false);
+                  }}
+                  error={!!errors.title}
+                  helperText={errors.title?.message} />
+                
                 </FormControl>
               </Box>
             </Collapse>
-          </Box>
-        ) : (
-          <>
+          </Box> :
+
+        <>
             <FormControl fullWidth sx={{ mb: 3 }}>
               <TextField
-                label="Autor"
-                variant="outlined"
-                {...register('author')}
-                value={watch('author') || ''}
-                onChange={(e) => {
-                  setValue('author', e.target.value);
-                  setHasSavedSuccessfully(false);
-                }}
-                error={!!errors.author}
-                helperText={errors.author?.message}
-              />
+              label="Autor"
+              variant="outlined"
+              {...register('author')}
+              value={watch('author') || ''}
+              onChange={(e) => {
+                setValue('author', e.target.value);
+                setHasSavedSuccessfully(false);
+              }}
+              error={!!errors.author}
+              helperText={errors.author?.message} />
+            
             </FormControl>
             <FormControl fullWidth sx={{ mb: 3 }}>
               <TextField
-                label="Título"
-                variant="outlined"
-                {...register('title')}
-                value={watch('title') || ''}
-                onChange={(e) => {
-                  setValue('title', e.target.value);
-                  setHasSavedSuccessfully(false);
-                }}
-                error={!!errors.title}
-                helperText={errors.title?.message}
-              />
+              label="Título"
+              variant="outlined"
+              {...register('title')}
+              value={watch('title') || ''}
+              onChange={(e) => {
+                setValue('title', e.target.value);
+                setHasSavedSuccessfully(false);
+              }}
+              error={!!errors.title}
+              helperText={errors.title?.message} />
+            
             </FormControl>
           </>
-        )}
+        }
 
         <Box sx={{ mb: 3 }}>
           <FormControlLabel
             control={
-              <Checkbox
-                checked={watch('has_spanish_subtitles')}
-                onChange={(e) => {
-                  setValue('has_spanish_subtitles', e.target.checked);
-                  setHasSavedSuccessfully(false);
-                }}
-                {...register('has_spanish_subtitles')}
-              />
+            <Checkbox
+              checked={watch('has_spanish_subtitles')}
+              onChange={(e) => {
+                setValue('has_spanish_subtitles', e.target.checked);
+                setHasSavedSuccessfully(false);
+              }}
+              {...register('has_spanish_subtitles')} />
+
             }
-            label="Tiene subtítulos en español"
-          />
+            label="Tiene subtítulos en español" />
+          
           <FormControlLabel
             control={
-              <Checkbox
-                checked={watch('has_spanish_dubbing')}
-                onChange={(e) => {
-                  setValue('has_spanish_dubbing', e.target.checked);
-                  setHasSavedSuccessfully(false);
-                }}
-                {...register('has_spanish_dubbing')}
-              />
+            <Checkbox
+              checked={watch('has_spanish_dubbing')}
+              onChange={(e) => {
+                setValue('has_spanish_dubbing', e.target.checked);
+                setHasSavedSuccessfully(false);
+              }}
+              {...register('has_spanish_dubbing')} />
+
             }
-            label="Está doblado al español"
-          />
+            label="Está doblado al español" />
+          
         </Box>
 
         {/* Producer and Visibility Options - Only for File Upload */}
-        {!isUrlMode && (
-          <Box sx={{ mt: 2 }}>
+        {!isUrlMode &&
+        <Box sx={{ mt: 2 }}>
             <FormControlLabel
-              control={
-                <Checkbox
-                  checked={watch('is_producer')}
-                  onChange={(e) => setValue('is_producer', e.target.checked)}
-                  {...register('is_producer')}
-                />
-              }
-              label="He producido este contenido"
-            />
-            {watch('is_producer') && (
-              <Box sx={{ ml: 3 }}>
+            control={
+            <Checkbox
+              checked={watch('is_producer')}
+              onChange={(e) => setValue('is_producer', e.target.checked)}
+              {...register('is_producer')} />
+
+            }
+            label="He producido este contenido" />
+          
+            {watch('is_producer') &&
+          <Box sx={{ ml: 3 }}>
                 <FormControlLabel
-                  control={
-                    <Switch
-                      checked={watch('is_visible')}
-                      onChange={(e) => setValue('is_visible', e.target.checked)}
-                      {...register('is_visible')}
-                    />
-                  }
-                  label="Visible en los resultados de búsqueda"
-                />
+              control={
+              <Switch
+                checked={watch('is_visible')}
+                onChange={(e) => setValue('is_visible', e.target.checked)}
+                {...register('is_visible')} />
+
+              }
+              label="Visible en los resultados de búsqueda" />
+            
                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
                   Nota: Solo el productor del contenido puede hacerlo invisible en los resultados de búsqueda.
                 </Typography>
               </Box>
-            )}
+          }
           </Box>
-        )        }
+        }
 
-        {isUploading && (
-          <Box sx={{ mt: 2 }}>
+        {isUploading &&
+        <Box sx={{ mt: 2 }}>
             <Stack direction="row" alignItems="center" spacing={2}>
               <LinearProgress
-                variant={uploadProgress !== null ? 'determinate' : 'indeterminate'}
-                value={uploadProgress ?? 0}
-                sx={{ flex: 1, height: 8, borderRadius: 1 }}
-              />
-              {uploadProgress !== null && (
-                <Typography variant="body2" color="text.secondary" sx={{ minWidth: 40 }}>
+              variant={uploadProgress !== null ? 'determinate' : 'indeterminate'}
+              value={uploadProgress ?? 0}
+              sx={{ flex: 1, height: 8, borderRadius: 1 }} />
+            
+              {uploadProgress !== null &&
+            <Typography variant="body2" color="text.secondary" sx={{ minWidth: 40 }}>
                   {uploadProgress}%
                 </Typography>
-              )}
+            }
             </Stack>
             <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-              {uploadProgress !== null
-                ? 'Subiendo archivo… no cierres esta pestaña.'
-                : 'Subiendo…'}
+              {uploadProgress !== null ?
+            'Subiendo archivo… no cierres esta pestaña.' :
+            'Subiendo…'}
             </Typography>
           </Box>
-        )}
+        }
 
-        {hasSavedSuccessfully && (
-          <Alert
-            icon={<CheckCircleIcon />}
-            severity="success"
-            sx={{ mt: 2 }}
-          >
+        {hasSavedSuccessfully &&
+        <Alert
+          icon={<CheckCircleIcon />}
+          severity="success"
+          sx={{ mt: 2 }}>
+          
             Guardado en tu biblioteca
           </Alert>
-        )}
+        }
 
         <Stack direction="row" spacing={2} sx={{ mt: 3 }}>
           <Button
@@ -1053,13 +1023,13 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
             color="primary"
             fullWidth
             disabled={isUploading || isLoadingPreview || hasSavedSuccessfully}
-            startIcon={isUploading ? <CircularProgress size={20} color="inherit" /> : null}
-          >
-            {isUploading
-              ? 'Subiendo...'
-              : hasSavedSuccessfully
-                ? (isEditMode ? 'Contenido actualizado' : 'Contenido guardado')
-                : (isEditMode ? 'Actualizar contenido' : 'Guardar Contenido')}
+            startIcon={isUploading ? <CircularProgress size={20} color="inherit" /> : null}>
+            
+            {isUploading ?
+            'Subiendo...' :
+            hasSavedSuccessfully ?
+            isEditMode ? 'Contenido actualizado' : 'Contenido guardado' :
+            isEditMode ? 'Actualizar contenido' : 'Guardar Contenido'}
           </Button>
         </Stack>
       </form>
@@ -1068,18 +1038,18 @@ const UploadContentForm = ({ onContentUploaded, initialData = null, isEditMode =
         open={snackbar.open}
         autoHideDuration={6000}
         onClose={() => setSnackbar({ ...snackbar, open: false })}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert 
-          onClose={() => setSnackbar({ ...snackbar, open: false })} 
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+        
+        <Alert
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
           severity={snackbar.severity}
-          sx={{ width: '100%' }}
-        >
+          sx={{ width: '100%' }}>
+          
           {snackbar.message}
         </Alert>
       </Snackbar>
-    </Paper>
-  );
+    </Paper>);
+
 };
 
-export default UploadContentForm; 
+export default UploadContentForm;

--- a/frontend/src/knowledgePaths/KnowledgePathList.jsx
+++ b/frontend/src/knowledgePaths/KnowledgePathList.jsx
@@ -11,8 +11,8 @@ import {
   Button,
   CircularProgress,
   Alert,
-  Stack,
-} from '@mui/material';
+  Stack } from
+'@mui/material';
 import knowledgePathsApi from '../api/knowledgePathsApi';
 import VoteComponent from '../votes/VoteComponent';
 import { AuthContext } from '../context/AuthContext';
@@ -31,9 +31,8 @@ const KnowledgePathList = () => {
     const fetchKnowledgePaths = async () => {
       try {
         const data = await knowledgePathsApi.getKnowledgePaths(currentPage);
-        console.log('API Response:', data);
-        console.log('Knowledge Paths:', data.results);
-        
+
+
         // Safety check: ensure data.results is always an array
         const results = Array.isArray(data.results) ? data.results : [];
         // Sort by vote count (descending) so the most voted paths appear first.
@@ -54,7 +53,7 @@ const KnowledgePathList = () => {
         });
 
         setKnowledgePaths(sortedResults);
-        
+
         setTotalPages(Math.ceil((data.count || 0) / 9));
         setHasNext(!!data.next);
         setHasPrevious(!!data.previous);
@@ -80,8 +79,8 @@ const KnowledgePathList = () => {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
         <CircularProgress />
-      </Box>
-    );
+      </Box>);
+
   }
 
   if (error) {
@@ -90,8 +89,8 @@ const KnowledgePathList = () => {
         <Alert severity="error" sx={{ mt: 2 }}>
           {error}
         </Alert>
-      </Container>
-    );
+      </Container>);
+
   }
 
   return (
@@ -102,59 +101,48 @@ const KnowledgePathList = () => {
           justifyContent: 'space-between',
           alignItems: 'center',
           mb: 3,
-          flexWrap: { xs: 'wrap', md: 'nowrap' },
-        }}
-      >
+          flexWrap: { xs: 'wrap', md: 'nowrap' }
+        }}>
+        
         <Typography variant="h4" component="h1" sx={{ mb: { xs: 2, md: 0 } }}>
           Caminos de Conocimiento
         </Typography>
-        {authState.isAuthenticated && (
-          <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} alignItems="center" sx={{ width: { xs: '100%', md: 'auto' } }}>
+        {authState.isAuthenticated &&
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} alignItems="center" sx={{ width: { xs: '100%', md: 'auto' } }}>
             <Link
-              to="/profiles/my_profile?section=knowledge-paths"
-              style={{ textDecoration: 'none' }}
-            >
+            to="/profiles/my_profile?section=knowledge-paths"
+            style={{ textDecoration: 'none' }}>
+            
               <Typography
-                component="span"
-                sx={{
-                  color: 'primary.main',
-                  '&:hover': { textDecoration: 'underline' },
-                }}
-              >
+              component="span"
+              sx={{
+                color: 'primary.main',
+                '&:hover': { textDecoration: 'underline' }
+              }}>
+              
                 Mis caminos del Conocimiento
               </Typography>
             </Link>
             <Button
-              component={Link}
-              to="/knowledge_path/create"
-              variant="contained"
-              color="primary"
-              sx={{
-                textDecoration: 'none',
-                width: { xs: '100%', md: 'auto' },
-              }}
-            >
+            component={Link}
+            to="/knowledge_path/create"
+            variant="contained"
+            color="primary"
+            sx={{
+              textDecoration: 'none',
+              width: { xs: '100%', md: 'auto' }
+            }}>
+            
               Crear Nuevo Camino
             </Button>
           </Stack>
-        )}
+        }
       </Box>
 
       <Grid container spacing={3}>
         {(knowledgePaths || []).map((path) => {
-          console.log('=== KnowledgePathList: VoteComponent props ===');
-          console.log('VoteComponent props:', {
-            type: 'knowledge_path',
-            ids: { pathId: path.id },
-            initialVoteCount: path.vote_count,
-            initialUserVote: path.user_vote,
-            voteCountType: typeof path.vote_count,
-            userVoteType: typeof path.user_vote,
-            voteCountValue: path.vote_count,
-            userVoteValue: path.user_vote
-          });
-          console.log('=== End KnowledgePathList VoteComponent props ===');
-          
+
+
           return (
             <Grid item xs={12} sm={6} lg={4} key={path.id}>
               <Card
@@ -163,42 +151,42 @@ const KnowledgePathList = () => {
                   display: 'flex',
                   flexDirection: 'column',
                   '&:hover': {
-                    boxShadow: 4,
-                  },
-                }}
-              >
+                    boxShadow: 4
+                  }
+                }}>
+                
                 {/* Cover Image */}
-                {(path.image_preview || path.image) ? (
-                  <CardMedia
-                    component="img"
-                    height="140"
-                    loading="lazy"
-                    image={path.image_preview || path.image}
-                    alt={path.title}
-                    sx={{
-                      objectFit: 'cover',
-                      objectPosition: path.image_focal_x != null && path.image_focal_y != null
-                        ? `${(path.image_focal_x * 100).toFixed(1)}% ${(path.image_focal_y * 100).toFixed(1)}%`
-                        : '50% 50%',
-                    }}
-                  />
-                ) : (
-                  <Box
-                    sx={{
-                      width: '100%',
-                      height: 140,
-                      bgcolor: 'grey.300',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      fontSize: '3rem',
-                      color: 'text.secondary',
-                      fontWeight: 700,
-                    }}
-                  >
+                {path.image_preview || path.image ?
+                <CardMedia
+                  component="img"
+                  height="140"
+                  loading="lazy"
+                  image={path.image_preview || path.image}
+                  alt={path.title}
+                  sx={{
+                    objectFit: 'cover',
+                    objectPosition: path.image_focal_x != null && path.image_focal_y != null ?
+                    `${(path.image_focal_x * 100).toFixed(1)}% ${(path.image_focal_y * 100).toFixed(1)}%` :
+                    '50% 50%'
+                  }} /> :
+
+
+                <Box
+                  sx={{
+                    width: '100%',
+                    height: 140,
+                    bgcolor: 'grey.300',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: '3rem',
+                    color: 'text.secondary',
+                    fontWeight: 700
+                  }}>
+                  
                     {path.title.charAt(0).toUpperCase()}
                   </Box>
-                )}
+                }
                 
                 <CardContent sx={{ flexGrow: 1 }}>
                   <Box sx={{ mb: 2 }}>
@@ -212,11 +200,11 @@ const KnowledgePathList = () => {
                         textDecoration: 'none',
                         color: 'text.primary',
                         '&:hover': {
-                          color: 'primary.main',
+                          color: 'primary.main'
                         },
-                        wordBreak: 'break-word',
-                      }}
-                    >
+                        wordBreak: 'break-word'
+                      }}>
+                      
                       {path.title}
                     </Typography>
 
@@ -228,9 +216,9 @@ const KnowledgePathList = () => {
                         display: '-webkit-box',
                         WebkitLineClamp: 3,
                         WebkitBoxOrient: 'vertical',
-                        overflow: 'hidden',
-                      }}
-                    >
+                        overflow: 'hidden'
+                      }}>
+                      
                       {path.description}
                     </Typography>
 
@@ -239,8 +227,8 @@ const KnowledgePathList = () => {
                         type="knowledge_path"
                         ids={{ pathId: path.id }}
                         initialVoteCount={Number(path.vote_count) || 0}
-                        initialUserVote={Number(path.user_vote) || 0}
-                      />
+                        initialUserVote={Number(path.user_vote) || 0} />
+                      
                     </Box>
                   </Box>
 
@@ -252,9 +240,9 @@ const KnowledgePathList = () => {
                       mt: 2,
                       pt: 2,
                       borderTop: 1,
-                      borderColor: 'divider',
-                    }}
-                  >
+                      borderColor: 'divider'
+                    }}>
+                    
                     <Typography
                       component={Link}
                       to={`/profiles/user_profile/${path.author_id}`}
@@ -263,10 +251,10 @@ const KnowledgePathList = () => {
                       sx={{
                         textDecoration: 'none',
                         '&:hover': {
-                          color: 'primary.main',
-                        },
-                      }}
-                    >
+                          color: 'primary.main'
+                        }
+                      }}>
+                      
                       Por {path.author}
                     </Typography>
                     <Typography variant="caption" color="text.secondary">
@@ -275,37 +263,37 @@ const KnowledgePathList = () => {
                   </Box>
                 </CardContent>
               </Card>
-            </Grid>
-          );
+            </Grid>);
+
         })}
       </Grid>
 
       {/* Pagination Controls */}
-      {totalPages > 1 && (
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            gap: 2,
-            mt: 4,
-          }}
-        >
+      {totalPages > 1 &&
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: 2,
+          mt: 4
+        }}>
+        
           <Button
-            onClick={() => handlePageChange(currentPage - 1)}
-            disabled={!hasPrevious}
-            variant="contained"
-            color={hasPrevious ? 'primary' : 'inherit'}
-            sx={{
-              bgcolor: hasPrevious ? 'primary.main' : 'grey.300',
-              color: hasPrevious ? 'white' : 'text.disabled',
-              textTransform: 'none',
-              '&:disabled': {
-                bgcolor: 'grey.300',
-                color: 'text.disabled',
-              },
-            }}
-          >
+          onClick={() => handlePageChange(currentPage - 1)}
+          disabled={!hasPrevious}
+          variant="contained"
+          color={hasPrevious ? 'primary' : 'inherit'}
+          sx={{
+            bgcolor: hasPrevious ? 'primary.main' : 'grey.300',
+            color: hasPrevious ? 'white' : 'text.disabled',
+            textTransform: 'none',
+            '&:disabled': {
+              bgcolor: 'grey.300',
+              color: 'text.disabled'
+            }
+          }}>
+          
             Anterior
           </Button>
           
@@ -314,26 +302,26 @@ const KnowledgePathList = () => {
           </Typography>
           
           <Button
-            onClick={() => handlePageChange(currentPage + 1)}
-            disabled={!hasNext}
-            variant="contained"
-            color={hasNext ? 'primary' : 'inherit'}
-            sx={{
-              bgcolor: hasNext ? 'primary.main' : 'grey.300',
-              color: hasNext ? 'white' : 'text.disabled',
-              textTransform: 'none',
-              '&:disabled': {
-                bgcolor: 'grey.300',
-                color: 'text.disabled',
-              },
-            }}
-          >
+          onClick={() => handlePageChange(currentPage + 1)}
+          disabled={!hasNext}
+          variant="contained"
+          color={hasNext ? 'primary' : 'inherit'}
+          sx={{
+            bgcolor: hasNext ? 'primary.main' : 'grey.300',
+            color: hasNext ? 'white' : 'text.disabled',
+            textTransform: 'none',
+            '&:disabled': {
+              bgcolor: 'grey.300',
+              color: 'text.disabled'
+            }
+          }}>
+          
             Siguiente
           </Button>
         </Box>
-      )}
-    </Container>
-  );
+      }
+    </Container>);
+
 };
 
 export default KnowledgePathList;

--- a/frontend/src/knowledgePaths/KnowledgePathsUser.jsx
+++ b/frontend/src/knowledgePaths/KnowledgePathsUser.jsx
@@ -14,8 +14,8 @@ import {
   Button,
   Stack,
   CircularProgress,
-  Alert,
-} from '@mui/material';
+  Alert } from
+'@mui/material';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import EditIcon from '@mui/icons-material/Edit';
@@ -25,7 +25,7 @@ import VoteComponent from '../votes/VoteComponent';
 
 const KnowledgePathsUser = () => {
   const [activeTab, setActiveTab] = useState(0); // 0 = Created, 1 = Engaged
-  
+
   // Created knowledge paths state
   const [createdPaths, setCreatedPaths] = useState([]);
   const [createdLoading, setCreatedLoading] = useState(true);
@@ -34,7 +34,7 @@ const KnowledgePathsUser = () => {
   const [createdTotalPages, setCreatedTotalPages] = useState(1);
   const [createdHasNext, setCreatedHasNext] = useState(false);
   const [createdHasPrevious, setCreatedHasPrevious] = useState(false);
-  
+
   // Engaged knowledge paths state
   const [engagedPaths, setEngagedPaths] = useState([]);
   const [engagedLoading, setEngagedLoading] = useState(true);
@@ -48,7 +48,7 @@ const KnowledgePathsUser = () => {
     const fetchCreatedKnowledgePaths = async () => {
       try {
         const data = await knowledgePathsApi.getUserKnowledgePaths(createdCurrentPage);
-        console.log('Created Knowledge Paths API Response:', data);
+
         setCreatedPaths(data.results);
         setCreatedTotalPages(Math.ceil(data.count / 9));
         setCreatedHasNext(!!data.next);
@@ -64,7 +64,7 @@ const KnowledgePathsUser = () => {
     const fetchEngagedKnowledgePaths = async () => {
       try {
         const data = await knowledgePathsApi.getUserEngagedKnowledgePaths(engagedCurrentPage);
-        console.log('Engaged Knowledge Paths API Response:', data);
+
         setEngagedPaths(data.results);
         setEngagedTotalPages(Math.ceil(data.count / 9));
         setEngagedHasNext(!!data.next);
@@ -102,8 +102,8 @@ const KnowledgePathsUser = () => {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
         <CircularProgress />
-      </Box>
-    );
+      </Box>);
+
   }
 
   return (
@@ -114,9 +114,9 @@ const KnowledgePathsUser = () => {
           justifyContent: 'space-between',
           alignItems: 'center',
           mb: 3,
-          flexWrap: { xs: 'wrap', md: 'nowrap' },
-        }}
-      >
+          flexWrap: { xs: 'wrap', md: 'nowrap' }
+        }}>
+        
         <Typography variant="h4" component="h1" sx={{ mb: { xs: 2, md: 0 } }}>
           Caminos de Conocimiento
         </Typography>
@@ -126,8 +126,8 @@ const KnowledgePathsUser = () => {
             to="/knowledge_path"
             variant="outlined"
             color="primary"
-            sx={{ textTransform: 'none', width: { xs: '100%', md: 'auto' } }}
-          >
+            sx={{ textTransform: 'none', width: { xs: '100%', md: 'auto' } }}>
+            
             Ver Todos los Caminos
           </Button>
           <Button
@@ -135,8 +135,8 @@ const KnowledgePathsUser = () => {
             to="/knowledge_path/create"
             variant="contained"
             color="primary"
-            sx={{ textTransform: 'none', width: { xs: '100%', md: 'auto' } }}
-          >
+            sx={{ textTransform: 'none', width: { xs: '100%', md: 'auto' } }}>
+            
             Crear Nuevo Camino
           </Button>
         </Stack>
@@ -151,67 +151,67 @@ const KnowledgePathsUser = () => {
       </Box>
 
       {/* Error State */}
-      {currentError && (
-        <Alert severity="error" sx={{ mt: 2 }}>
+      {currentError &&
+      <Alert severity="error" sx={{ mt: 2 }}>
           {currentError}
         </Alert>
-      )}
+      }
 
       {/* Created Knowledge Paths Tab - same card layout as KnowledgePathList */}
-      {activeTab === 0 && !currentError && (
-        <Box>
+      {activeTab === 0 && !currentError &&
+      <Box>
           <Grid container spacing={3}>
-            {createdPaths.map((path) => (
-              <Grid item xs={12} sm={6} lg={4} key={path.id}>
+            {createdPaths.map((path) =>
+          <Grid item xs={12} sm={6} lg={4} key={path.id}>
                 <Card
-                  sx={{
-                    height: '100%',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    '&:hover': { boxShadow: 4 },
-                  }}
-                >
+              sx={{
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                '&:hover': { boxShadow: 4 }
+              }}>
+              
                   <Box sx={{ position: 'relative' }}>
-                    {(path.image_preview || path.image) ? (
-                      <CardMedia
-                        component="img"
-                        height="140"
-                        loading="lazy"
-                        image={path.image_preview || path.image}
-                        alt={path.title}
-                        sx={{
-                          objectFit: 'cover',
-                          objectPosition: path.image_focal_x != null && path.image_focal_y != null
-                            ? `${(path.image_focal_x * 100).toFixed(1)}% ${(path.image_focal_y * 100).toFixed(1)}%`
-                            : '50% 50%',
-                        }}
-                      />
-                    ) : (
-                      <Box
-                        sx={{
-                          width: '100%',
-                          height: 140,
-                          bgcolor: 'grey.300',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          fontSize: '3rem',
-                          color: 'text.secondary',
-                          fontWeight: 700,
-                        }}
-                      >
+                    {path.image_preview || path.image ?
+                <CardMedia
+                  component="img"
+                  height="140"
+                  loading="lazy"
+                  image={path.image_preview || path.image}
+                  alt={path.title}
+                  sx={{
+                    objectFit: 'cover',
+                    objectPosition: path.image_focal_x != null && path.image_focal_y != null ?
+                    `${(path.image_focal_x * 100).toFixed(1)}% ${(path.image_focal_y * 100).toFixed(1)}%` :
+                    '50% 50%'
+                  }} /> :
+
+
+                <Box
+                  sx={{
+                    width: '100%',
+                    height: 140,
+                    bgcolor: 'grey.300',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: '3rem',
+                    color: 'text.secondary',
+                    fontWeight: 700
+                  }}>
+                  
                         {path.title.charAt(0).toUpperCase()}
                       </Box>
-                    )}
+                }
                     <Box sx={{ position: 'absolute', top: 8, right: 8, bgcolor: 'rgba(255,255,255,0.9)', borderRadius: 1 }}>
                       <Button
-                        component={Link}
-                        to={`/knowledge_path/${path.id}/edit`}
-                        variant="outlined"
-                        size="small"
-                        startIcon={<EditIcon />}
-                        sx={{ textTransform: 'none', minWidth: 'auto' }}
-                      >
+                    component={Link}
+                    to={`/knowledge_path/${path.id}/edit`}
+                    variant="outlined"
+                    size="small"
+                    startIcon={<EditIcon />}
+                    sx={{ textTransform: 'none', minWidth: 'auto' }}>
+                    
                         Editar
                       </Button>
                     </Box>
@@ -219,62 +219,62 @@ const KnowledgePathsUser = () => {
                   <CardContent sx={{ flexGrow: 1 }}>
                     <Box sx={{ mb: 2 }}>
                       <Typography
-                        component={Link}
-                        to={`/knowledge_path/${path.id}`}
-                        variant="h5"
-                        sx={{
-                          display: 'block',
-                          mb: 1,
-                          textDecoration: 'none',
-                          color: 'text.primary',
-                          '&:hover': { color: 'primary.main' },
-                          wordBreak: 'break-word',
-                        }}
-                      >
+                    component={Link}
+                    to={`/knowledge_path/${path.id}`}
+                    variant="h5"
+                    sx={{
+                      display: 'block',
+                      mb: 1,
+                      textDecoration: 'none',
+                      color: 'text.primary',
+                      '&:hover': { color: 'primary.main' },
+                      wordBreak: 'break-word'
+                    }}>
+                    
                         {path.title}
                       </Typography>
                       <Box sx={{ mb: 1.5 }}>
                         <Chip
-                          icon={path.is_visible ? <VisibilityIcon /> : <VisibilityOffIcon />}
-                          label={path.is_visible ? 'Público' : 'Privado'}
-                          color={path.is_visible ? 'success' : 'default'}
-                          size="small"
-                          variant="outlined"
-                        />
+                      icon={path.is_visible ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                      label={path.is_visible ? 'Público' : 'Privado'}
+                      color={path.is_visible ? 'success' : 'default'}
+                      size="small"
+                      variant="outlined" />
+                    
                       </Box>
                       <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{
-                          mb: 2,
-                          display: '-webkit-box',
-                          WebkitLineClamp: 3,
-                          WebkitBoxOrient: 'vertical',
-                          overflow: 'hidden',
-                        }}
-                      >
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                      mb: 2,
+                      display: '-webkit-box',
+                      WebkitLineClamp: 3,
+                      WebkitBoxOrient: 'vertical',
+                      overflow: 'hidden'
+                    }}>
+                    
                         {path.description}
                       </Typography>
                       <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
                         <VoteComponent
-                          type="knowledge_path"
-                          ids={{ pathId: path.id }}
-                          initialVoteCount={Number(path.vote_count) || 0}
-                          initialUserVote={Number(path.user_vote) || 0}
-                        />
+                      type="knowledge_path"
+                      ids={{ pathId: path.id }}
+                      initialVoteCount={Number(path.vote_count) || 0}
+                      initialUserVote={Number(path.user_vote) || 0} />
+                    
                       </Box>
                     </Box>
                     <Box
-                      sx={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        mt: 2,
-                        pt: 2,
-                        borderTop: 1,
-                        borderColor: 'divider',
-                      }}
-                    >
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    mt: 2,
+                    pt: 2,
+                    borderTop: 1,
+                    borderColor: 'divider'
+                  }}>
+                  
                       <Typography variant="caption" color="text.secondary">
                         Por {path.author}
                       </Typography>
@@ -285,10 +285,10 @@ const KnowledgePathsUser = () => {
                   </CardContent>
                 </Card>
               </Grid>
-            ))}
+          )}
           </Grid>
-          {createdPaths.length === 0 && (
-            <Box sx={{ textAlign: 'center', py: 8 }}>
+          {createdPaths.length === 0 &&
+        <Box sx={{ textAlign: 'center', py: 8 }}>
               <Typography variant="h6" sx={{ fontWeight: 600, color: 'text.secondary', mb: 2 }}>
                 Aún no has creado caminos de conocimiento
               </Typography>
@@ -299,147 +299,147 @@ const KnowledgePathsUser = () => {
                 Crear Tu Primer Camino
               </Button>
             </Box>
-          )}
-          {createdTotalPages > 1 && (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2, mt: 4 }}>
+        }
+          {createdTotalPages > 1 &&
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2, mt: 4 }}>
               <Button
-                onClick={() => handleCreatedPageChange(createdCurrentPage - 1)}
-                disabled={!createdHasPrevious}
-                variant="contained"
-                color={createdHasPrevious ? 'primary' : 'inherit'}
-                sx={{
-                  bgcolor: createdHasPrevious ? 'primary.main' : 'grey.300',
-                  color: createdHasPrevious ? 'white' : 'text.disabled',
-                  textTransform: 'none',
-                  '&:disabled': { bgcolor: 'grey.300', color: 'text.disabled' },
-                }}
-              >
+            onClick={() => handleCreatedPageChange(createdCurrentPage - 1)}
+            disabled={!createdHasPrevious}
+            variant="contained"
+            color={createdHasPrevious ? 'primary' : 'inherit'}
+            sx={{
+              bgcolor: createdHasPrevious ? 'primary.main' : 'grey.300',
+              color: createdHasPrevious ? 'white' : 'text.disabled',
+              textTransform: 'none',
+              '&:disabled': { bgcolor: 'grey.300', color: 'text.disabled' }
+            }}>
+            
                 Anterior
               </Button>
               <Typography variant="body2" color="text.secondary">
                 Página {createdCurrentPage} de {createdTotalPages}
               </Typography>
               <Button
-                onClick={() => handleCreatedPageChange(createdCurrentPage + 1)}
-                disabled={!createdHasNext}
-                variant="contained"
-                color={createdHasNext ? 'primary' : 'inherit'}
-                sx={{
-                  bgcolor: createdHasNext ? 'primary.main' : 'grey.300',
-                  color: createdHasNext ? 'white' : 'text.disabled',
-                  textTransform: 'none',
-                  '&:disabled': { bgcolor: 'grey.300', color: 'text.disabled' },
-                }}
-              >
+            onClick={() => handleCreatedPageChange(createdCurrentPage + 1)}
+            disabled={!createdHasNext}
+            variant="contained"
+            color={createdHasNext ? 'primary' : 'inherit'}
+            sx={{
+              bgcolor: createdHasNext ? 'primary.main' : 'grey.300',
+              color: createdHasNext ? 'white' : 'text.disabled',
+              textTransform: 'none',
+              '&:disabled': { bgcolor: 'grey.300', color: 'text.disabled' }
+            }}>
+            
                 Siguiente
               </Button>
             </Box>
-          )}
+        }
         </Box>
-      )}
+      }
 
       {/* Engaged Knowledge Paths Tab - same card layout as KnowledgePathList */}
-      {activeTab === 1 && !currentError && (
-        <Box>
+      {activeTab === 1 && !currentError &&
+      <Box>
           <Grid container spacing={3}>
-            {engagedPaths.map((path) => (
-              <Grid item xs={12} sm={6} lg={4} key={path.id}>
+            {engagedPaths.map((path) =>
+          <Grid item xs={12} sm={6} lg={4} key={path.id}>
                 <Card
-                  sx={{
-                    height: '100%',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    '&:hover': { boxShadow: 4 },
-                  }}
-                >
-                  {(path.image_preview || path.image) ? (
-                    <CardMedia
-                      component="img"
-                      height="140"
-                      loading="lazy"
-                      image={path.image_preview || path.image}
-                      alt={path.title}
-                      sx={{
-                        objectFit: 'cover',
-                        objectPosition: path.image_focal_x != null && path.image_focal_y != null
-                          ? `${(path.image_focal_x * 100).toFixed(1)}% ${(path.image_focal_y * 100).toFixed(1)}%`
-                          : '50% 50%',
-                      }}
-                    />
-                  ) : (
-                    <Box
-                      sx={{
-                        width: '100%',
-                        height: 140,
-                        bgcolor: 'grey.300',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontSize: '3rem',
-                        color: 'text.secondary',
-                        fontWeight: 700,
-                      }}
-                    >
+              sx={{
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                '&:hover': { boxShadow: 4 }
+              }}>
+              
+                  {path.image_preview || path.image ?
+              <CardMedia
+                component="img"
+                height="140"
+                loading="lazy"
+                image={path.image_preview || path.image}
+                alt={path.title}
+                sx={{
+                  objectFit: 'cover',
+                  objectPosition: path.image_focal_x != null && path.image_focal_y != null ?
+                  `${(path.image_focal_x * 100).toFixed(1)}% ${(path.image_focal_y * 100).toFixed(1)}%` :
+                  '50% 50%'
+                }} /> :
+
+
+              <Box
+                sx={{
+                  width: '100%',
+                  height: 140,
+                  bgcolor: 'grey.300',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '3rem',
+                  color: 'text.secondary',
+                  fontWeight: 700
+                }}>
+                
                       {path.title.charAt(0).toUpperCase()}
                     </Box>
-                  )}
+              }
                   <CardContent sx={{ flexGrow: 1 }}>
                     <Box sx={{ mb: 2 }}>
                       <Typography
-                        component={Link}
-                        to={`/knowledge_path/${path.id}`}
-                        variant="h5"
-                        sx={{
-                          display: 'block',
-                          mb: 1.5,
-                          textDecoration: 'none',
-                          color: 'text.primary',
-                          '&:hover': { color: 'primary.main' },
-                          wordBreak: 'break-word',
-                        }}
-                      >
+                    component={Link}
+                    to={`/knowledge_path/${path.id}`}
+                    variant="h5"
+                    sx={{
+                      display: 'block',
+                      mb: 1.5,
+                      textDecoration: 'none',
+                      color: 'text.primary',
+                      '&:hover': { color: 'primary.main' },
+                      wordBreak: 'break-word'
+                    }}>
+                    
                         {path.title}
                       </Typography>
                       <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{
-                          mb: 2,
-                          display: '-webkit-box',
-                          WebkitLineClamp: 3,
-                          WebkitBoxOrient: 'vertical',
-                          overflow: 'hidden',
-                        }}
-                      >
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{
+                      mb: 2,
+                      display: '-webkit-box',
+                      WebkitLineClamp: 3,
+                      WebkitBoxOrient: 'vertical',
+                      overflow: 'hidden'
+                    }}>
+                    
                         {path.description}
                       </Typography>
                       <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
                         <VoteComponent
-                          type="knowledge_path"
-                          ids={{ pathId: path.id }}
-                          initialVoteCount={Number(path.vote_count) || 0}
-                          initialUserVote={Number(path.user_vote) || 0}
-                        />
+                      type="knowledge_path"
+                      ids={{ pathId: path.id }}
+                      initialVoteCount={Number(path.vote_count) || 0}
+                      initialUserVote={Number(path.user_vote) || 0} />
+                    
                       </Box>
                     </Box>
                     <Box
-                      sx={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        mt: 2,
-                        pt: 2,
-                        borderTop: 1,
-                        borderColor: 'divider',
-                      }}
-                    >
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    mt: 2,
+                    pt: 2,
+                    borderTop: 1,
+                    borderColor: 'divider'
+                  }}>
+                  
                       <Typography
-                        component={Link}
-                        to={path.author_id ? `/profiles/user_profile/${path.author_id}` : '#'}
-                        variant="caption"
-                        color="text.secondary"
-                        sx={{ textDecoration: 'none', '&:hover': { color: 'primary.main' } }}
-                      >
+                    component={Link}
+                    to={path.author_id ? `/profiles/user_profile/${path.author_id}` : '#'}
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ textDecoration: 'none', '&:hover': { color: 'primary.main' } }}>
+                    
                         Por {path.author}
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
@@ -449,10 +449,10 @@ const KnowledgePathsUser = () => {
                   </CardContent>
                 </Card>
               </Grid>
-            ))}
+          )}
           </Grid>
-          {engagedPaths.length === 0 && (
-            <Box sx={{ textAlign: 'center', py: 8 }}>
+          {engagedPaths.length === 0 &&
+        <Box sx={{ textAlign: 'center', py: 8 }}>
               <Typography variant="h6" sx={{ fontWeight: 600, color: 'text.secondary', mb: 2 }}>
                 Aún no participas en caminos de conocimiento
               </Typography>
@@ -463,46 +463,46 @@ const KnowledgePathsUser = () => {
                 Explorar Caminos de Conocimiento
               </Button>
             </Box>
-          )}
-          {engagedTotalPages > 1 && (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2, mt: 4 }}>
+        }
+          {engagedTotalPages > 1 &&
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2, mt: 4 }}>
               <Button
-                onClick={() => handleEngagedPageChange(engagedCurrentPage - 1)}
-                disabled={!engagedHasPrevious}
-                variant="contained"
-                color={engagedHasPrevious ? 'primary' : 'inherit'}
-                sx={{
-                  bgcolor: engagedHasPrevious ? 'primary.main' : 'grey.300',
-                  color: engagedHasPrevious ? 'white' : 'text.disabled',
-                  textTransform: 'none',
-                  '&:disabled': { bgcolor: 'grey.300', color: 'text.disabled' },
-                }}
-              >
+            onClick={() => handleEngagedPageChange(engagedCurrentPage - 1)}
+            disabled={!engagedHasPrevious}
+            variant="contained"
+            color={engagedHasPrevious ? 'primary' : 'inherit'}
+            sx={{
+              bgcolor: engagedHasPrevious ? 'primary.main' : 'grey.300',
+              color: engagedHasPrevious ? 'white' : 'text.disabled',
+              textTransform: 'none',
+              '&:disabled': { bgcolor: 'grey.300', color: 'text.disabled' }
+            }}>
+            
                 Anterior
               </Button>
               <Typography variant="body2" color="text.secondary">
                 Página {engagedCurrentPage} de {engagedTotalPages}
               </Typography>
               <Button
-                onClick={() => handleEngagedPageChange(engagedCurrentPage + 1)}
-                disabled={!engagedHasNext}
-                variant="contained"
-                color={engagedHasNext ? 'primary' : 'inherit'}
-                sx={{
-                  bgcolor: engagedHasNext ? 'primary.main' : 'grey.300',
-                  color: engagedHasNext ? 'white' : 'text.disabled',
-                  textTransform: 'none',
-                  '&:disabled': { bgcolor: 'grey.300', color: 'text.disabled' },
-                }}
-              >
+            onClick={() => handleEngagedPageChange(engagedCurrentPage + 1)}
+            disabled={!engagedHasNext}
+            variant="contained"
+            color={engagedHasNext ? 'primary' : 'inherit'}
+            sx={{
+              bgcolor: engagedHasNext ? 'primary.main' : 'grey.300',
+              color: engagedHasNext ? 'white' : 'text.disabled',
+              textTransform: 'none',
+              '&:disabled': { bgcolor: 'grey.300', color: 'text.disabled' }
+            }}>
+            
                 Siguiente
               </Button>
             </Box>
-          )}
+        }
         </Box>
-      )}
-    </Container>
-  );
+      }
+    </Container>);
+
 };
 
-export default KnowledgePathsUser; 
+export default KnowledgePathsUser;

--- a/frontend/src/knowledgePaths/NodeCreate.jsx
+++ b/frontend/src/knowledgePaths/NodeCreate.jsx
@@ -8,8 +8,8 @@ import {
   Button,
   Alert,
   CircularProgress,
-  Stack,
-} from '@mui/material';
+  Stack } from
+'@mui/material';
 import knowledgePathsApi from '../api/knowledgePathsApi';
 import ContentSelector from '../content/ContentSelector';
 
@@ -45,25 +45,23 @@ const NodeCreate = () => {
   }, [pathId]);
 
   const handleContentSelected = useCallback((content_profile) => {
-    console.log('Selected content profile:', content_profile);
-    console.log('Content profile title:', content_profile.title);
-    console.log('Content profile original title:', content_profile.content?.original_title);
-    
+
+
     setSelectedContent(content_profile);
-    setFormData(prev => {
+    setFormData((prev) => {
       const newFormData = {
         ...prev,
         content_profile_id: content_profile.id,
         title: prev.title || content_profile.title || content_profile.content?.original_title || 'Untitled'
       };
-      console.log('New form data being set:', newFormData);
+
       return newFormData;
     });
   }, []);
 
   const handleContentRemoved = useCallback(() => {
     setSelectedContent(null);
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
       content_profile_id: null
     }));
@@ -95,16 +93,16 @@ const NodeCreate = () => {
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
           <CircularProgress />
         </Box>
-      </Container>
-    );
+      </Container>);
+
   }
 
   if (error) {
     return (
       <Container sx={{ py: 4 }}>
         <Alert severity="error">{error}</Alert>
-      </Container>
-    );
+      </Container>);
+
   }
 
   return (
@@ -124,39 +122,39 @@ const NodeCreate = () => {
             onContentRemoved={handleContentRemoved}
             previewVariant="detailed"
             onUploadingChange={handleUploadingChange}
-            onPendingContentChange={setHasPendingContent}
-          />
+            onPendingContentChange={setHasPendingContent} />
+          
 
-          <Box 
-            component="form" 
-            onSubmit={handleSubmit} 
-            sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
-          >
+          <Box
+            component="form"
+            onSubmit={handleSubmit}
+            sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+            
             <TextField
               fullWidth
               id="title"
               label="Título del Nodo"
               value={formData.title}
-              onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
-              required
-            />
+              onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
+              required />
+            
 
             <TextField
               fullWidth
               id="description"
               label="Descripción"
               value={formData.description}
-              onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+              onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
               multiline
               minRows={5}
-              maxRows={24}
-            />
+              maxRows={24} />
+            
 
-            {isUploadingContent && (
-              <Alert severity="info" sx={{ mb: 1 }}>
+            {isUploadingContent &&
+            <Alert severity="info" sx={{ mb: 1 }}>
                 Subiendo contenido… Completa el título y la descripción del nodo mientras tanto.
               </Alert>
-            )}
+            }
 
             <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
               <Button
@@ -164,8 +162,8 @@ const NodeCreate = () => {
                 variant="contained"
                 color="primary"
                 disabled={!formData.content_profile_id || submitting || isUploadingContent || hasPendingContent}
-                sx={{ minWidth: { xs: '100%', md: 'auto' } }}
-              >
+                sx={{ minWidth: { xs: '100%', md: 'auto' } }}>
+                
                 {submitting ? 'Agregando...' : 'Agregar Nodo'}
               </Button>
               <Button
@@ -173,16 +171,16 @@ const NodeCreate = () => {
                 onClick={() => navigate(`/knowledge_path/${pathId}/edit`)}
                 variant="outlined"
                 color="inherit"
-                sx={{ minWidth: { xs: '100%', md: 'auto' } }}
-              >
+                sx={{ minWidth: { xs: '100%', md: 'auto' } }}>
+                
                 Cancelar
               </Button>
             </Stack>
           </Box>
         </Box>
       </Box>
-    </Container>
-  );
+    </Container>);
+
 };
 
 export default NodeCreate;

--- a/frontend/src/knowledgePaths/NodeDetail.jsx
+++ b/frontend/src/knowledgePaths/NodeDetail.jsx
@@ -9,10 +9,6 @@ import ImageIcon from '@mui/icons-material/Image';
 import VideoFileIcon from '@mui/icons-material/VideoFile';
 import TextSnippetIcon from '@mui/icons-material/TextSnippet';
 import AudioFileIcon from '@mui/icons-material/AudioFile';
-
-// Added to track render cycles
-let renderCount = 0;
-
 const NodeDetail = () => {
   const { pathId, nodeId } = useParams();
   const navigate = useNavigate();
@@ -24,65 +20,53 @@ const NodeDetail = () => {
   const [nextNode, setNextNode] = useState(null);
   const [prevNode, setPrevNode] = useState(null);
   const user = getUserFromLocalStorage();
-  
-  // Track render count to detect potential infinite loops
-  renderCount++;
-  console.log(`🔄 NodeDetail RENDER #${renderCount} - pathId: ${pathId}, nodeId: ${nodeId}`);
+
 
   useEffect(() => {
-    console.log('📥 useEffect triggered - fetching data');
-    
-    // Reset renderCount on path/node change
-    renderCount = 1;
-    
+
     let isMounted = true;
-    
+
     const fetchData = async () => {
       try {
-        console.log('🔍 Starting API calls');
-        const startTime = performance.now();
-        
         // Fetch node and path data first
         const [nodeData, pathData] = await Promise.all([
-          knowledgePathsApi.getNode(pathId, nodeId),
-          knowledgePathsApi.getKnowledgePath(pathId)
-        ]);
-        
+        knowledgePathsApi.getNode(pathId, nodeId),
+        knowledgePathsApi.getKnowledgePath(pathId)]
+        );
+
         if (!isMounted) return;
-        
+
         setNode(nodeData);
         setKnowledgePath(pathData);
-        
+
         // Find next and previous nodes by order
-        const nextAvailableNode = pathData.nodes.find(n => 
-          n.order === nodeData.order + 1
+        const nextAvailableNode = pathData.nodes.find((n) =>
+        n.order === nodeData.order + 1
         );
-        const previousNode = pathData.nodes.find(n => 
-          n.order === nodeData.order - 1
+        const previousNode = pathData.nodes.find((n) =>
+        n.order === nodeData.order - 1
         );
-        
+
         setNextNode(nextAvailableNode);
         setPrevNode(previousNode);
-        
+
         // If content_profile_id exists, fetch content details using the same endpoint as ContentDetailsTopic
         if (nodeData.content_profile_id) {
           // Get the content ID from the content profile
           const contentProfile = await knowledgePathsApi.getNodeContent(nodeData.content_profile_id);
           if (contentProfile && contentProfile.content && contentProfile.content.id) {
             const contentId = contentProfile.content.id;
-            console.log('Fetching content details with context=knowledge_path:', contentId);
-            
+
+
             // Use the same endpoint as ContentDetailsTopic but with knowledge_path context
             const contentData = await contentApi.getContentPreview(contentId, 'knowledge_path', pathId);
             if (isMounted) {
-              console.log('Content data loaded:', contentData);
+
               setNodeContent(contentData);
             }
           }
         }
-        
-        const endTime = performance.now();
-        console.log(`✅ API calls completed in ${Math.round(endTime - startTime)}ms`);
+
       } catch (err) {
         console.error('❌ Error fetching data:', err);
         if (isMounted) {
@@ -90,37 +74,37 @@ const NodeDetail = () => {
         }
       } finally {
         if (isMounted) {
-          console.log('✅ Setting loading to false');
+
           setLoading(false);
         }
       }
     };
 
     fetchData();
-    
+
     // Cleanup function
     return () => {
-      console.log('🧹 Cleaning up NodeDetail component');
+
       isMounted = false;
     };
   }, [pathId, nodeId]);
 
   const handleComplete = async () => {
-    console.log('🎯 handleComplete called');
+
     let response;
     try {
       response = await knowledgePathsApi.markNodeCompleted(pathId, nodeId);
-      console.log('Response from marking node completed:', response);
-      
+
+
       // Backend returns {"message": "Node completed successfully"}
       // If we get a successful response, mark the node as completed
-      setNode(prev => ({ ...prev, is_completed: true }));
+      setNode((prev) => ({ ...prev, is_completed: true }));
     } catch (error) {
       console.error('Error marking node as completed:', error);
       setError('Error al marcar el nodo como completado');
       return;
     }
-        
+
     // Check if there's a quiz for this node
     if (node.quizzes && node.quizzes.length > 0) {
       navigate(`/quizzes/${node.quizzes[0].id}`);
@@ -133,39 +117,33 @@ const NodeDetail = () => {
     }
   };
 
-  console.log('🧩 Before render - loading:', loading, 'error:', error, 'node exists:', !!node);
 
   if (loading) return <Box display="flex" justifyContent="center" alignItems="center" minHeight="80vh"><CircularProgress /></Box>;
   if (error) {
     return (
       <Container maxWidth="md" sx={{ py: 3 }}>
         <Alert severity="error">{error}</Alert>
-      </Container>
-    );
+      </Container>);
+
   }
   if (!node) {
     return (
       <Container maxWidth="md" sx={{ py: 3 }}>
         <Alert severity="warning">Nodo no encontrado</Alert>
-      </Container>
-    );
+      </Container>);
+
   }
 
-  console.log('🧩 Ready to render with node:', {
-    id: node.id, 
-    title: node.title,
-    has_content: !!nodeContent
-  });
 
   // Helper function to get media type icon
   const getMediaTypeIcon = (mediaType) => {
     const type = (mediaType || '').toUpperCase();
     switch (type) {
-      case 'IMAGE': return <ImageIcon />;
-      case 'VIDEO': return <VideoFileIcon />;
-      case 'TEXT': return <TextSnippetIcon />;
-      case 'AUDIO': return <AudioFileIcon />;
-      default: return null;
+      case 'IMAGE':return <ImageIcon />;
+      case 'VIDEO':return <VideoFileIcon />;
+      case 'TEXT':return <TextSnippetIcon />;
+      case 'AUDIO':return <AudioFileIcon />;
+      default:return null;
     }
   };
 
@@ -179,8 +157,8 @@ const NodeDetail = () => {
             to={`/knowledge_path/${pathId}`}
             underline="hover"
             color="primary"
-            sx={{ fontWeight: 500 }}
-          >
+            sx={{ fontWeight: 500 }}>
+            
             {knowledgePath?.title}
           </MuiLink>
           <Typography component="span" sx={{ mx: 1 }}>›</Typography>
@@ -195,123 +173,123 @@ const NodeDetail = () => {
           
           {/* Content Display */}
           <Box sx={{ mb: 3 }}>
-            {nodeContent ? (
-              <>
-                {console.log('🖼️ Rendering ContentDisplay with:', nodeContent)}
+            {nodeContent ?
+            <>
+                
                 <ContentDisplay
-                  content={nodeContent}
-                  variant="preview"
-                  showAuthor={true}
-                />
-              </>
-            ) : (
-              <Alert severity="info" sx={{ mb: 2 }}>
+                content={nodeContent}
+                variant="preview"
+                showAuthor={true} />
+              
+              </> :
+
+            <Alert severity="info" sx={{ mb: 2 }}>
                 <div>
                   <Typography variant="body1" gutterBottom>
                     Este nodo no tiene contenido adjunto.
                   </Typography>
-                  {node.media_type && (
-                    <Chip 
-                      icon={getMediaTypeIcon(node.media_type)} 
-                      label={`Tipo de medio: ${node.media_type}`} 
-                      color="primary" 
-                      variant="outlined" 
-                    />
-                  )}
+                  {node.media_type &&
+                <Chip
+                  icon={getMediaTypeIcon(node.media_type)}
+                  label={`Tipo de medio: ${node.media_type}`}
+                  color="primary"
+                  variant="outlined" />
+
+                }
                 </div>
               </Alert>
-            )}
+            }
           </Box>
 
           {/* Description */}
-          {node.description && (
-            <Box sx={{ mt: 3 }}>
+          {node.description &&
+          <Box sx={{ mt: 3 }}>
               <Typography variant="h6" sx={{ mb: 1 }}>Descripción del Nodo</Typography>
               <Typography
-                variant="body1"
-                sx={{ whiteSpace: 'pre-line', wordBreak: 'break-word', lineHeight: 1.8 }}
-              >
+              variant="body1"
+              sx={{ whiteSpace: 'pre-line', wordBreak: 'break-word', lineHeight: 1.8 }}>
+              
                 {String(node.description).replace(/<br\s*\/?>/gi, '\n')}
               </Typography>
             </Box>
-          )}
+          }
 
           {/* Quiz Information */}
-          {node.quizzes && node.quizzes.length > 0 && (
-            <Alert severity="info" sx={{ mt: 3 }}>
+          {node.quizzes && node.quizzes.length > 0 &&
+          <Alert severity="info" sx={{ mt: 3 }}>
               <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
                 Cuestionario: {node.quizzes[0].title || 'El nodo incluye un cuestionario'}
               </Typography>
               <Typography variant="body2">Marca el nodo como completado para realizar el cuestionario.</Typography>
             </Alert>
-          )}
+          }
 
           {/* Action Buttons */}
           <Stack
             direction={{ xs: 'column', sm: 'row' }}
             flexWrap="wrap"
             gap={2}
-            sx={{ mt: 4 }}
-          >
-            {prevNode && (
-              <Button
-                variant="outlined"
-                onClick={() => navigate(`/knowledge_path/${pathId}/nodes/${prevNode.id}`)}
-                sx={{ textTransform: 'none', minWidth: { xs: '100%', sm: 'auto' } }}
-              >
+            sx={{ mt: 4 }}>
+            
+            {prevNode &&
+            <Button
+              variant="outlined"
+              onClick={() => navigate(`/knowledge_path/${pathId}/nodes/${prevNode.id}`)}
+              sx={{ textTransform: 'none', minWidth: { xs: '100%', sm: 'auto' } }}>
+              
                 ← Anterior
               </Button>
-            )}
-            {user && user.username === knowledgePath?.author && (
-              <Button
-                component={Link}
-                to={`/knowledge_path/${pathId}/nodes/${nodeId}/edit`}
-                variant="outlined"
-                sx={{ textTransform: 'none', minWidth: { xs: '100%', sm: 'auto' } }}
-              >
+            }
+            {user && user.username === knowledgePath?.author &&
+            <Button
+              component={Link}
+              to={`/knowledge_path/${pathId}/nodes/${nodeId}/edit`}
+              variant="outlined"
+              sx={{ textTransform: 'none', minWidth: { xs: '100%', sm: 'auto' } }}>
+              
                 Editar Nodo
               </Button>
-            )}
+            }
             <Button
               component={Link}
               to={`/knowledge_path/${pathId}`}
               variant="outlined"
               color="inherit"
-              sx={{ textTransform: 'none', minWidth: { xs: '100%', sm: 'auto' } }}
-            >
+              sx={{ textTransform: 'none', minWidth: { xs: '100%', sm: 'auto' } }}>
+              
               Volver al Camino
             </Button>
-            {node.is_completed ? (
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={() => {
-                  if (node.quizzes && node.quizzes.length > 0) {
-                    navigate(`/quizzes/${node.quizzes[0].id}`);
-                  } else if (nextNode) {
-                    navigate(`/knowledge_path/${pathId}/nodes/${nextNode.id}`);
-                  }
-                }}
-                disabled={!nextNode && !node.quizzes?.length}
-                sx={{ textTransform: 'none', minWidth: { xs: '100%', sm: 'auto' } }}
-              >
+            {node.is_completed ?
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={() => {
+                if (node.quizzes && node.quizzes.length > 0) {
+                  navigate(`/quizzes/${node.quizzes[0].id}`);
+                } else if (nextNode) {
+                  navigate(`/knowledge_path/${pathId}/nodes/${nextNode.id}`);
+                }
+              }}
+              disabled={!nextNode && !node.quizzes?.length}
+              sx={{ textTransform: 'none', minWidth: { xs: '100%', sm: 'auto' } }}>
+              
                 Ya Completado {nextNode ? '— Siguiente →' : ''}
-              </Button>
-            ) : (
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleComplete}
-                sx={{ textTransform: 'none', minWidth: { xs: '100%', sm: 'auto' } }}
-              >
+              </Button> :
+
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleComplete}
+              sx={{ textTransform: 'none', minWidth: { xs: '100%', sm: 'auto' } }}>
+              
                 Marcar como Completado
               </Button>
-            )}
+            }
           </Stack>
         </Paper>
       </Box>
-    </Container>
-  );
+    </Container>);
+
 };
 
-export default NodeDetail; 
+export default NodeDetail;

--- a/frontend/src/knowledgePaths/NodeEdit.jsx
+++ b/frontend/src/knowledgePaths/NodeEdit.jsx
@@ -10,8 +10,8 @@ import {
   CircularProgress,
   Stack,
   Paper,
-  Divider,
-} from '@mui/material';
+  Divider } from
+'@mui/material';
 import QuizIcon from '@mui/icons-material/Quiz';
 import knowledgePathsApi from '../api/knowledgePathsApi';
 import quizzesApi from '../api/quizzesApi';
@@ -35,33 +35,33 @@ const NodeEdit = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        console.log('Fetching data for node edit');
+
         // Fetch both the knowledge path and node data
         const [pathData, nodeData] = await Promise.all([
-          knowledgePathsApi.getKnowledgePathBasic(pathId),
-          knowledgePathsApi.getNode(pathId, nodeId)
-        ]);
+        knowledgePathsApi.getKnowledgePathBasic(pathId),
+        knowledgePathsApi.getNode(pathId, nodeId)]
+        );
 
-        console.log('Node data:', nodeData);
+
         setKnowledgePath(pathData);
-        
+
         // Check if there's a content_profile_id
         const hasContentProfile = nodeData.content_profile_id !== null && nodeData.content_profile_id !== undefined;
-        console.log('Has content profile?', hasContentProfile, 'content_profile_id:', nodeData.content_profile_id);
-        
+
+
         // Set initial form data with the node information
         setFormData({
           title: nodeData.title,
           description: nodeData.description || '',
           content_profile_id: hasContentProfile ? nodeData.content_profile_id : null
         });
-        
+
         // If we have a content profile ID, fetch the content details
         if (hasContentProfile) {
           try {
-            console.log('Fetching content profile:', nodeData.content_profile_id);
+
             const contentProfileData = await knowledgePathsApi.getNodeContent(nodeData.content_profile_id);
-            console.log('Content profile data:', contentProfileData);
+
             setSelectedContent(contentProfileData);
           } catch (contentErr) {
             console.error('Error fetching content profile:', contentErr);
@@ -72,9 +72,9 @@ const NodeEdit = () => {
         // Fetch quiz associated with this node
         try {
           const quizzesData = await quizzesApi.getQuizzesByPathId(pathId);
-          const quizForNode = Array.isArray(quizzesData) 
-            ? quizzesData.find(quiz => quiz.node === parseInt(nodeId))
-            : null;
+          const quizForNode = Array.isArray(quizzesData) ?
+          quizzesData.find((quiz) => quiz.node === parseInt(nodeId)) :
+          null;
           setNodeQuiz(quizForNode || null);
         } catch (quizErr) {
           console.error('Error fetching quiz:', quizErr);
@@ -92,19 +92,16 @@ const NodeEdit = () => {
   }, [pathId, nodeId]);
 
   const handleContentSelected = (content_profile) => {
-    console.log('Selected content profile:', content_profile);
-    console.log('Content profile title:', content_profile.title);
-    console.log('Content profile original title:', content_profile.content?.original_title);
-    console.log('Current form data:', formData);
-    
+
+
     setSelectedContent(content_profile);
-    setFormData(prev => {
+    setFormData((prev) => {
       const newFormData = {
         ...prev,
         content_profile_id: content_profile.id,
         title: prev.title || content_profile.title || content_profile.content?.original_title || 'Untitled'
       };
-      console.log('New form data being set:', newFormData);
+
       return newFormData;
     });
   };
@@ -114,7 +111,7 @@ const NodeEdit = () => {
     setError(null);
 
     try {
-      console.log('Submitting form data:', formData);
+
       await knowledgePathsApi.updateNode(pathId, nodeId, formData);
       navigate(`/knowledge_path/${pathId}/edit`);
     } catch (err) {
@@ -129,16 +126,16 @@ const NodeEdit = () => {
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
           <CircularProgress />
         </Box>
-      </Container>
-    );
+      </Container>);
+
   }
 
   if (error) {
     return (
       <Container sx={{ py: 4 }}>
         <Alert severity="error">{error}</Alert>
-      </Container>
-    );
+      </Container>);
+
   }
 
   return (
@@ -157,18 +154,18 @@ const NodeEdit = () => {
             onContentSelected={handleContentSelected}
             onContentRemoved={() => {
               setSelectedContent(null);
-              setFormData(prev => ({
+              setFormData((prev) => ({
                 ...prev,
                 content_profile_id: null
               }));
             }}
             previewVariant="detailed"
-            onPendingContentChange={setHasPendingContent}
-          />
+            onPendingContentChange={setHasPendingContent} />
+          
 
           {/* Quiz Section */}
-          {nodeQuiz && (
-            <Paper elevation={1} sx={{ p: 2, borderRadius: 2 }}>
+          {nodeQuiz &&
+          <Paper elevation={1} sx={{ p: 2, borderRadius: 2 }}>
               <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
                 <Stack direction="row" spacing={1} alignItems="center">
                   <QuizIcon color="secondary" />
@@ -177,17 +174,17 @@ const NodeEdit = () => {
                   </Typography>
                 </Stack>
                 <Button
-                  component={Link}
-                  to={`/quizzes/${nodeQuiz.id}/edit`}
-                  variant="outlined"
-                  color="secondary"
-                  sx={{ textTransform: 'none' }}
-                >
+                component={Link}
+                to={`/quizzes/${nodeQuiz.id}/edit`}
+                variant="outlined"
+                color="secondary"
+                sx={{ textTransform: 'none' }}>
+                
                   Editar cuestionario
                 </Button>
               </Stack>
             </Paper>
-          )}
+          }
 
           <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
             <TextField
@@ -195,20 +192,20 @@ const NodeEdit = () => {
               id="title"
               label="Título del Nodo"
               value={formData.title}
-              onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
-              required
-            />
+              onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
+              required />
+            
 
             <TextField
               fullWidth
               id="description"
               label="Descripción"
               value={formData.description}
-              onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+              onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
               multiline
               minRows={5}
-              maxRows={24}
-            />
+              maxRows={24} />
+            
 
             <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
               <Button
@@ -216,8 +213,8 @@ const NodeEdit = () => {
                 variant="contained"
                 color="success"
                 disabled={hasPendingContent}
-                sx={{ minWidth: { xs: '100%', md: 'auto' } }}
-              >
+                sx={{ minWidth: { xs: '100%', md: 'auto' } }}>
+                
                 Guardar Cambios
               </Button>
               <Button
@@ -225,16 +222,16 @@ const NodeEdit = () => {
                 onClick={() => navigate(`/knowledge_path/${pathId}/edit`)}
                 variant="outlined"
                 color="inherit"
-                sx={{ minWidth: { xs: '100%', md: 'auto' } }}
-              >
+                sx={{ minWidth: { xs: '100%', md: 'auto' } }}>
+                
                 Cancelar
               </Button>
             </Stack>
           </Box>
         </Box>
       </Box>
-    </Container>
-  );
+    </Container>);
+
 };
 
 export default NodeEdit;

--- a/frontend/src/profiles/About.jsx
+++ b/frontend/src/profiles/About.jsx
@@ -1,9 +1,9 @@
 import '/src/styles/about.css';
 const About = () => {
-    console.log('estoy en about');
 
-    return (
-        <div>
+
+  return (
+    <div>
             <h1>Academia Blockchain: Decentralizing Education for the Future</h1>
 
             <div className="feature-block">
@@ -40,8 +40,8 @@ const About = () => {
                 <h4>Gamification System</h4>
                 <p>Earn badges and points by learning, contributing, and engaging with the community. Badges recognize meaningful achievements and contributions.</p>
             </div>
-        </div>
-    );
+        </div>);
+
 };
 
 export default About;

--- a/frontend/src/profiles/Bookmarks.jsx
+++ b/frontend/src/profiles/Bookmarks.jsx
@@ -10,8 +10,8 @@ import {
   Divider,
   IconButton,
   Tooltip,
-  Stack,
-} from "@mui/material";
+  Stack } from
+"@mui/material";
 import { getBookmarks, deleteBookmark } from "../api/bookmarkApi";
 import SchoolIcon from "@mui/icons-material/School";
 import ArticleIcon from "@mui/icons-material/Article";
@@ -30,8 +30,8 @@ const Bookmarks = () => {
   const fetchBookmarks = async () => {
     try {
       const bookmarksData = await getBookmarks();
-      console.log("\n=== Bookmarks Data ===");
-      console.log("Raw bookmarks:", bookmarksData);
+
+
       setBookmarks(bookmarksData);
     } catch (err) {
       console.error("Failed to load bookmarks:", err);
@@ -46,8 +46,8 @@ const Bookmarks = () => {
   }, []);
 
   const handleBookmarkClick = (bookmark) => {
-    console.log("\n=== Bookmark Click ===");
-    console.log("Bookmark data:", bookmark);
+
+
     const { content_type_name, object_id, topic } = bookmark;
 
     if (content_type_name === "content") {
@@ -79,11 +79,11 @@ const Bookmarks = () => {
         display="flex"
         justifyContent="center"
         alignItems="center"
-        minHeight="200px"
-      >
+        minHeight="200px">
+        
         <CircularProgress />
-      </Box>
-    );
+      </Box>);
+
   }
 
   if (error) {
@@ -92,8 +92,8 @@ const Bookmarks = () => {
         <Alert severity="error" sx={{ mt: 2 }}>
           {error}
         </Alert>
-      </Container>
-    );
+      </Container>);
+
   }
 
   return (
@@ -106,106 +106,103 @@ const Bookmarks = () => {
             fontSize: {
               xs: "1.5rem", // ~24px on mobile
               sm: "1.75rem", // ~28px on small screens
-              md: "2.125rem", // ~34px on desktop (default h4)
+              md: "2.125rem" // ~34px on desktop (default h4)
             },
-            fontWeight: 600,
-          }}
-        >
+            fontWeight: 600
+          }}>
+          
           Marcadores
         </Typography>
 
-        {bookmarks.length === 0 ? (
-          <Typography variant="body1" align="center" sx={{ py: 4 }}>
+        {bookmarks.length === 0 ?
+        <Typography variant="body1" align="center" sx={{ py: 4 }}>
             No hay elementos guardados
-          </Typography>
-        ) : (
-          <Box>
-            {bookmarks.map((bookmark, index) => {
-              console.log("\n=== Rendering Bookmark ===");
-              console.log("Bookmark:", bookmark);
-              console.log("Content type name:", bookmark.content_type_name);
-              console.log("Content profile:", bookmark.content_profile);
+          </Typography> :
 
-              return (
-                <Box key={bookmark.id}>
-                  {bookmark.content_type_name === "content" && bookmark.content_profile && (
-                    <Box
-                      onClick={() => handleBookmarkClick(bookmark)}
-                      sx={{
-                        cursor: "pointer",
-                        "&:hover": {
-                          backgroundColor: "action.hover",
-                        },
-                        p: 2,
-                      }}
-                    >
+        <Box>
+            {bookmarks.map((bookmark, index) => {
+
+
+            return (
+              <Box key={bookmark.id}>
+                  {bookmark.content_type_name === "content" && bookmark.content_profile &&
+                <Box
+                  onClick={() => handleBookmarkClick(bookmark)}
+                  sx={{
+                    cursor: "pointer",
+                    "&:hover": {
+                      backgroundColor: "action.hover"
+                    },
+                    p: 2
+                  }}>
+                  
                       <ContentDisplay
-                        content={bookmark.content_profile}
-                        variant="simple"
-                        showAuthor={true}
-                        showActions={true}
-                        onClick={() => handleBookmarkClick(bookmark)}
-                        additionalActions={
-                          <Box sx={{ display: "flex", gap: 1 }}>
+                    content={bookmark.content_profile}
+                    variant="simple"
+                    showAuthor={true}
+                    showActions={true}
+                    onClick={() => handleBookmarkClick(bookmark)}
+                    additionalActions={
+                    <Box sx={{ display: "flex", gap: 1 }}>
                             {(() => {
-                              const profileUserId = bookmark.content_profile?.user;
-                              const currentUserId = authState.user?.id;
-                              const isOwnContent = profileUserId && currentUserId && parseInt(profileUserId) === parseInt(currentUserId);
-                              return !isOwnContent ? (
-                                <AddToLibraryModal
-                                  content={bookmark.content_profile}
-                                  onSuccess={fetchBookmarks}
-                                />
-                              ) : null;
-                            })()}
+                        const profileUserId = bookmark.content_profile?.user;
+                        const currentUserId = authState.user?.id;
+                        const isOwnContent = profileUserId && currentUserId && parseInt(profileUserId) === parseInt(currentUserId);
+                        return !isOwnContent ?
+                        <AddToLibraryModal
+                          content={bookmark.content_profile}
+                          onSuccess={fetchBookmarks} /> :
+
+                        null;
+                      })()}
                             <Tooltip title="Eliminar marcador">
                               <IconButton
-                                onClick={(e) => handleDelete(bookmark.id, e)}
-                                color="error"
-                                size="small"
-                              >
+                          onClick={(e) => handleDelete(bookmark.id, e)}
+                          color="error"
+                          size="small">
+                          
                                 <DeleteIcon />
                               </IconButton>
                             </Tooltip>
                           </Box>
-                        }
-                      />
+                    } />
+                  
                     </Box>
-                  )}
+                }
 
-                  {bookmark.content_type_name === "knowledgepath" && (
-                    <Box
-                      onClick={() => handleBookmarkClick(bookmark)}
-                      sx={{
-                        cursor: "pointer",
-                        "&:hover": {
-                          backgroundColor: "action.hover",
-                        },
-                        p: 2,
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 2,
-                      }}
-                    >
+                  {bookmark.content_type_name === "knowledgepath" &&
+                <Box
+                  onClick={() => handleBookmarkClick(bookmark)}
+                  sx={{
+                    cursor: "pointer",
+                    "&:hover": {
+                      backgroundColor: "action.hover"
+                    },
+                    p: 2,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 2
+                  }}>
+                  
                       <Box
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          width: 60,
-                          height: 60,
-                          backgroundColor: "background.paper",
-                          borderRadius: 0.5,
-                        }}
-                      >
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      width: 60,
+                      height: 60,
+                      backgroundColor: "background.paper",
+                      borderRadius: 0.5
+                    }}>
+                    
                         <SchoolIcon
-                          sx={{ fontSize: 40, color: "primary.main" }}
-                        />
+                      sx={{ fontSize: 40, color: "primary.main" }} />
+                    
                       </Box>
                       <Box sx={{ flex: 1 }}>
                         <Typography variant="h6" color="text.primary">
                           {bookmark.content_profile?.title ||
-                            "Camino de conocimiento sin título"}
+                      "Camino de conocimiento sin título"}
                         </Typography>
                         <Typography variant="body2" color="text.secondary">
                           Camino de conocimiento
@@ -213,49 +210,49 @@ const Bookmarks = () => {
                       </Box>
                       <Tooltip title="Delete bookmark">
                         <IconButton
-                          onClick={(e) => handleDelete(bookmark.id, e)}
-                          color="error"
-                          size="small"
-                        >
+                      onClick={(e) => handleDelete(bookmark.id, e)}
+                      color="error"
+                      size="small">
+                      
                           <DeleteIcon />
                         </IconButton>
                       </Tooltip>
                     </Box>
-                  )}
+                }
 
-                  {bookmark.content_type_name === "publication" && (
-                    <Box
-                      onClick={() => handleBookmarkClick(bookmark)}
-                      sx={{
-                        cursor: "pointer",
-                        "&:hover": {
-                          backgroundColor: "action.hover",
-                        },
-                        p: 2,
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 2,
-                      }}
-                    >
+                  {bookmark.content_type_name === "publication" &&
+                <Box
+                  onClick={() => handleBookmarkClick(bookmark)}
+                  sx={{
+                    cursor: "pointer",
+                    "&:hover": {
+                      backgroundColor: "action.hover"
+                    },
+                    p: 2,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 2
+                  }}>
+                  
                       <Box
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          width: 60,
-                          height: 60,
-                          backgroundColor: "background.paper",
-                          borderRadius: 0.5,
-                        }}
-                      >
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      width: 60,
+                      height: 60,
+                      backgroundColor: "background.paper",
+                      borderRadius: 0.5
+                    }}>
+                    
                         <ArticleIcon
-                          sx={{ fontSize: 40, color: "primary.main" }}
-                        />
+                      sx={{ fontSize: 40, color: "primary.main" }} />
+                    
                       </Box>
                       <Box sx={{ flex: 1 }}>
                         <Typography variant="h6" color="text.primary">
                           {bookmark.content_profile?.title ||
-                            "Publicación sin título"}
+                      "Publicación sin título"}
                         </Typography>
                         <Typography variant="body2" color="text.secondary">
                           Publicación
@@ -263,25 +260,25 @@ const Bookmarks = () => {
                       </Box>
                       <Tooltip title="Delete bookmark">
                         <IconButton
-                          onClick={(e) => handleDelete(bookmark.id, e)}
-                          color="error"
-                          size="small"
-                        >
+                      onClick={(e) => handleDelete(bookmark.id, e)}
+                      color="error"
+                      size="small">
+                      
                           <DeleteIcon />
                         </IconButton>
                       </Tooltip>
                     </Box>
-                  )}
+                }
 
                   {index < bookmarks.length - 1 && <Divider />}
-                </Box>
-              );
-            })}
+                </Box>);
+
+          })}
           </Box>
-        )}
+        }
       </Paper>
-    </Container>
-  );
+    </Container>);
+
 };
 
 export default Bookmarks;

--- a/frontend/src/profiles/CertificateRequests.jsx
+++ b/frontend/src/profiles/CertificateRequests.jsx
@@ -18,8 +18,8 @@ import {
   Box,
   Chip,
   Stack,
-  Link as MuiLink,
-} from '@mui/material';
+  Link as MuiLink } from
+'@mui/material';
 
 const CertificateRequests = () => {
   const [requests, setRequests] = useState([]);
@@ -114,8 +114,8 @@ const CertificateRequests = () => {
 
   const sortRequests = (requests) => {
     // First, separate requests into pending and non-pending
-    const pendingRequests = requests.filter(req => req.status === 'PENDING');
-    const nonPendingRequests = requests.filter(req => req.status !== 'PENDING');
+    const pendingRequests = requests.filter((req) => req.status === 'PENDING');
+    const nonPendingRequests = requests.filter((req) => req.status !== 'PENDING');
 
     // Sort non-pending requests by date (newest first)
     nonPendingRequests.sort((a, b) => new Date(b.request_date) - new Date(a.request_date));
@@ -129,14 +129,7 @@ const CertificateRequests = () => {
 
     return sortedRequests.map((request) => {
       // Debug logs for each request
-      console.log('Request data:', {
-        id: request.id,
-        status: request.status,
-        knowledge_path_author: request.knowledge_path_author,
-        current_user: authState.user?.username,
-        isTeacher: request.knowledge_path_author === authState.user?.username,
-        isRejected: request.status === 'REJECTED'
-      });
+
 
       return (
         <Card key={request.id} sx={{ mb: 2 }}>
@@ -147,114 +140,112 @@ const CertificateRequests = () => {
                 justifyContent: 'space-between',
                 alignItems: 'flex-start',
                 gap: 2,
-                flexWrap: 'wrap',
-              }}
-            >
+                flexWrap: 'wrap'
+              }}>
+              
               <Box sx={{ flex: 1, minWidth: 240 }}>
                 <Typography variant="h6" color="text.primary">
                   {request.knowledge_path_title}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  {isTeacherView ? (
-                    <>
+                  {isTeacherView ?
+                  <>
                       Solicitado por:{' '}
                       <MuiLink
-                        component={Link}
-                        to={`/profiles/user_profile/${request.requester_id}`}
-                        underline="hover"
-                      >
+                      component={Link}
+                      to={`/profiles/user_profile/${request.requester_id}`}
+                      underline="hover">
+                      
                         {request.requester}
                       </MuiLink>
-                    </>
-                  ) : (
-                    `Solicitado el: ${new Date(request.request_date).toLocaleDateString()}`
-                  )}
+                    </> :
+
+                  `Solicitado el: ${new Date(request.request_date).toLocaleDateString()}`
+                  }
                 </Typography>
-                {!isTeacherView && (
-                  <Typography variant="body2" color="text.secondary">
+                {!isTeacherView &&
+                <Typography variant="body2" color="text.secondary">
                     Autor: {request.knowledge_path_author}
                   </Typography>
-                )}
+                }
                 <Chip
                   label={request.status}
                   color={getStatusColor(request.status)}
                   size="small"
-                  sx={{ mt: 1 }}
-                />
-                {request.notes && 
-                 ((typeof request.notes === 'object' && Object.keys(request.notes).length > 0) || 
-                  (typeof request.notes === 'string' && request.notes.trim() !== '')) && (
-                  <Typography variant="body2" sx={{ mt: 1 }}>
+                  sx={{ mt: 1 }} />
+                
+                {request.notes && (
+                typeof request.notes === 'object' && Object.keys(request.notes).length > 0 ||
+                typeof request.notes === 'string' && request.notes.trim() !== '') &&
+                <Typography variant="body2" sx={{ mt: 1 }}>
                     Notas: {typeof request.notes === 'object' ? JSON.stringify(request.notes) : request.notes}
                   </Typography>
-                )}
+                }
               </Box>
 
               <Stack direction="row" spacing={1.5} sx={{ flexWrap: 'wrap' }}>
-                {request.status === 'PENDING' && request.knowledge_path_author === authState.user?.username && (
-                  <>
+                {request.status === 'PENDING' && request.knowledge_path_author === authState.user?.username &&
+                <>
                     <Button
-                      variant="contained"
-                      color="success"
-                      onClick={() => openApproveDialog(request)}
-                    >
+                    variant="contained"
+                    color="success"
+                    onClick={() => openApproveDialog(request)}>
+                    
                       Aprobar
                     </Button>
                     <Button
-                      variant="contained"
-                      color="error"
-                      onClick={() => openRejectDialog(request)}
-                    >
+                    variant="contained"
+                    color="error"
+                    onClick={() => openRejectDialog(request)}>
+                    
                       Rechazar
                     </Button>
                   </>
-                )}
-                {request.status === 'REJECTED' && request.knowledge_path_author === authState.user?.username && (
-                  <Button
-                    variant="contained"
-                    color="success"
-                    onClick={() => openApproveDialog(request)}
-                  >
+                }
+                {request.status === 'REJECTED' && request.knowledge_path_author === authState.user?.username &&
+                <Button
+                  variant="contained"
+                  color="success"
+                  onClick={() => openApproveDialog(request)}>
+                  
                     Aceptar solicitud
                   </Button>
-                )}
-                {request.status === 'PENDING' && request.requester === authState.user?.username && (
-                  <Button
-                    variant="outlined"
-                    color="error"
-                    onClick={() => handleCancel(request.id)}
-                  >
+                }
+                {request.status === 'PENDING' && request.requester === authState.user?.username &&
+                <Button
+                  variant="outlined"
+                  color="error"
+                  onClick={() => handleCancel(request.id)}>
+                  
                     Cancelar
                   </Button>
-                )}
+                }
               </Stack>
             </Box>
 
-            {request.rejection_reason && (
-              <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+            {request.rejection_reason &&
+            <Typography variant="body2" color="error" sx={{ mt: 1 }}>
                 Motivo del rechazo: {request.rejection_reason}
               </Typography>
-            )}
+            }
           </CardContent>
-        </Card>
-      );
+        </Card>);
+
     });
   };
 
   // Add debug logs for the requests data
   useEffect(() => {
-    console.log('All requests:', requests);
-    console.log('Teacher requests:', requests.filter(req => req.knowledge_path_author === authState.user?.username));
-    console.log('Student requests:', requests.filter(req => req.requester === authState.user?.username));
-    console.log('Current user:', authState.user?.username);
+
+
   }, [requests, authState.user]);
 
   if (loading) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
         <CircularProgress />
-      </Box>
-    );
+      </Box>);
+
   }
 
   if (error) {
@@ -262,65 +253,65 @@ const CertificateRequests = () => {
   }
 
   // Separate requests into teacher view (requests to review) and student view (own requests)
-  const teacherRequests = requests.filter(req => req.knowledge_path_author === authState.user?.username);
-  const studentRequests = requests.filter(req => req.requester === authState.user?.username);
+  const teacherRequests = requests.filter((req) => req.knowledge_path_author === authState.user?.username);
+  const studentRequests = requests.filter((req) => req.requester === authState.user?.username);
 
   return (
     <Container maxWidth="lg" sx={{ py: 3 }}>
-      <Typography 
-        variant="h4" 
-        gutterBottom 
+      <Typography
+        variant="h4"
+        gutterBottom
         color="text.primary"
-        sx={{ fontWeight: 600 }}
-      >
+        sx={{ fontWeight: 600 }}>
+        
         Solicitudes de certificados
       </Typography>
 
-      {requests.length === 0 ? (
-        <Typography variant="body1" color="text.secondary">
+      {requests.length === 0 ?
+      <Typography variant="body1" color="text.secondary">
           No se encontraron solicitudes de certificados.
-        </Typography>
-      ) : (
-        <Stack spacing={4}>
+        </Typography> :
+
+      <Stack spacing={4}>
           {/* Teacher View */}
-          {teacherRequests.length > 0 && (
-            <Box>
-              <Typography 
-                variant="h5" 
-                gutterBottom 
-                color="text.primary"
-                sx={{ fontWeight: 600 }}
-              >
+          {teacherRequests.length > 0 &&
+        <Box>
+              <Typography
+            variant="h5"
+            gutterBottom
+            color="text.primary"
+            sx={{ fontWeight: 600 }}>
+            
                 Solicitudes para revisar
               </Typography>
               {renderRequests(teacherRequests, true)}
             </Box>
-          )}
+        }
 
           {/* Student View */}
-          {studentRequests.length > 0 && (
-            <Box>
-              <Typography 
-                variant="h5" 
-                gutterBottom 
-                color="text.primary"
-                sx={{ fontWeight: 600 }}
-              >
+          {studentRequests.length > 0 &&
+        <Box>
+              <Typography
+            variant="h5"
+            gutterBottom
+            color="text.primary"
+            sx={{ fontWeight: 600 }}>
+            
                 Mis solicitudes
               </Typography>
               {renderRequests(studentRequests, false)}
             </Box>
-          )}
+        }
         </Stack>
-      )}
+      }
 
       {/* Approve Dialog */}
-      <Dialog 
-        open={approveDialogOpen} 
+      <Dialog
+        open={approveDialogOpen}
         onClose={() => setApproveDialogOpen(false)}
         maxWidth="sm"
-        fullWidth
-      >
+        fullWidth>
+        
         <DialogTitle>Aprobar solicitud de certificado</DialogTitle>
         <DialogContent>
           <Box sx={{ mt: 2 }}>
@@ -332,29 +323,29 @@ const CertificateRequests = () => {
               placeholder="Opcionalmente agrega una nota al estudiante"
               value={approveNote}
               onChange={(e) => setApproveNote(e.target.value)}
-              variant="outlined"
-            />
+              variant="outlined" />
+            
           </Box>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setApproveDialogOpen(false)}>Cancelar</Button>
-          <Button 
+          <Button
             onClick={handleApprove}
             variant="contained"
-            color="success"
-          >
+            color="success">
+            
             Aprobar
           </Button>
         </DialogActions>
       </Dialog>
 
       {/* Reject Dialog */}
-      <Dialog 
-        open={rejectDialogOpen} 
+      <Dialog
+        open={rejectDialogOpen}
         onClose={() => setRejectDialogOpen(false)}
         maxWidth="sm"
-        fullWidth
-      >
+        fullWidth>
+        
         <DialogTitle>Rechazar solicitud de certificado</DialogTitle>
         <DialogContent>
           <Box sx={{ mt: 2 }}>
@@ -366,24 +357,24 @@ const CertificateRequests = () => {
               rows={2}
               value={rejectReason}
               onChange={(e) => setRejectReason(e.target.value)}
-              required
-            />
+              required />
+            
           </Box>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setRejectDialogOpen(false)}>Cancelar</Button>
-          <Button 
+          <Button
             onClick={handleReject}
             variant="contained"
             color="error"
-            disabled={!rejectReason.trim()}
-          >
+            disabled={!rejectReason.trim()}>
+            
             Rechazar
           </Button>
         </DialogActions>
       </Dialog>
-    </Container>
-  );
+    </Container>);
+
 };
 
-export default CertificateRequests; 
+export default CertificateRequests;

--- a/frontend/src/profiles/Certificates.jsx
+++ b/frontend/src/profiles/Certificates.jsx
@@ -19,8 +19,8 @@ import {
   Tabs,
   Tab,
   Stack,
-  Link as MuiLink,
-} from "@mui/material";
+  Link as MuiLink } from
+"@mui/material";
 
 const Certificates = ({ isOwnProfile = false, userId = null }) => {
   const [activeTab, setActiveTab] = useState("certificates");
@@ -54,7 +54,7 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
       } else {
         data = await certificatesApi.getUserCertificatesById(userId);
       }
-      console.log("DEBUG: Fetched certificates:", data);
+
       setCertificates(data);
     } catch (err) {
       setError("Error al cargar los certificados");
@@ -210,68 +210,68 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
   return (
     <Box>
       {/* Material-UI Tabs - Only show requests tab for owners */}
-      {isOwnProfile ? (
-        <Box sx={{ borderBottom: 1, borderColor: "divider", mb: 3 }}>
+      {isOwnProfile ?
+      <Box sx={{ borderBottom: 1, borderColor: "divider", mb: 3 }}>
           <Tabs value={activeTab} onChange={handleTabChange}>
             <Tab label="Certificados" value="certificates" />
             <Tab label="Solicitudes de certificados" value="requests" />
           </Tabs>
-        </Box>
-      ) : (
-        // For visitors, show a simple header
-        <Box sx={{ mb: 3 }}>
+        </Box> :
+
+      // For visitors, show a simple header
+      <Box sx={{ mb: 3 }}>
           <Typography
-            variant="h4"
-            gutterBottom
-            sx={{
-              fontSize: {
-                xs: "1.5rem", // ~24px on mobile
-                sm: "1.75rem", // ~28px on small screens
-                md: "2.125rem", // ~34px on desktop (default h4)
-              },
-              fontWeight: 600,
-            }}
-          >
+          variant="h4"
+          gutterBottom
+          sx={{
+            fontSize: {
+              xs: "1.5rem", // ~24px on mobile
+              sm: "1.75rem", // ~28px on small screens
+              md: "2.125rem" // ~34px on desktop (default h4)
+            },
+            fontWeight: 600
+          }}>
+          
             Certificados ({certificates.length})
           </Typography>
         </Box>
-      )}
+      }
 
       {/* Tab Content */}
       <Box>
-        {(activeTab === "certificates" || !isOwnProfile) && (
-          <Box>
-            {certificatesLoading ? (
-              <Box
-                display="flex"
-                justifyContent="center"
-                alignItems="center"
-                minHeight="200px"
-              >
+        {(activeTab === "certificates" || !isOwnProfile) &&
+        <Box>
+            {certificatesLoading ?
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            minHeight="200px">
+            
                 <CircularProgress />
-              </Box>
-            ) : error ? (
-              <Alert severity="error">{error}</Alert>
-            ) : certificates.length === 0 ? (
-              <Typography variant="body1" color="text.secondary">
-                {isOwnProfile
-                  ? "Aún no has obtenido ningún certificado. ¡Completa caminos de conocimiento o asiste a eventos para obtener certificados!"
-                  : "No se encontraron certificados."}
-              </Typography>
-            ) : (
-              <Stack spacing={2}>
-                {certificates.map((certificate) => (
-                  <Card key={certificate.id}>
+              </Box> :
+          error ?
+          <Alert severity="error">{error}</Alert> :
+          certificates.length === 0 ?
+          <Typography variant="body1" color="text.secondary">
+                {isOwnProfile ?
+            "Aún no has obtenido ningún certificado. ¡Completa caminos de conocimiento o asiste a eventos para obtener certificados!" :
+            "No se encontraron certificados."}
+              </Typography> :
+
+          <Stack spacing={2}>
+                {certificates.map((certificate) =>
+            <Card key={certificate.id}>
                     <CardContent>
                       <Box
-                        sx={{
-                          display: "flex",
-                          justifyContent: "space-between",
-                          alignItems: "flex-start",
-                          gap: 2,
-                          flexWrap: "wrap",
-                        }}
-                      >
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: 2,
+                    flexWrap: "wrap"
+                  }}>
+                  
                         <Box sx={{ flex: 1, minWidth: 240 }}>
                           <Typography variant="h6" color="text.primary">
                             {getCertificateTitle(certificate)}
@@ -282,122 +282,122 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
                           <Typography variant="body2" color="text.secondary">
                             Emitido el:{" "}
                             {new Date(
-                              certificate.issued_on
-                            ).toLocaleDateString()}
+                        certificate.issued_on
+                      ).toLocaleDateString()}
                           </Typography>
-                          {certificate.blockchain_hash && (
-                            <Chip
-                              label="En Blockchain"
-                              color="success"
-                              size="small"
-                              sx={{ mt: 1 }}
-                            />
-                          )}
+                          {certificate.blockchain_hash &&
+                    <Chip
+                      label="En Blockchain"
+                      color="success"
+                      size="small"
+                      sx={{ mt: 1 }} />
+
+                    }
                         </Box>
-                        {(certificate.download_url || certificate.certificate_file_url) && (
-                          <Button
-                            variant="contained"
-                            color="primary"
-                            href={certificate.download_url || certificate.certificate_file_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
+                        {(certificate.download_url || certificate.certificate_file_url) &&
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    href={certificate.download_url || certificate.certificate_file_url}
+                    target="_blank"
+                    rel="noopener noreferrer">
+                    
                             Descargar
                           </Button>
-                        )}
+                  }
                       </Box>
                     </CardContent>
                   </Card>
-                ))}
-              </Stack>
             )}
+              </Stack>
+          }
           </Box>
-        )}
-        {isOwnProfile && activeTab === "requests" && (
-          <Box>
-            {requestsLoading ? (
-              <Box
-                display="flex"
-                justifyContent="center"
-                alignItems="center"
-                minHeight="200px"
-              >
+        }
+        {isOwnProfile && activeTab === "requests" &&
+        <Box>
+            {requestsLoading ?
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            minHeight="200px">
+            
                 <CircularProgress />
-              </Box>
-            ) : error ? (
-              <Alert severity="error">{error}</Alert>
-            ) : requests.length === 0 ? (
-              <Box textAlign="center" py={4}>
+              </Box> :
+          error ?
+          <Alert severity="error">{error}</Alert> :
+          requests.length === 0 ?
+          <Box textAlign="center" py={4}>
                 <Typography variant="h6" color="text.secondary" gutterBottom>
                   ¿Tienes algo que enseñar? Crea un Camino de Conocimiento o un Evento
                   y emite certificados
                 </Typography>
                 <Box
-                  mt={3}
-                  sx={{
-                    display: {
-                      xs: "block", // mobile → stacked
-                      md: "flex", // md and up → flex row
-                    },
-                  }}
-                  gap={2}
-                  justifyContent="center"
-                >
+              mt={3}
+              sx={{
+                display: {
+                  xs: "block", // mobile → stacked
+                  md: "flex" // md and up → flex row
+                }
+              }}
+              gap={2}
+              justifyContent="center">
+              
                   <Button
-                    sx={{
-                      mb: {
-                        xs: 2, // vertical spacing between children on mobile
-                        md: 0, // no spacing when flex row
-                      },
-                    }}
-                    variant="contained"
-                    color="primary"
-                    onClick={() => navigate("/knowledge_path/create")}
-                  >
+                sx={{
+                  mb: {
+                    xs: 2, // vertical spacing between children on mobile
+                    md: 0 // no spacing when flex row
+                  }
+                }}
+                variant="contained"
+                color="primary"
+                onClick={() => navigate("/knowledge_path/create")}>
+                
                     Crear camino de conocimiento
                   </Button>
                   <Button
-                    variant="contained"
-                    color="secondary"
-                    onClick={() => navigate("/events/create")}
-                  >
+                variant="contained"
+                color="secondary"
+                onClick={() => navigate("/events/create")}>
+                
                     Crear un evento
                   </Button>
                 </Box>
-              </Box>
-            ) : (
-              <Stack spacing={4}>
+              </Box> :
+
+          <Stack spacing={4}>
                 {/* Teacher View */}
                 {requests.filter(
-                  (req) =>
-                    req.knowledge_path_author === authState.user?.username
-                ).length > 0 && (
-                  <Box>
-                    <Typography 
-                      variant="h5" 
-                      gutterBottom 
-                      color="text.primary"
-                      sx={{ fontWeight: 600 }}
-                    >
+              (req) =>
+              req.knowledge_path_author === authState.user?.username
+            ).length > 0 &&
+            <Box>
+                    <Typography
+                variant="h5"
+                gutterBottom
+                color="text.primary"
+                sx={{ fontWeight: 600 }}>
+                
                       Solicitudes para revisar
                     </Typography>
                     {sortRequests(
-                      requests.filter(
-                        (req) =>
-                          req.knowledge_path_author === authState.user?.username
-                      )
-                    ).map((request) => (
-                      <Card key={request.id} sx={{ mb: 2 }}>
+                requests.filter(
+                  (req) =>
+                  req.knowledge_path_author === authState.user?.username
+                )
+              ).map((request) =>
+              <Card key={request.id} sx={{ mb: 2 }}>
                         <CardContent>
                           <Box
-                            sx={{
-                              display: "flex",
-                              justifyContent: "space-between",
-                              alignItems: "flex-start",
-                              gap: 2,
-                              flexWrap: "wrap",
-                            }}
-                          >
+                    sx={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "flex-start",
+                      gap: 2,
+                      flexWrap: "wrap"
+                    }}>
+                    
                             <Box sx={{ flex: 1, minWidth: 240 }}>
                               <Typography variant="h6">
                                 {getRequestTitle(request)}
@@ -405,10 +405,10 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
                               <Typography variant="body2" color="text.secondary">
                                 Solicitado por:{" "}
                                 <MuiLink
-                                  component={Link}
-                                  to={`/profiles/user_profile/${request.requester_id}`}
-                                  underline="hover"
-                                >
+                          component={Link}
+                          to={`/profiles/user_profile/${request.requester_id}`}
+                          underline="hover">
+                          
                                   {request.requester}
                                 </MuiLink>
                               </Typography>
@@ -416,100 +416,100 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
                                 Tipo: {getRequestType(request)}
                               </Typography>
                               <Chip
-                                label={request.status}
-                                color={getStatusColor(request.status)}
-                                size="small"
-                                sx={{ mt: 1 }}
-                              />
-                              {request.notes &&
-                                ((typeof request.notes === "object" &&
-                                  Object.keys(request.notes).length > 0) ||
-                                  (typeof request.notes === "string" &&
-                                    request.notes.trim() !== "")) && (
-                                  <Typography variant="body2" sx={{ mt: 1 }}>
+                        label={request.status}
+                        color={getStatusColor(request.status)}
+                        size="small"
+                        sx={{ mt: 1 }} />
+                      
+                              {request.notes && (
+                      typeof request.notes === "object" &&
+                      Object.keys(request.notes).length > 0 ||
+                      typeof request.notes === "string" &&
+                      request.notes.trim() !== "") &&
+                      <Typography variant="body2" sx={{ mt: 1 }}>
                                     Notas:{" "}
-                                    {typeof request.notes === "object"
-                                      ? JSON.stringify(request.notes)
-                                      : request.notes}
+                                    {typeof request.notes === "object" ?
+                        JSON.stringify(request.notes) :
+                        request.notes}
                                   </Typography>
-                                )}
+                      }
                             </Box>
 
                             <Stack direction="row" spacing={1.5} sx={{ flexWrap: "wrap" }}>
-                              {request.status === "PENDING" && (
-                                <>
+                              {request.status === "PENDING" &&
+                      <>
                                   <Button
-                                    variant="contained"
-                                    color="success"
-                                    onClick={() => openApproveDialog(request)}
-                                  >
+                          variant="contained"
+                          color="success"
+                          onClick={() => openApproveDialog(request)}>
+                          
                                     Aprobar
                                   </Button>
                                   <Button
-                                    variant="contained"
-                                    color="error"
-                                    onClick={() => openRejectDialog(request)}
-                                  >
+                          variant="contained"
+                          color="error"
+                          onClick={() => openRejectDialog(request)}>
+                          
                                     Rechazar
                                   </Button>
                                 </>
-                              )}
-                              {request.status === "REJECTED" && (
-                                <Button
-                                  variant="contained"
-                                  color="success"
-                                  onClick={() => openApproveDialog(request)}
-                                >
+                      }
+                              {request.status === "REJECTED" &&
+                      <Button
+                        variant="contained"
+                        color="success"
+                        onClick={() => openApproveDialog(request)}>
+                        
                                   Aceptar solicitud
                                 </Button>
-                              )}
+                      }
                             </Stack>
                           </Box>
 
-                          {request.rejection_reason && (
-                            <Typography
-                              variant="body2"
-                              color="error"
-                              sx={{ mt: 1 }}
-                            >
+                          {request.rejection_reason &&
+                  <Typography
+                    variant="body2"
+                    color="error"
+                    sx={{ mt: 1 }}>
+                    
                               Rejection reason: {request.rejection_reason}
                             </Typography>
-                          )}
+                  }
                         </CardContent>
                       </Card>
-                    ))}
+              )}
                   </Box>
-                )}
+            }
 
                 {/* Student View */}
                 {requests.filter(
-                  (req) => req.requester === authState.user?.username
-                ).length > 0 && (
-                  <Box>
-                    <Typography 
-                      variant="h5" 
-                      gutterBottom 
-                      color="text.primary"
-                      sx={{ fontWeight: 600 }}
-                    >
+              (req) => req.requester === authState.user?.username
+            ).length > 0 &&
+            <Box>
+                    <Typography
+                variant="h5"
+                gutterBottom
+                color="text.primary"
+                sx={{ fontWeight: 600 }}>
+                
                       Mis solicitudes
                     </Typography>
                     {sortRequests(
-                      requests.filter(
-                        (req) => req.requester === authState.user?.username
-                      )
-                    ).map((request) => (
-                      <Card key={request.id} sx={{ mb: 2 }}>
+                requests.filter(
+                  (req) => req.requester === authState.user?.username
+                )
+              ).map((request) =>
+              <Card key={request.id} sx={{ mb: 2 }}>
                         <CardContent>
                           <Box
-                            sx={{
-                              display: "flex",
-                              justifyContent: "space-between",
-                              alignItems: "flex-start",
-                              gap: 2,
-                              flexWrap: "wrap",
-                            }}
-                          >
+                    sx={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "flex-start",
+                      gap: 2,
+                      flexWrap: "wrap"
+                    }}>
+                    
                             <Box sx={{ flex: 1, minWidth: 240 }}>
                               <Typography variant="h6" color="text.primary">
                                 {getRequestTitle(request)}
@@ -517,80 +517,80 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
                               <Typography variant="body2" color="text.secondary">
                                 Solicitado el:{" "}
                                 {new Date(
-                                  request.request_date
-                                ).toLocaleDateString()}
+                          request.request_date
+                        ).toLocaleDateString()}
                               </Typography>
                               <Typography variant="body2" color="text.secondary">
                                 Autor:{" "}
                                 <MuiLink
-                                  component={Link}
-                                  to={`/profiles/user_profile/${
-                                    request.knowledge_path_author_id ||
-                                    request.event_owner_id
-                                  }`}
-                                  underline="hover"
-                                >
+                          component={Link}
+                          to={`/profiles/user_profile/${
+                          request.knowledge_path_author_id ||
+                          request.event_owner_id}`
+                          }
+                          underline="hover">
+                          
                                   {request.knowledge_path_author ||
-                                    request.event_owner}
+                          request.event_owner}
                                 </MuiLink>
                               </Typography>
                               <Typography variant="body2" color="text.secondary">
                                 Tipo: {getRequestType(request)}
                               </Typography>
                               <Chip
-                                label={request.status}
-                                color={getStatusColor(request.status)}
-                                size="small"
-                                sx={{ mt: 1 }}
-                              />
-                              {request.notes &&
-                                ((typeof request.notes === "object" &&
-                                  Object.keys(request.notes).length > 0) ||
-                                  (typeof request.notes === "string" &&
-                                    request.notes.trim() !== "")) && (
-                                  <Typography variant="body2" sx={{ mt: 1 }}>
+                        label={request.status}
+                        color={getStatusColor(request.status)}
+                        size="small"
+                        sx={{ mt: 1 }} />
+                      
+                              {request.notes && (
+                      typeof request.notes === "object" &&
+                      Object.keys(request.notes).length > 0 ||
+                      typeof request.notes === "string" &&
+                      request.notes.trim() !== "") &&
+                      <Typography variant="body2" sx={{ mt: 1 }}>
                                     Notas:{" "}
-                                    {typeof request.notes === "object"
-                                      ? JSON.stringify(request.notes)
-                                      : request.notes}
+                                    {typeof request.notes === "object" ?
+                        JSON.stringify(request.notes) :
+                        request.notes}
                                   </Typography>
-                                )}
+                      }
                             </Box>
-                            {request.status === "PENDING" && (
-                              <Button
-                                variant="outlined"
-                                color="error"
-                                onClick={() => handleCancel(request.id)}
-                              >
+                            {request.status === "PENDING" &&
+                    <Button
+                      variant="outlined"
+                      color="error"
+                      onClick={() => handleCancel(request.id)}>
+                      
                                 Cancelar
                               </Button>
-                            )}
+                    }
                           </Box>
-                          {request.rejection_reason && (
-                            <Typography
-                              variant="body2"
-                              color="error"
-                              sx={{ mt: 1 }}
-                            >
+                          {request.rejection_reason &&
+                  <Typography
+                    variant="body2"
+                    color="error"
+                    sx={{ mt: 1 }}>
+                    
                               Motivo del rechazo: {request.rejection_reason}
                             </Typography>
-                          )}
+                  }
                         </CardContent>
                       </Card>
-                    ))}
+              )}
                   </Box>
-                )}
+            }
               </Stack>
-            )}
+          }
           </Box>
-        )}
+        }
       </Box>
 
       {/* Approve Dialog */}
       <Dialog
         open={approveDialogOpen}
-        onClose={() => setApproveDialogOpen(false)}
-      >
+        onClose={() => setApproveDialogOpen(false)}>
+        
         <DialogTitle>Aprobar solicitud de certificado</DialogTitle>
         <DialogContent>
           <TextField
@@ -602,8 +602,8 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
             multiline
             rows={4}
             value={approveNote}
-            onChange={(e) => setApproveNote(e.target.value)}
-          />
+            onChange={(e) => setApproveNote(e.target.value)} />
+          
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setApproveDialogOpen(false)}>Cancelar</Button>
@@ -616,8 +616,8 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
       {/* Reject Dialog */}
       <Dialog
         open={rejectDialogOpen}
-        onClose={() => setRejectDialogOpen(false)}
-      >
+        onClose={() => setRejectDialogOpen(false)}>
+        
         <DialogTitle>Rechazar solicitud de certificado</DialogTitle>
         <DialogContent>
           <TextField
@@ -630,8 +630,8 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
             multiline
             rows={4}
             value={rejectReason}
-            onChange={(e) => setRejectReason(e.target.value)}
-          />
+            onChange={(e) => setRejectReason(e.target.value)} />
+          
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setRejectDialogOpen(false)}>Cancelar</Button>
@@ -640,8 +640,8 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
-  );
+    </Box>);
+
 };
 
 export default Certificates;

--- a/frontend/src/profiles/Login.jsx
+++ b/frontend/src/profiles/Login.jsx
@@ -7,8 +7,8 @@ import {
   setAuthenticationStatus,
   isAuthenticated,
   getAccessTokenFromLocalStorage,
-  setAccessTokenInLocalStorage,
-} from "../context/localStorageUtils.js";
+  setAccessTokenInLocalStorage } from
+"../context/localStorageUtils.js";
 import SocialLogin from "../components/SocialLogin";
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
@@ -25,8 +25,8 @@ import {
   Paper,
   Stack,
   TextField,
-  Typography,
-} from "@mui/material";
+  Typography } from
+"@mui/material";
 
 /**
  * Regular Login Component
@@ -48,60 +48,52 @@ const Login = () => {
     // Select a random login cover image (1-10)
     const randomImageNumber = Math.floor(Math.random() * 10) + 1;
     setLoginImage(`/images/login_cover/login_cover${randomImageNumber}.jpg`);
-
-    // Log environment variables to verify they're accessible
-    console.log(
-      "Google Client ID:",
-      import.meta.env.VITE_GOOGLE_OAUTH_CLIENT_ID
-    );
-    console.log("API URL:", import.meta.env.VITE_API_URL);
-
     const storedUser = getUserFromLocalStorage();
     const localStorageAuth = isAuthenticated();
 
     // Check if the user is authenticated with the backend and sync with localStorage
     checkAuth().then((isBackendAuthenticated) => {
       setBackendAuthStatus(isBackendAuthenticated);
-      if (localStorageAuth && isBackendAuthenticated) {
-        console.log("User is already authenticated");
-      } else if (isBackendAuthenticated && !authState.isAuthenticated) {
+
+
+      if (isBackendAuthenticated && !authState.isAuthenticated) {
         // Backend says authenticated but context was cleared (e.g. after wrong redirect on refresh)
         // Restore session: get new token and user, then redirect away from login
         setIsRestoringSession(true);
-        refreshToken()
-          .then((data) => {
-            const access_token = data?.access_token;
-            if (!access_token) {
+        refreshToken().
+        then((data) => {
+          const access_token = data?.access_token;
+          if (!access_token) {
+            setIsRestoringSession(false);
+            return;
+          }
+          setAccessTokenInLocalStorage(access_token);
+          return getUserProfile().then((profile) => {
+            if (!profile?.user) {
               setIsRestoringSession(false);
               return;
             }
-            setAccessTokenInLocalStorage(access_token);
-            return getUserProfile().then((profile) => {
-              if (!profile?.user) {
-                setIsRestoringSession(false);
-                return;
-              }
-              updateAuthState(profile.user, access_token);
-              const from = location.state?.from?.pathname || "/profiles/my_profile";
-              navigate(from, { replace: true });
-            });
-          })
-          .catch(() => {
-            setIsRestoringSession(false);
-            // Restore failed (e.g. no refresh cookie); backendAuthStatus is still true so we show "Ya has iniciado sesión"
+            updateAuthState(profile.user, access_token);
+            const from = location.state?.from?.pathname || "/profiles/my_profile";
+            navigate(from, { replace: true });
           });
+        }).
+        catch(() => {
+          setIsRestoringSession(false);
+          // Restore failed (e.g. no refresh cookie); backendAuthStatus is still true so we show "Ya has iniciado sesión"
+        });
       } else if (isBackendAuthenticated && !localStorageAuth && storedUser) {
         setAuthenticationStatus(true);
         setAuthState({
           isAuthenticated: true,
-          user: storedUser,
+          user: storedUser
         });
       } else if (!isBackendAuthenticated && localStorageAuth) {
-        console.log("User is authenticated but backend is not");
+
         setAuthenticationStatus(false);
         setAuthState({
           isAuthenticated: false,
-          user: storedUser,
+          user: storedUser
         });
       }
     });
@@ -113,16 +105,16 @@ const Login = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Submitting login form with:", { username, password });
+
     try {
       // Check if user had previous session data before login using utilities
       const storedUser = getUserFromLocalStorage();
       const wasAuthenticated = isAuthenticated();
       const hadAccessToken = getAccessTokenFromLocalStorage() !== null;
-      const hadPreviousSession = (storedUser !== null) || wasAuthenticated || hadAccessToken;
-      
+      const hadPreviousSession = storedUser !== null || wasAuthenticated || hadAccessToken;
+
       const response = await apiLogin({ username, password });
-      console.log("Login API response:", response);
+
 
       if (response.data) {
         const { access_token, ...userData } = response.data;
@@ -137,9 +129,9 @@ const Login = () => {
     } catch (error) {
       console.error("Login error:", error);
       const errorMessage =
-        error.response?.data?.error ||
-        error.response?.statusText ||
-        "Error al iniciar sesión: " + error.message;
+      error.response?.data?.error ||
+      error.response?.statusText ||
+      "Error al iniciar sesión: " + error.message;
       setError(errorMessage);
     }
   };
@@ -152,8 +144,8 @@ const Login = () => {
           <CircularProgress size={28} />
           <Typography>Restaurando sesión...</Typography>
         </Stack>
-      </Box>
-    );
+      </Box>);
+
   }
 
   // Already authenticated (backend says so); show message only when not restoring
@@ -167,8 +159,8 @@ const Login = () => {
           </MuiLink>
           ?
         </Alert>
-      </Container>
-    );
+      </Container>);
+
   }
 
   // Not authenticated: show login form
@@ -183,18 +175,18 @@ const Login = () => {
           overflow: "hidden",
           border: "1px solid",
           borderColor: "divider",
-          bgcolor: "background.paper",
-        }}
-      >
+          bgcolor: "background.paper"
+        }}>
+        
         <Box
           sx={{
             display: { xs: "none", md: "block" },
             minHeight: 460,
             backgroundImage: `url(${loginImage})`,
             backgroundSize: "cover",
-            backgroundPosition: "center",
-          }}
-        />
+            backgroundPosition: "center"
+          }} />
+        
 
         <Box sx={{ p: { xs: 3, md: 4 }, display: "flex", alignItems: "center" }}>
           <Paper elevation={0} sx={{ width: "100%" }}>
@@ -209,8 +201,8 @@ const Login = () => {
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
                   fullWidth
-                  autoComplete="username"
-                />
+                  autoComplete="username" />
+                
                 <TextField
                   label="Contraseña"
                   type={showPassword ? "text" : "password"}
@@ -219,19 +211,19 @@ const Login = () => {
                   fullWidth
                   autoComplete="current-password"
                   InputProps={{
-                    endAdornment: (
-                      <InputAdornment position="end">
+                    endAdornment:
+                    <InputAdornment position="end">
                         <IconButton
-                          edge="end"
-                          onClick={() => setShowPassword(!showPassword)}
-                          aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
-                        >
+                        edge="end"
+                        onClick={() => setShowPassword(!showPassword)}
+                        aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}>
+                        
                           {showPassword ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
                         </IconButton>
                       </InputAdornment>
-                    ),
-                  }}
-                />
+
+                  }} />
+                
 
                 {error && <Alert severity="error">{error}</Alert>}
 
@@ -253,8 +245,8 @@ const Login = () => {
           </Paper>
         </Box>
       </Box>
-    </Container>
-  );
+    </Container>);
+
 };
 
 export default Login;

--- a/frontend/src/profiles/Logout.jsx
+++ b/frontend/src/profiles/Logout.jsx
@@ -19,10 +19,10 @@ const Logout = () => {
 
     const logoutUser = async () => {
       if (isLoggingOut) return; // Prevent multiple logout attempts
-      
+
       try {
         setIsLoggingOut(true);
-        console.log('Attempting to logout...');
+
         await apiLogout();
         clearAuthState();
         clearAuthenticationStatus();
@@ -46,13 +46,13 @@ const Logout = () => {
 
   return (
     <div>
-      {error ? (
-        <div style={{ color: 'red' }}>Error: {error}</div>
-      ) : (
-        <div>Cerrando sesión de {username}...</div>
-      )}
-    </div>
-  );
+      {error ?
+      <div style={{ color: 'red' }}>Error: {error}</div> :
+
+      <div>Cerrando sesión de {username}...</div>
+      }
+    </div>);
+
 };
 
 export default Logout;

--- a/frontend/src/profiles/Notifications.jsx
+++ b/frontend/src/profiles/Notifications.jsx
@@ -11,9 +11,9 @@ const Notifications = ({
   unreadCount = 0,
   onMarkAsRead = () => {},
   onMarkAllAsRead = () => {},
-  onRefresh = () => {},
+  onRefresh = () => {}
 }) => {
-  console.log('Notifications prop:', notifications);
+
 
   const getNotificationDescription = (notification) => {
     if (notification.verb === 'comentó en tu camino de conocimiento') {
@@ -53,8 +53,8 @@ const Notifications = ({
               <br />
               <br />
               {match[2]}
-            </>
-          );
+            </>);
+
         }
         // Fallback: intentar dividir por el primer ": " después de las comillas de cierre
         const quoteIndex = notification.description.lastIndexOf('"');
@@ -69,8 +69,8 @@ const Notifications = ({
                 <br />
                 <br />
                 {optionalMessage}
-              </>
-            );
+              </>);
+
           }
         }
         return notification.description;
@@ -108,11 +108,11 @@ const Notifications = ({
             fontSize: {
               xs: "1.5rem", // ~24px on mobile
               sm: "1.75rem", // ~28px on small screens
-              md: "2.125rem", // ~34px on desktop (default h4)
+              md: "2.125rem" // ~34px on desktop (default h4)
             },
-            fontWeight: 600,
-          }}
-        >
+            fontWeight: 600
+          }}>
+          
           Notificaciones
         </Typography>
       </Box>
@@ -121,44 +121,44 @@ const Notifications = ({
           Marcar todas como leídas
         </Button>
       </Box>
-      {loading ? (
-        <Box sx={{ py: 6, display: 'flex', justifyContent: 'center' }}>
+      {loading ?
+      <Box sx={{ py: 6, display: 'flex', justifyContent: 'center' }}>
           <Stack alignItems="center" spacing={1.5}>
             <CircularProgress size={28} />
             <Typography variant="body2" color="text.secondary">
               Cargando notificaciones...
             </Typography>
           </Stack>
-        </Box>
-      ) : error ? (
-        <Alert severity="error">{error}</Alert>
-      ) : notifications.length === 0 ? (
-        <Alert severity="info">No se encontraron notificaciones</Alert>
-      ) : (
-        <Stack spacing={2}>
+        </Box> :
+      error ?
+      <Alert severity="error">{error}</Alert> :
+      notifications.length === 0 ?
+      <Alert severity="info">No se encontraron notificaciones</Alert> :
+
+      <Stack spacing={2}>
           {notifications.map((notification) => {
-            console.log('Notification:', notification);
-            return (
-              <Paper
-                key={notification.id}
-                variant="outlined"
-                sx={{
-                  p: 2,
-                  borderColor: notification.unread ? 'primary.light' : 'divider',
-                  bgcolor: notification.unread ? 'action.hover' : 'background.paper',
-                }}
-              >
+
+          return (
+            <Paper
+              key={notification.id}
+              variant="outlined"
+              sx={{
+                p: 2,
+                borderColor: notification.unread ? 'primary.light' : 'divider',
+                bgcolor: notification.unread ? 'action.hover' : 'background.paper'
+              }}>
+              
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}>
                   <Box sx={{ flex: 1 }}>
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap' }}>
                       <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                      {notification.actor && notification.actor_id ? (
-                        <MuiLink component={Link} to={`/profiles/user_profile/${notification.actor_id}`} underline="hover">
+                      {notification.actor && notification.actor_id ?
+                      <MuiLink component={Link} to={`/profiles/user_profile/${notification.actor_id}`} underline="hover">
                           {notification.actor}
-                        </MuiLink>
-                      ) : (
-                        notification.actor
-                      )}
+                        </MuiLink> :
+
+                      notification.actor
+                      }
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
                         {new Date(notification.timestamp).toLocaleString()}
@@ -169,45 +169,45 @@ const Notifications = ({
                       <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'pre-line' }}>
                       {getNotificationDescription(notification)}
                       </Typography>
-                    {notification.target_url && (
-                      <MuiLink
-                        component={Link}
-                        to={notification.target_url}
-                        underline="none"
-                        color="text.secondary"
-                        sx={{ display: 'flex', alignItems: 'center', ml: 1 }}
-                      >
+                    {notification.target_url &&
+                    <MuiLink
+                      component={Link}
+                      to={notification.target_url}
+                      underline="none"
+                      color="text.secondary"
+                      sx={{ display: 'flex', alignItems: 'center', ml: 1 }}>
+                      
                         <ApiIcon sx={{ fontSize: 20 }} />
                       </MuiLink>
-                    )}
+                    }
                     </Box>
                   </Box>
 
-                  {notification.unread && (
-                    <Tooltip title="Marcar como leída" arrow>
+                  {notification.unread &&
+                <Tooltip title="Marcar como leída" arrow>
                       <IconButton
-                        color="primary"
-                        onClick={() => onMarkAsRead(notification.id)}
-                      >
+                    color="primary"
+                    onClick={() => onMarkAsRead(notification.id)}>
+                    
                         <CheckCircleIcon sx={{ fontSize: 20 }} />
                       </IconButton>
                     </Tooltip>
-                  )}
+                }
                 </Box>
-              </Paper>
-            );
-          })}
+              </Paper>);
+
+        })}
         </Stack>
-      )}
+      }
       <Typography
         variant="caption"
         color="text.secondary"
-        sx={{ textAlign: 'center', display: 'block', mt: 2.5, fontStyle: 'italic' }}
-      >
+        sx={{ textAlign: 'center', display: 'block', mt: 2.5, fontStyle: 'italic' }}>
+        
         Las notificaciones leídas se eliminan después de 30 días
       </Typography>
-    </Container>
-  );
+    </Container>);
+
 };
 
-export default Notifications; 
+export default Notifications;

--- a/frontend/src/profiles/Register.jsx
+++ b/frontend/src/profiles/Register.jsx
@@ -16,8 +16,8 @@ import {
   Paper,
   Stack,
   TextField,
-  Typography,
-} from '@mui/material';
+  Typography } from
+'@mui/material';
 
 const Register = () => {
   const navigate = useNavigate();
@@ -26,7 +26,7 @@ const Register = () => {
     username: '',
     email: '',
     password: '',
-    confirmPassword: '',
+    confirmPassword: ''
   });
   const [errors, setErrors] = useState({});
   const [serverError, setServerError] = useState('');
@@ -65,7 +65,7 @@ const Register = () => {
       'A user with that username already exists.': 'Ya existe un usuario con ese nombre de usuario.',
       'A user with this email already exists.': 'Ya existe un usuario con ese correo electrónico.',
       'user with this username already exists.': 'Ya existe un usuario con ese nombre de usuario.',
-      'user with this email already exists.': 'Ya existe un usuario con ese correo electrónico.',
+      'user with this email already exists.': 'Ya existe un usuario con ese correo electrónico.'
     };
 
     // Check if message is in translations
@@ -113,15 +113,15 @@ const Register = () => {
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    
+
     // Prevent @ symbol in username field
     if (name === 'username' && value.includes('@')) {
       return; // Don't update the value if it contains @
     }
-    
+
     setFormData((prevData) => ({
       ...prevData,
-      [name]: value,
+      [name]: value
     }));
 
     // Clear error for this field when user starts typing
@@ -181,7 +181,7 @@ const Register = () => {
       username: true,
       email: true,
       password: true,
-      confirmPassword: true,
+      confirmPassword: true
     });
 
     // Validate all fields
@@ -226,7 +226,7 @@ const Register = () => {
     try {
       const { confirmPassword, ...registrationData } = formData;
       const response = await apiRegister(registrationData);
-      console.log("Register API response:", response);
+
 
       if (response.data) {
         const { access_token, ...userData } = response.data;
@@ -236,7 +236,7 @@ const Register = () => {
       }
     } catch (error) {
       console.error('Registration error:', error);
-      
+
       if (error.response && error.response.data) {
         if (typeof error.response.data === 'object' && error.response.data !== null) {
           const backendErrors = {};
@@ -253,9 +253,9 @@ const Register = () => {
             } else {
               // For non-field errors like 'detail' or general 'error' from backend
               if (key === 'detail' || key === 'error') {
-                const errorMsg = typeof error.response.data[key] === 'string' 
-                  ? translateErrorMessage(error.response.data[key])
-                  : JSON.stringify(error.response.data[key]);
+                const errorMsg = typeof error.response.data[key] === 'string' ?
+                translateErrorMessage(error.response.data[key]) :
+                JSON.stringify(error.response.data[key]);
                 setServerError(errorMsg.charAt(0).toUpperCase() + errorMsg.slice(1));
                 continue;
               }
@@ -263,7 +263,7 @@ const Register = () => {
             }
           }
           if (Object.keys(backendErrors).length > 0) {
-            setErrors(prevErrors => ({...prevErrors, ...backendErrors}));
+            setErrors((prevErrors) => ({ ...prevErrors, ...backendErrors }));
           }
         } else {
           // Handle cases where error.response.data is a string
@@ -287,11 +287,11 @@ const Register = () => {
           Crear cuenta
         </Typography>
 
-        {serverError && (
-          <Alert severity="error" sx={{ mb: 2 }} role="alert">
+        {serverError &&
+        <Alert severity="error" sx={{ mb: 2 }} role="alert">
             {serverError}
           </Alert>
-        )}
+        }
 
         <Box component="form" onSubmit={handleSubmit}>
           <Stack spacing={2}>
@@ -309,8 +309,8 @@ const Register = () => {
               }}
               error={Boolean(errors.username)}
               helperText={errors.username || ''}
-              fullWidth
-            />
+              fullWidth />
+            
 
             <TextField
               id="email"
@@ -322,8 +322,8 @@ const Register = () => {
               onBlur={handleBlur}
               error={Boolean(errors.email)}
               helperText={errors.email || ''}
-              fullWidth
-            />
+              fullWidth />
+            
 
             <TextField
               id="password"
@@ -335,42 +335,42 @@ const Register = () => {
               onBlur={handleBlur}
               error={Boolean(errors.password)}
               helperText={
-                Array.isArray(errors.password) ? (
-                  <Box component="span">
-                    {errors.password.map((err, index) => (
-                      <Box key={index} component="span" sx={{ display: 'block' }}>
+              Array.isArray(errors.password) ?
+              <Box component="span">
+                    {errors.password.map((err, index) =>
+                <Box key={index} component="span" sx={{ display: 'block' }}>
                         {err}
                       </Box>
-                    ))}
-                  </Box>
-                ) : (
-                  errors.password || ''
-                )
+                )}
+                  </Box> :
+
+              errors.password || ''
+
               }
               fullWidth
               InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
+                endAdornment:
+                <InputAdornment position="end">
                     <IconButton
-                      edge="end"
-                      onClick={() => setShowPassword(!showPassword)}
-                      aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-                    >
+                    edge="end"
+                    onClick={() => setShowPassword(!showPassword)}
+                    aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}>
+                    
                       {showPassword ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
                     </IconButton>
                   </InputAdornment>
-                ),
-              }}
-            />
+
+              }} />
+            
 
             {!errors.password &&
-              touched.password &&
-              formData.password &&
-              validatePassword(formData.password).length === 0 && (
-                <Alert severity="success">
+            touched.password &&
+            formData.password &&
+            validatePassword(formData.password).length === 0 &&
+            <Alert severity="success">
                   La contrasena cumple con todos los requisitos de seguridad.
                 </Alert>
-              )}
+            }
 
             <TextField
               id="confirmPassword"
@@ -384,19 +384,19 @@ const Register = () => {
               helperText={errors.confirmPassword || ''}
               fullWidth
               InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
+                endAdornment:
+                <InputAdornment position="end">
                     <IconButton
-                      edge="end"
-                      onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                      aria-label={showConfirmPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-                    >
+                    edge="end"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    aria-label={showConfirmPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}>
+                    
                       {showConfirmPassword ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
                     </IconButton>
                   </InputAdornment>
-                ),
-              }}
-            />
+
+              }} />
+            
 
             <Button type="submit" variant="contained" size="large" disabled={isSubmitting}>
               {isSubmitting ? 'Creando cuenta...' : 'Crear cuenta'}
@@ -407,8 +407,8 @@ const Register = () => {
         <Divider sx={{ my: 3 }}>O continúa con</Divider>
         <SocialLogin />
       </Paper>
-    </Container>
-  );
+    </Container>);
+
 };
 
 export default Register;

--- a/frontend/src/publications/PublicationCreationForm.jsx
+++ b/frontend/src/publications/PublicationCreationForm.jsx
@@ -6,8 +6,8 @@ import {
   Box,
   Typography,
   Paper,
-  Divider,
-} from "@mui/material";
+  Divider } from
+"@mui/material";
 import contentApi from "../api/contentApi";
 import ContentSelector from "../content/ContentSelector";
 
@@ -15,7 +15,7 @@ const PublicationCreationForm = () => {
   const navigate = useNavigate();
   const [formData, setFormData] = useState({
     text_content: "",
-    status: "PUBLISHED",
+    status: "PUBLISHED"
   });
   const [selectedContent, setSelectedContent] = useState(null);
   const [error, setError] = useState(null);
@@ -24,7 +24,7 @@ const PublicationCreationForm = () => {
   const [hasPendingContent, setHasPendingContent] = useState(false);
 
   const handleContentSelected = (contentProfile) => {
-    console.log("Content selected for publication:", contentProfile);
+
     setSelectedContent(contentProfile);
   };
 
@@ -38,9 +38,9 @@ const PublicationCreationForm = () => {
       setIsLoading(true);
       const publicationData = {
         ...formData,
-        content_profile_id: selectedContent?.id || null,
+        content_profile_id: selectedContent?.id || null
       };
-      console.log("Sending publication data:", publicationData);
+
       await contentApi.createPublication(publicationData);
       navigate("/profiles/my_profile");
     } catch (err) {
@@ -58,18 +58,18 @@ const PublicationCreationForm = () => {
   return (
     <Box sx={{ p: 3 }}>
 <Typography
-  variant="h4"
-  color="#000"
-  gutterBottom
-  sx={{
-    fontSize: {
-      xs: "1.5rem",  // ~24px on mobile
-      sm: "1.75rem", // ~28px on small screens
-      md: "2.125rem" // ~34px (default h4) on desktop
-    },
-    fontWeight: 600, // optional if you want it bolder
-  }}
->
+        variant="h4"
+        color="#000"
+        gutterBottom
+        sx={{
+          fontSize: {
+            xs: "1.5rem", // ~24px on mobile
+            sm: "1.75rem", // ~28px on small screens
+            md: "2.125rem" // ~34px (default h4) on desktop
+          },
+          fontWeight: 600 // optional if you want it bolder
+        }}>
+        
         Crear Nueva Publicación
       </Typography>
 
@@ -79,8 +79,8 @@ const PublicationCreationForm = () => {
         onContentRemoved={handleContentRemoved}
         previewVariant="detailed"
         onUploadingChange={setIsUploadingContent}
-        onPendingContentChange={setHasPendingContent}
-      />
+        onPendingContentChange={setHasPendingContent} />
+      
 
       <Paper elevation={2} sx={{ p: 4 }}>
         <Typography variant="h6" gutterBottom>
@@ -95,47 +95,47 @@ const PublicationCreationForm = () => {
           label="Contenido de Texto"
           value={formData.text_content}
           onChange={(e) =>
-            setFormData({ ...formData, text_content: e.target.value })
+          setFormData({ ...formData, text_content: e.target.value })
           }
           required
-          sx={{ mb: 3 }}
-        />
+          sx={{ mb: 3 }} />
+        
 
         <Divider sx={{ my: 3 }} />
 
         <Box sx={{ display: {
-                xs: "block",
-                md: "flex",
-              }, gap: 2, justifyContent: "flex-end" }}>
-          <Button  sx={{
-                mb: {
-                  xs: 1.25, // 10px on mobile (xs–sm) → 1.25 * 8px = 10px
-                  md: 0, // 0 on desktop (md+)
-                },
-              }}
-            variant="outlined"
-            onClick={handleCancel}
-            disabled={isLoading || isUploadingContent}
-          >
+            xs: "block",
+            md: "flex"
+          }, gap: 2, justifyContent: "flex-end" }}>
+          <Button sx={{
+            mb: {
+              xs: 1.25, // 10px on mobile (xs–sm) → 1.25 * 8px = 10px
+              md: 0 // 0 on desktop (md+)
+            }
+          }}
+          variant="outlined"
+          onClick={handleCancel}
+          disabled={isLoading || isUploadingContent}>
+            
             Cancelar
           </Button>
           <Button
             variant="contained"
             onClick={handleSubmit}
-            disabled={isLoading || isUploadingContent || hasPendingContent}
-          >
+            disabled={isLoading || isUploadingContent || hasPendingContent}>
+            
             {isLoading ? "Creando..." : "Crear Publicación"}
           </Button>
         </Box>
       </Paper>
 
-      {error && (
-        <Typography color="error" sx={{ mt: 2 }}>
+      {error &&
+      <Typography color="error" sx={{ mt: 2 }}>
           {error}
         </Typography>
-      )}
-    </Box>
-  );
+      }
+    </Box>);
+
 };
 
 export default PublicationCreationForm;

--- a/frontend/src/publications/PublicationEditForm.jsx
+++ b/frontend/src/publications/PublicationEditForm.jsx
@@ -23,21 +23,21 @@ const PublicationEditForm = () => {
       try {
         setIsFetching(true);
         const publicationData = await contentApi.getPublicationDetails(publicationId);
-        console.log('Publication data:', publicationData);
-        
+
+
         // Set form data
         setFormData({
           text_content: publicationData.text_content || '',
           status: publicationData.status || 'PUBLISHED',
           content_profile_id: publicationData.content_profile_id || null
         });
-        
+
         // Set content if it exists
         if (publicationData.content) {
-          console.log('Setting content:', publicationData.content);
+
           setSelectedContent(publicationData.content);
         }
-        
+
         setError(null);
       } catch (err) {
         console.error('Error fetching publication details:', err);
@@ -51,11 +51,11 @@ const PublicationEditForm = () => {
   }, [publicationId]);
 
   const handleContentSelected = (contentProfile) => {
-    console.log('Content selected for publication edit:', contentProfile);
+
     const contentProfileId = contentProfile.profile_id || contentProfile.id;
-    
+
     setSelectedContent(contentProfile);
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
       content_profile_id: contentProfileId
     }));
@@ -63,7 +63,7 @@ const PublicationEditForm = () => {
 
   const handleContentRemoved = () => {
     setSelectedContent(null);
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
       content_profile_id: null
     }));
@@ -76,7 +76,7 @@ const PublicationEditForm = () => {
       const publicationData = {
         ...formData
       };
-      console.log('Sending publication update data:', publicationData);
+
       await contentApi.updatePublication(publicationId, publicationData);
       navigate('/profiles/my_profile');
     } catch (err) {
@@ -110,19 +110,19 @@ const PublicationEditForm = () => {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
         <CircularProgress />
-      </Box>
-    );
+      </Box>);
+
   }
 
   return (
     <Box sx={{ p: 3 }}>
       <Box sx={{ mb: 3 }}>
-        <Link 
+        <Link
           component="button"
           variant="body2"
           onClick={() => navigate('/profiles/my_profile')}
-          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-        >
+          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          
           ← Volver al Perfil
         </Link>
       </Box>
@@ -137,8 +137,8 @@ const PublicationEditForm = () => {
         onContentRemoved={handleContentRemoved}
         previewVariant="preview"
         onUploadingChange={setIsUploadingContent}
-        onPendingContentChange={setHasPendingContent}
-      />
+        onPendingContentChange={setHasPendingContent} />
+      
 
       <Paper elevation={2} sx={{ p: 4 }}>
         <Typography variant="h6" gutterBottom>
@@ -154,8 +154,8 @@ const PublicationEditForm = () => {
           value={formData.text_content}
           onChange={(e) => setFormData({ ...formData, text_content: e.target.value })}
           required
-          sx={{ mb: 3 }}
-        />
+          sx={{ mb: 3 }} />
+        
 
         <Divider sx={{ my: 3 }} />
 
@@ -164,34 +164,34 @@ const PublicationEditForm = () => {
             variant="outlined"
             color="error"
             onClick={handleDelete}
-            disabled={isLoading || isUploadingContent}
-          >
+            disabled={isLoading || isUploadingContent}>
+            
             Eliminar
           </Button>
           <Button
             variant="outlined"
             onClick={handleCancel}
-            disabled={isLoading || isUploadingContent}
-          >
+            disabled={isLoading || isUploadingContent}>
+            
             Cancelar
           </Button>
           <Button
             variant="contained"
             onClick={handleSubmit}
-            disabled={isLoading || isUploadingContent || hasPendingContent}
-          >
+            disabled={isLoading || isUploadingContent || hasPendingContent}>
+            
             {isLoading ? 'Actualizando...' : 'Actualizar Publicación'}
           </Button>
         </Box>
       </Paper>
 
-      {error && (
-        <Typography color="error" sx={{ mt: 2 }}>
+      {error &&
+      <Typography color="error" sx={{ mt: 2 }}>
           {error}
         </Typography>
-      )}
-    </Box>
-  );
+      }
+    </Box>);
+
 };
 
-export default PublicationEditForm; 
+export default PublicationEditForm;

--- a/frontend/src/quizzes/QuizForm.jsx
+++ b/frontend/src/quizzes/QuizForm.jsx
@@ -27,8 +27,8 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  DialogTitle,
-} from '@mui/material';
+  DialogTitle } from
+'@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -41,7 +41,7 @@ const QuizForm = () => {
   const navigate = useNavigate();
   const { pathId: initialPathId, quizId } = useParams();
   const mode = quizId ? 'edit' : 'create';
-  
+
   const [nodes, setNodes] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -49,7 +49,7 @@ const QuizForm = () => {
   const [submitting, setSubmitting] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeletingQuiz, setIsDeletingQuiz] = useState(false);
-  
+
   const [quizData, setQuizData] = useState({
     title: '',
     description: '',
@@ -62,36 +62,36 @@ const QuizForm = () => {
     const initializeForm = async () => {
       try {
         let pathIdToUse = initialPathId;
-        console.log('Initializing form with path ID:', pathIdToUse);
-        
+
+
         if (mode === 'edit' && quizId) {
-          console.log('Edit mode - fetching quiz data for ID:', quizId);
+
           const quizData = await quizApi.getQuiz(quizId);
-          console.log('Received quiz data:', quizData);
-          
+
+
           if (!quizData.node) {
             console.error('Quiz is missing node information:', quizData);
             setError('Al cuestionario le falta información del nodo');
             return;
           }
-          
+
           pathIdToUse = quizData.knowledge_path;
-          console.log('Using path ID from quiz:', pathIdToUse);
+
           setCurrentPathId(pathIdToUse);
-          
+
           // Ensure max_attempts_per_day is at least 2
           const maxAttempts = Math.max(2, parseInt(quizData.max_attempts_per_day) || 2);
-          console.log('Initializing max_attempts_per_day:', maxAttempts);
-          
+
+
           setQuizData({
             title: quizData.title,
             description: quizData.description,
             precedingNodeId: String(quizData.node),
             max_attempts_per_day: maxAttempts,
-            questions: quizData.questions.map(q => ({
+            questions: quizData.questions.map((q) => ({
               text: q.text,
               questionType: q.question_type,
-              options: q.options.map(opt => ({
+              options: q.options.map((opt) => ({
                 text: opt.text,
                 isCorrect: opt.is_correct
               }))
@@ -99,11 +99,11 @@ const QuizForm = () => {
           });
         }
 
-        console.log('Fetching path data for ID:', pathIdToUse);
+
         const pathData = await knowledgePathsApi.getKnowledgePath(pathIdToUse);
-        console.log('Received path data:', pathData);
+
         setNodes(pathData.nodes || []);
-        console.log('Available nodes:', pathData.nodes);
+
       } catch (err) {
         console.error('Form initialization error:', err);
         console.error('Error details:', {
@@ -123,26 +123,16 @@ const QuizForm = () => {
     e.preventDefault();
     setError(null);
     setSubmitting(true);
-    console.log('Submitting quiz data:', quizData);
-    console.log('Current path ID:', currentPathId);
-    console.log('Initial path ID:', initialPathId);
-    console.log('Selected node ID:', quizData.precedingNodeId);
-    
+
+
     try {
       if (mode === 'create') {
-        console.log('Creating new quiz with data:', {
-          pathId: initialPathId,
-          quizData: {
-            ...quizData,
-            node: quizData.precedingNodeId
-          }
-        });
+
+
         await quizApi.createQuiz(initialPathId, quizData);
       } else {
-        console.log('Updating quiz with data:', {
-          ...quizData,
-          node: quizData.precedingNodeId
-        });
+
+
         await quizApi.updateQuiz(quizId, {
           ...quizData,
           node: quizData.precedingNodeId
@@ -157,27 +147,27 @@ const QuizForm = () => {
       });
       // Parse the error response
       let errorMessage = `Error al ${mode === 'create' ? 'crear' : 'actualizar'} el cuestionario`;
-      
+
       if (err?.response?.data) {
         const errors = err.response.data;
-        console.log('Received error data:', errors);
+
         // Convert validation errors into readable messages
         const errorMessages = Object.entries(errors).map(([field, messages]) => {
           // Convert field name to readable format (e.g., max_attempts_per_day -> Maximum Attempts Per Day)
-          const readableField = field
-            .split('_')
-            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(' ');
+          const readableField = field.
+          split('_').
+          map((word) => word.charAt(0).toUpperCase() + word.slice(1)).
+          join(' ');
           // Handle both string and array messages
           const messageList = Array.isArray(messages) ? messages : [messages];
           return `${readableField}: ${messageList.join(', ')}`;
         });
-        
+
         if (errorMessages.length > 0) {
           errorMessage = errorMessages.join('\n');
         }
       }
-      
+
       setError(errorMessage);
     } finally {
       setSubmitting(false);
@@ -185,15 +175,15 @@ const QuizForm = () => {
   };
 
   const handleAddQuestion = () => {
-    setQuizData(prev => ({
+    setQuizData((prev) => ({
       ...prev,
       questions: [...prev.questions, {
         text: '',
         questionType: 'SINGLE',
         options: [
-          { text: '', isCorrect: true },
-          { text: '', isCorrect: false }
-        ]
+        { text: '', isCorrect: true },
+        { text: '', isCorrect: false }]
+
       }]
     }));
   };
@@ -201,21 +191,21 @@ const QuizForm = () => {
   const handleQuestionChange = (index, field, value) => {
     const updatedQuestions = [...quizData.questions];
     const question = updatedQuestions[index];
-    
+
     if (field === 'questionType') {
       // When changing question type, ensure proper option selection
       if (value === 'SINGLE') {
         // For Single Choice, ensure exactly one option is correct
-        const hasCorrectOption = question.options.some(opt => opt.isCorrect);
+        const hasCorrectOption = question.options.some((opt) => opt.isCorrect);
         if (!hasCorrectOption && question.options.length > 0) {
           // If no option is correct, make the first one correct
           question.options[0].isCorrect = true;
         }
       }
     }
-    
+
     updatedQuestions[index] = { ...question, [field]: value };
-    setQuizData(prev => ({ ...prev, questions: updatedQuestions }));
+    setQuizData((prev) => ({ ...prev, questions: updatedQuestions }));
   };
 
   const handleOptionChange = (questionIndex, optionIndex, field, value) => {
@@ -231,7 +221,7 @@ const QuizForm = () => {
         });
       } else {
         // If unchecking the only correct option, prevent it
-        const correctOptionsCount = question.options.filter(opt => opt.isCorrect).length;
+        const correctOptionsCount = question.options.filter((opt) => opt.isCorrect).length;
         if (correctOptionsCount <= 1) {
           return; // Don't allow unchecking if it's the only correct option
         }
@@ -244,24 +234,24 @@ const QuizForm = () => {
       [field]: value
     };
 
-    setQuizData(prev => ({ ...prev, questions: updatedQuestions }));
+    setQuizData((prev) => ({ ...prev, questions: updatedQuestions }));
   };
 
   const handleRemoveOption = (questionIndex, optionIndex) => {
     const updatedQuestions = [...quizData.questions];
     updatedQuestions[questionIndex].options = updatedQuestions[questionIndex].options.filter((_, i) => i !== optionIndex);
-    setQuizData(prev => ({ ...prev, questions: updatedQuestions }));
+    setQuizData((prev) => ({ ...prev, questions: updatedQuestions }));
   };
 
   const handleAddOption = (questionIndex) => {
     const updatedQuestions = [...quizData.questions];
     updatedQuestions[questionIndex].options.push({ text: '', isCorrect: false });
-    setQuizData(prev => ({ ...prev, questions: updatedQuestions }));
+    setQuizData((prev) => ({ ...prev, questions: updatedQuestions }));
   };
 
   const handleRemoveQuestion = (questionIndex) => {
     const updatedQuestions = quizData.questions.filter((_, i) => i !== questionIndex);
-    setQuizData(prev => ({ ...prev, questions: updatedQuestions }));
+    setQuizData((prev) => ({ ...prev, questions: updatedQuestions }));
   };
 
   const openDeleteDialog = () => setDeleteDialogOpen(true);
@@ -288,8 +278,8 @@ const QuizForm = () => {
         <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
           <CircularProgress />
         </Box>
-      </Container>
-    );
+      </Container>);
+
   }
 
   return (
@@ -300,8 +290,8 @@ const QuizForm = () => {
           <Button
             startIcon={<ArrowBackIcon />}
             onClick={() => navigate(`/knowledge_path/${currentPathId}/edit`)}
-            sx={{ textTransform: 'none', mb: 2 }}
-          >
+            sx={{ textTransform: 'none', mb: 2 }}>
+            
             Volver al Camino de Conocimiento
           </Button>
           <Typography variant="h4" component="h1" sx={{ fontWeight: 700, mb: 1 }}>
@@ -310,11 +300,11 @@ const QuizForm = () => {
         </Box>
 
         {/* Error Alert */}
-        {error && (
-          <Alert severity="error" sx={{ whiteSpace: 'pre-line' }}>
+        {error &&
+        <Alert severity="error" sx={{ whiteSpace: 'pre-line' }}>
             {error}
           </Alert>
-        )}
+        }
 
         {/* Form */}
         <Paper elevation={1} sx={{ p: { xs: 3, md: 4 }, borderRadius: 3 }}>
@@ -328,16 +318,16 @@ const QuizForm = () => {
                   id="preceding-node"
                   value={quizData.precedingNodeId}
                   label="Seleccionar Nodo Precedente"
-                  onChange={(e) => setQuizData(prev => ({ ...prev, precedingNodeId: e.target.value }))}
-                >
+                  onChange={(e) => setQuizData((prev) => ({ ...prev, precedingNodeId: e.target.value }))}>
+                  
                   <MenuItem value="">
                     <em>Seleccionar un nodo...</em>
                   </MenuItem>
-                  {nodes.map(node => (
-                    <MenuItem key={node.id} value={node.id}>
+                  {nodes.map((node) =>
+                  <MenuItem key={node.id} value={node.id}>
                       {node.title}
                     </MenuItem>
-                  ))}
+                  )}
                 </Select>
               </FormControl>
 
@@ -347,20 +337,20 @@ const QuizForm = () => {
                 required
                 label="Título del Cuestionario"
                 value={quizData.title}
-                onChange={(e) => setQuizData(prev => ({ ...prev, title: e.target.value }))}
-                variant="outlined"
-              />
+                onChange={(e) => setQuizData((prev) => ({ ...prev, title: e.target.value }))}
+                variant="outlined" />
+              
 
               {/* Quiz Description */}
               <TextField
                 fullWidth
                 label="Descripción del Cuestionario"
                 value={quizData.description}
-                onChange={(e) => setQuizData(prev => ({ ...prev, description: e.target.value }))}
+                onChange={(e) => setQuizData((prev) => ({ ...prev, description: e.target.value }))}
                 variant="outlined"
                 multiline
-                rows={3}
-              />
+                rows={3} />
+              
 
               <Divider />
 
@@ -371,14 +361,14 @@ const QuizForm = () => {
                   <Typography variant="h6" component="h2" sx={{ fontWeight: 600 }}>
                     Preguntas
                   </Typography>
-                  {quizData.questions.length > 0 && (
-                    <Chip label={`${quizData.questions.length} pregunta(s)`} size="small" color="primary" variant="outlined" />
-                  )}
+                  {quizData.questions.length > 0 &&
+                  <Chip label={`${quizData.questions.length} pregunta(s)`} size="small" color="primary" variant="outlined" />
+                  }
                 </Stack>
 
                 <Stack spacing={3}>
-                  {quizData.questions.map((question, qIndex) => (
-                    <Card key={qIndex} variant="outlined" sx={{ borderRadius: 2 }}>
+                  {quizData.questions.map((question, qIndex) =>
+                  <Card key={qIndex} variant="outlined" sx={{ borderRadius: 2 }}>
                       <CardContent>
                         <Stack spacing={3}>
                           {/* Question Header */}
@@ -386,40 +376,40 @@ const QuizForm = () => {
                             <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
                               Pregunta {qIndex + 1}
                             </Typography>
-                            {quizData.questions.length > 1 && (
-                              <IconButton
-                                size="small"
-                                color="error"
-                                onClick={() => handleRemoveQuestion(qIndex)}
-                                aria-label="Eliminar pregunta"
-                              >
+                            {quizData.questions.length > 1 &&
+                          <IconButton
+                            size="small"
+                            color="error"
+                            onClick={() => handleRemoveQuestion(qIndex)}
+                            aria-label="Eliminar pregunta">
+                            
                                 <DeleteIcon fontSize="small" />
                               </IconButton>
-                            )}
+                          }
                           </Stack>
 
                           {/* Question Text */}
                           <TextField
-                            fullWidth
-                            required
-                            label="Texto de la Pregunta"
-                            value={question.text}
-                            onChange={(e) => handleQuestionChange(qIndex, 'text', e.target.value)}
-                            variant="outlined"
-                            multiline
-                            rows={2}
-                          />
+                          fullWidth
+                          required
+                          label="Texto de la Pregunta"
+                          value={question.text}
+                          onChange={(e) => handleQuestionChange(qIndex, 'text', e.target.value)}
+                          variant="outlined"
+                          multiline
+                          rows={2} />
+                        
 
                           {/* Question Type */}
                           <FormControl fullWidth>
                             <InputLabel id={`question-type-${qIndex}-label`}>Tipo de Pregunta</InputLabel>
                             <Select
-                              labelId={`question-type-${qIndex}-label`}
-                              id={`question-type-${qIndex}`}
-                              value={question.questionType}
-                              label="Tipo de Pregunta"
-                              onChange={(e) => handleQuestionChange(qIndex, 'questionType', e.target.value)}
-                            >
+                            labelId={`question-type-${qIndex}-label`}
+                            id={`question-type-${qIndex}`}
+                            value={question.questionType}
+                            label="Tipo de Pregunta"
+                            onChange={(e) => handleQuestionChange(qIndex, 'questionType', e.target.value)}>
+                            
                               <MenuItem value="SINGLE">Opción Única</MenuItem>
                               <MenuItem value="MULTIPLE">Opción Múltiple</MenuItem>
                             </Select>
@@ -433,51 +423,51 @@ const QuizForm = () => {
                               Opciones
                             </Typography>
                             <Stack spacing={2}>
-                              {question.options.map((option, oIndex) => (
-                                <Stack key={oIndex} direction="row" spacing={2} alignItems="flex-start">
-                                  {question.questionType === 'SINGLE' ? (
-                                    <Radio
-                                      checked={option.isCorrect}
-                                      onChange={(e) => handleOptionChange(qIndex, oIndex, 'isCorrect', e.target.checked)}
-                                      name={`question-${qIndex}-correct`}
-                                      sx={{ mt: 0.5 }}
-                                    />
-                                  ) : (
-                                    <Checkbox
-                                      checked={option.isCorrect}
-                                      onChange={(e) => handleOptionChange(qIndex, oIndex, 'isCorrect', e.target.checked)}
-                                      sx={{ mt: 0.5 }}
-                                    />
-                                  )}
+                              {question.options.map((option, oIndex) =>
+                            <Stack key={oIndex} direction="row" spacing={2} alignItems="flex-start">
+                                  {question.questionType === 'SINGLE' ?
+                              <Radio
+                                checked={option.isCorrect}
+                                onChange={(e) => handleOptionChange(qIndex, oIndex, 'isCorrect', e.target.checked)}
+                                name={`question-${qIndex}-correct`}
+                                sx={{ mt: 0.5 }} /> :
+
+
+                              <Checkbox
+                                checked={option.isCorrect}
+                                onChange={(e) => handleOptionChange(qIndex, oIndex, 'isCorrect', e.target.checked)}
+                                sx={{ mt: 0.5 }} />
+
+                              }
                                   <TextField
-                                    fullWidth
-                                    required
-                                    size="small"
-                                    placeholder="Texto de la opción"
-                                    value={option.text}
-                                    onChange={(e) => handleOptionChange(qIndex, oIndex, 'text', e.target.value)}
-                                    variant="outlined"
-                                  />
-                                  {question.options.length > 2 && (
-                                    <IconButton
-                                      size="small"
-                                      color="error"
-                                      onClick={() => handleRemoveOption(qIndex, oIndex)}
-                                      aria-label="Eliminar opción"
-                                      sx={{ mt: 0.5 }}
-                                    >
+                                fullWidth
+                                required
+                                size="small"
+                                placeholder="Texto de la opción"
+                                value={option.text}
+                                onChange={(e) => handleOptionChange(qIndex, oIndex, 'text', e.target.value)}
+                                variant="outlined" />
+                              
+                                  {question.options.length > 2 &&
+                              <IconButton
+                                size="small"
+                                color="error"
+                                onClick={() => handleRemoveOption(qIndex, oIndex)}
+                                aria-label="Eliminar opción"
+                                sx={{ mt: 0.5 }}>
+                                
                                       <DeleteIcon fontSize="small" />
                                     </IconButton>
-                                  )}
+                              }
                                 </Stack>
-                              ))}
+                            )}
                               <Button
-                                startIcon={<AddIcon />}
-                                onClick={() => handleAddOption(qIndex)}
-                                variant="outlined"
-                                size="small"
-                                sx={{ textTransform: 'none', alignSelf: 'flex-start' }}
-                              >
+                              startIcon={<AddIcon />}
+                              onClick={() => handleAddOption(qIndex)}
+                              variant="outlined"
+                              size="small"
+                              sx={{ textTransform: 'none', alignSelf: 'flex-start' }}>
+                              
                                 Agregar Opción
                               </Button>
                             </Stack>
@@ -485,7 +475,7 @@ const QuizForm = () => {
                         </Stack>
                       </CardContent>
                     </Card>
-                  ))}
+                  )}
 
                   {/* Add Question Button */}
                   <Button
@@ -493,8 +483,8 @@ const QuizForm = () => {
                     onClick={handleAddQuestion}
                     variant="outlined"
                     color="success"
-                    sx={{ textTransform: 'none' }}
-                  >
+                    sx={{ textTransform: 'none' }}>
+                    
                     Agregar Pregunta
                   </Button>
                 </Stack>
@@ -512,14 +502,14 @@ const QuizForm = () => {
                   label="Intentos Máximos por Día"
                   onChange={(e) => {
                     const value = Math.max(2, parseInt(e.target.value) || 2);
-                    setQuizData(prev => ({ ...prev, max_attempts_per_day: value }));
-                  }}
-                >
-                  {[2, 3, 4, 5, 6, 7, 8, 9].map(num => (
-                    <MenuItem key={num} value={num}>
+                    setQuizData((prev) => ({ ...prev, max_attempts_per_day: value }));
+                  }}>
+                  
+                  {[2, 3, 4, 5, 6, 7, 8, 9].map((num) =>
+                  <MenuItem key={num} value={num}>
                       {num} intentos
                     </MenuItem>
-                  ))}
+                  )}
                 </Select>
                 <FormHelperText>
                   Establezca cuántas veces un estudiante puede intentar este cuestionario por día
@@ -531,8 +521,8 @@ const QuizForm = () => {
                 <Button
                   onClick={() => navigate(`/knowledge_path/${currentPathId}/edit`)}
                   variant="outlined"
-                  sx={{ textTransform: 'none' }}
-                >
+                  sx={{ textTransform: 'none' }}>
+                  
                   Cancelar
                 </Button>
                 <Button
@@ -540,16 +530,16 @@ const QuizForm = () => {
                   variant="contained"
                   color="primary"
                   disabled={submitting}
-                  sx={{ textTransform: 'none' }}
-                >
-                  {submitting ? (
-                    <>
+                  sx={{ textTransform: 'none' }}>
+                  
+                  {submitting ?
+                  <>
                       <CircularProgress size={20} sx={{ mr: 1 }} />
                       {mode === 'create' ? 'Creando...' : 'Actualizando...'}
-                    </>
-                  ) : (
-                    mode === 'create' ? 'Crear Cuestionario' : 'Actualizar Cuestionario'
-                  )}
+                    </> :
+
+                  mode === 'create' ? 'Crear Cuestionario' : 'Actualizar Cuestionario'
+                  }
                 </Button>
               </Box>
             </Stack>
@@ -557,17 +547,17 @@ const QuizForm = () => {
         </Paper>
 
         {/* Zona de peligro: eliminar cuestionario (solo en modo edición) */}
-        {mode === 'edit' && (
-          <Paper
-            elevation={1}
-            sx={{
-              mt: 2,
-              p: 3,
-              borderRadius: 3,
-              border: '1px solid',
-              borderColor: 'error.light',
-            }}
-          >
+        {mode === 'edit' &&
+        <Paper
+          elevation={1}
+          sx={{
+            mt: 2,
+            p: 3,
+            borderRadius: 3,
+            border: '1px solid',
+            borderColor: 'error.light'
+          }}>
+          
             <Typography variant="h6" color="error" sx={{ fontWeight: 700, mb: 1 }}>
               Zona de peligro
             </Typography>
@@ -575,16 +565,16 @@ const QuizForm = () => {
               Si eliminas este cuestionario se borrarán todas sus preguntas y respuestas y no podrás recuperarlos.
             </Typography>
             <Button
-              variant="outlined"
-              color="error"
-              startIcon={<DeleteForeverIcon />}
-              onClick={openDeleteDialog}
-              sx={{ textTransform: 'none' }}
-            >
+            variant="outlined"
+            color="error"
+            startIcon={<DeleteForeverIcon />}
+            onClick={openDeleteDialog}
+            sx={{ textTransform: 'none' }}>
+            
               Eliminar cuestionario
             </Button>
           </Paper>
-        )}
+        }
 
       </Stack>
 
@@ -605,8 +595,8 @@ const QuizForm = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Container>
-  );
+    </Container>);
+
 };
 
 export default QuizForm;

--- a/frontend/src/topics/TopicContentMediaType.jsx
+++ b/frontend/src/topics/TopicContentMediaType.jsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { 
-    Box, 
-    Typography, 
-    Grid,
-    Chip,
-    Button,
-    Link
-} from '@mui/material';
+import {
+  Box,
+  Typography,
+  Grid,
+  Chip,
+  Button,
+  Link } from
+'@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import contentApi from '../api/contentApi';
 import { resolveMediaUrl } from '../utils/fileUtils';
@@ -17,168 +17,166 @@ import TopicHeader from './TopicHeader';
 import ContentDisplay from '../content/ContentDisplay';
 
 const TopicContentMediaType = () => {
-    const { topicId, mediaType } = useParams();
-    const navigate = useNavigate();
-    const [topic, setTopic] = useState(null);
-    const [contents, setContents] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
+  const { topicId, mediaType } = useParams();
+  const navigate = useNavigate();
+  const [topic, setTopic] = useState(null);
+  const [contents, setContents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-    useEffect(() => {
-        const fetchTopicAndContents = async () => {
-            try {
-                console.log(`Fetching topic ${topicId} and ${mediaType} contents...`);
-                const [topicData, contentsData] = await Promise.all([
-                    contentApi.getTopicDetails(topicId),
-                    contentApi.getTopicContentByType(topicId, mediaType)
-                ]);
-                
-                console.log('Received topic data:', topicData);
-                console.log('Received contents data:', contentsData);
-                
-                setTopic(topicData);
-                setContents(contentsData.contents || []);
-                setLoading(false);
-            } catch (err) {
-                console.error('Error fetching data:', err);
-                console.error('Error details:', {
-                    message: err.message,
-                    status: err.response?.status,
-                    data: err.response?.data
-                });
-                setError('Error al cargar los detalles del tema o del contenido');
-                setLoading(false);
-            }
-        };
+  useEffect(() => {
+    const fetchTopicAndContents = async () => {
+      try {
 
-        fetchTopicAndContents();
-    }, [topicId, mediaType]);
+        const [topicData, contentsData] = await Promise.all([
+        contentApi.getTopicDetails(topicId),
+        contentApi.getTopicContentByType(topicId, mediaType)]
+        );
 
-    const renderContentPreview = (content) => {
-        if (!content.file_details) return null;
 
-        switch (mediaType) {
-            case 'image':
-                return (
-                    <CardMedia
-                        component="img"
-                        sx={{ 
-                            height: 200,
-                            width: '100%',
-                            objectFit: 'cover'
-                        }}
-                        image={resolveMediaUrl(content.file_details?.url) || `https://picsum.photos/800/600?random=${content.id}`}
-                        alt={content.selected_profile?.title || 'Content image'}
-                    />
-                );
-            case 'text':
-                return (
-                    <CardContent>
+        setTopic(topicData);
+        setContents(contentsData.contents || []);
+        setLoading(false);
+      } catch (err) {
+        console.error('Error fetching data:', err);
+        console.error('Error details:', {
+          message: err.message,
+          status: err.response?.status,
+          data: err.response?.data
+        });
+        setError('Error al cargar los detalles del tema o del contenido');
+        setLoading(false);
+      }
+    };
+
+    fetchTopicAndContents();
+  }, [topicId, mediaType]);
+
+  const renderContentPreview = (content) => {
+    if (!content.file_details) return null;
+
+    switch (mediaType) {
+      case 'image':
+        return (
+          <CardMedia
+            component="img"
+            sx={{
+              height: 200,
+              width: '100%',
+              objectFit: 'cover'
+            }}
+            image={resolveMediaUrl(content.file_details?.url) || `https://picsum.photos/800/600?random=${content.id}`}
+            alt={content.selected_profile?.title || 'Content image'} />);
+
+
+      case 'text':
+        return (
+          <CardContent>
                         <Typography variant="body2" color="text.secondary" noWrap>
                             {content.file_details?.text || 'Vista previa no disponible'}
                         </Typography>
-                    </CardContent>
-                );
-            case 'video':
-                return (
-                    <Box sx={{ position: 'relative', height: 200 }}>
+                    </CardContent>);
+
+      case 'video':
+        return (
+          <Box sx={{ position: 'relative', height: 200 }}>
                         <CardMedia
-                            component="video"
-                            sx={{ 
-                                height: '100%',
-                                width: '100%',
-                                objectFit: 'cover'
-                            }}
-                            image={resolveMediaUrl(content.file_details?.url)}
-                        />
+              component="video"
+              sx={{
+                height: '100%',
+                width: '100%',
+                objectFit: 'cover'
+              }}
+              image={resolveMediaUrl(content.file_details?.url)} />
+            
                         <Box
-                            sx={{
-                                position: 'absolute',
-                                top: 0,
-                                left: 0,
-                                width: '100%',
-                                height: '100%',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                bgcolor: 'rgba(0, 0, 0, 0.3)',
-                            }}
-                        >
+              sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                bgcolor: 'rgba(0, 0, 0, 0.3)'
+              }}>
+              
                             <Typography variant="body1" color="white">
                                 Haz clic para reproducir el video
                             </Typography>
                         </Box>
-                    </Box>
-                );
-            case 'audio':
-                return (
-                    <Box sx={{ p: 2 }}>
+                    </Box>);
+
+      case 'audio':
+        return (
+          <Box sx={{ p: 2 }}>
                         <audio
-                            controls
-                            style={{ width: '100%' }}
-                        >
+              controls
+              style={{ width: '100%' }}>
+              
                             <source src={resolveMediaUrl(content.file_details?.url)} type="audio/mpeg" />
                             Tu navegador no soporta el elemento de audio.
                         </audio>
-                    </Box>
-                );
-            default:
-                return null;
-        }
-    };
+                    </Box>);
 
-    if (loading) return <Typography>Cargando contenido...</Typography>;
-    if (error) return <Typography color="error">{error}</Typography>;
-    if (!topic) return <Typography>Tema no encontrado</Typography>;
+      default:
+        return null;
+    }
+  };
 
-    return (
-        <Box sx={{ pt: { xs: 2, md: 4 }, px: { xs: 1, md: 3 }, maxWidth: 1200, mx: 'auto' }}>
-            <TopicHeader 
-                topic={topic}
-                onEdit={() => navigate(`/content/topics/${topicId}/edit`)}
-                size="small"
-            />
+  if (loading) return <Typography>Cargando contenido...</Typography>;
+  if (error) return <Typography color="error">{error}</Typography>;
+  if (!topic) return <Typography>Tema no encontrado</Typography>;
+
+  return (
+    <Box sx={{ pt: { xs: 2, md: 4 }, px: { xs: 1, md: 3 }, maxWidth: 1200, mx: 'auto' }}>
+            <TopicHeader
+        topic={topic}
+        onEdit={() => navigate(`/content/topics/${topicId}/edit`)}
+        size="small" />
+      
 
             <Box sx={{ mb: 4 }}>
                 <Button
-                    onClick={() => navigate(`/content/topics/${topicId}`)}
-                    startIcon={<ArrowBackIcon />}
-                    sx={{ mb: 2, textTransform: 'none' }}
-                >
+          onClick={() => navigate(`/content/topics/${topicId}`)}
+          startIcon={<ArrowBackIcon />}
+          sx={{ mb: 2, textTransform: 'none' }}>
+          
                     Regresar a la vista principal del tema
                 </Button>
-                <Typography 
-                    variant="h5" 
-                    sx={{ 
-                        mb: 2,
-                        fontFamily: "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif",
-                        fontWeight: 400,
-                        fontSize: "20px"
-                    }} 
-                    color="text.primary"
-                >
+                <Typography
+          variant="h5"
+          sx={{
+            mb: 2,
+            fontFamily: "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif",
+            fontWeight: 400,
+            fontSize: "20px"
+          }}
+          color="text.primary">
+          
                     {mediaType === 'image' ? 'Todas las imágenes' : mediaType === 'text' ? 'Todos los textos' : `Todos los ${mediaType}s`}
                 </Typography>
 
                 <Grid container spacing={3}>
-                    {contents.map((content) => (
-                        <Grid item xs={12} sm={6} md={4} key={content.id}>
+                    {contents.map((content) =>
+          <Grid item xs={12} sm={6} md={4} key={content.id}>
                             <ContentDisplay
-                                content={content}
-                                variant="card"
-                                showAuthor={true}
-                                showTitle={mediaType !== 'image'}
-                                topicId={topicId}
-                                onClick={() => navigate(`/content/${content.id}/topic/${topicId}`)}
-                            />
+              content={content}
+              variant="card"
+              showAuthor={true}
+              showTitle={mediaType !== 'image'}
+              topicId={topicId}
+              onClick={() => navigate(`/content/${content.id}/topic/${topicId}`)} />
+            
                         </Grid>
-                    ))}
+          )}
                 </Grid>
             </Box>
 
             <CommentSection topicId={topicId} />
-        </Box>
-    );
+        </Box>);
+
 };
 
-export default TopicContentMediaType; 
+export default TopicContentMediaType;

--- a/frontend/src/votes/VoteComponent.jsx
+++ b/frontend/src/votes/VoteComponent.jsx
@@ -8,171 +8,137 @@ import { AuthContext } from '../context/AuthContext';
 import useAuthErrorHandler, { AUTH_ERROR_STRATEGY } from '../hooks/useAuthErrorHandler';
 
 const VoteComponent = ({ type, ids, initialVoteCount = 0, initialUserVote = 0 }) => {
-    const { authState } = useContext(AuthContext);
-    const { handleAuthError, getErrorMessage } = useAuthErrorHandler();
-    const [voteCount, setVoteCount] = useState(Number(initialVoteCount) || 0);
-    const [userVote, setUserVote] = useState(Number(initialUserVote) || 0);
-    const [loading, setLoading] = useState(false);
+  const { authState } = useContext(AuthContext);
+  const { handleAuthError, getErrorMessage } = useAuthErrorHandler();
+  const [voteCount, setVoteCount] = useState(Number(initialVoteCount) || 0);
+  const [userVote, setUserVote] = useState(Number(initialUserVote) || 0);
+  const [loading, setLoading] = useState(false);
+  // Update state when props change
+  useEffect(() => {
+    const newVoteCount = Number(initialVoteCount) || 0;
+    const newUserVote = Number(initialUserVote) || 0;
 
-    // Debug logging
-    console.log('VoteComponent render:', {
-        type,
-        ids,
-        initialVoteCount,
-        initialUserVote,
-        voteCount,
-        userVote,
-        loading,
-        isAuthenticated: authState.isAuthenticated
-    });
 
-    // Update state when props change
-    useEffect(() => {
-        const newVoteCount = Number(initialVoteCount) || 0;
-        const newUserVote = Number(initialUserVote) || 0;
-        
-        console.log('VoteComponent useEffect:', {
-            initialVoteCount,
-            initialUserVote,
-            newVoteCount,
-            newUserVote
-        });
-        
-        setVoteCount(newVoteCount);
-        setUserVote(newUserVote);
-    }, [initialVoteCount, initialUserVote]);
+    setVoteCount(newVoteCount);
+    setUserVote(newUserVote);
+  }, [initialVoteCount, initialUserVote]);
 
-    const calculateVoteChange = (currentVote, action) => {
-        // If upvoting
-        if (action === 'upvote') {
-            if (currentVote === 1) {
-                return { voteChange: -1, newUserVote: 0 }; // Remove upvote
-            }
-            if (currentVote === -1) {
-                return { voteChange: 2, newUserVote: 1 }; // Change from downvote to upvote
-            }
-            return { voteChange: 1, newUserVote: 1 }; // Add upvote
-        }
-        // If downvoting
-        if (action === 'downvote') {
-            if (currentVote === -1) {
-                return { voteChange: 1, newUserVote: 0 }; // Remove downvote
-            }
-            if (currentVote === 1) {
-                return { voteChange: -2, newUserVote: -1 }; // Change from upvote to downvote
-            }
-            return { voteChange: -1, newUserVote: -1 }; // Add downvote
-        }
-        return { voteChange: 0, newUserVote: currentVote };
-    };
+  const calculateVoteChange = (currentVote, action) => {
+    // If upvoting
+    if (action === 'upvote') {
+      if (currentVote === 1) {
+        return { voteChange: -1, newUserVote: 0 }; // Remove upvote
+      }
+      if (currentVote === -1) {
+        return { voteChange: 2, newUserVote: 1 }; // Change from downvote to upvote
+      }
+      return { voteChange: 1, newUserVote: 1 }; // Add upvote
+    }
+    // If downvoting
+    if (action === 'downvote') {
+      if (currentVote === -1) {
+        return { voteChange: 1, newUserVote: 0 }; // Remove downvote
+      }
+      if (currentVote === 1) {
+        return { voteChange: -2, newUserVote: -1 }; // Change from upvote to downvote
+      }
+      return { voteChange: -1, newUserVote: -1 }; // Add downvote
+    }
+    return { voteChange: 0, newUserVote: currentVote };
+  };
 
-    const handleVote = async (action) => {
-        if (loading) {
-            console.log('VoteComponent: Already loading, ignoring vote action');
-            return;
-        }
-        
-        // Check if user is authenticated
-        if (!authState.isAuthenticated) {
-            console.log('VoteComponent: User not authenticated, cannot vote');
-            alert('Please log in to vote');
-            return;
-        }
-        
-        console.log('VoteComponent handleVote:', {
-            action,
-            type,
-            ids,
-            currentVoteCount: voteCount,
-            currentUserVote: userVote,
-            isAuthenticated: authState.isAuthenticated
-        });
-        
-        setLoading(true);
+  const handleVote = async (action) => {
+    if (loading) {
 
-        try {
-            let response;
-            switch (type) {
-                case 'content':
-                    response = await votesApi.voteContent(ids.topicId, ids.contentId, action);
-                    break;
-                case 'comment':
-                    response = await votesApi.voteComment(ids.commentId, action);
-                    break;
-                case 'knowledge_path':
-                    response = await votesApi.voteKnowledgePath(ids.pathId, action);
-                    break;
-                case 'publication':
-                    response = await votesApi.votePublication(ids.publicationId, action);
-                    break;
-                case 'content_suggestion':
-                    response = await votesApi.voteContentSuggestion(ids.suggestionId, action);
-                    break;
-                default:
-                    throw new Error('Invalid vote type');
-            }
-            
-            console.log('VoteComponent API response:', response);
-            
-            // Update with server values
-            const newVoteCount = Number(response.vote_count) || 0;
-            const newUserVote = Number(response.user_vote) || 0;
-            
-            console.log('VoteComponent updating state:', {
-                newVoteCount,
-                newUserVote,
-                oldVoteCount: voteCount,
-                oldUserVote: userVote
-            });
-            
-            setVoteCount(newVoteCount);
-            setUserVote(newUserVote);
-        } catch (error) {
-            console.error('Error in handleVote:', error);
+      return;
+    }
 
-            const authResult = handleAuthError(error, {
-                strategy: AUTH_ERROR_STRATEGY.MESSAGE,
-                message: 'Por favor inicia sesión para votar',
-            });
-            if (authResult.handled) {
-                alert(authResult.message);
-                return;
-            }
+    // Check if user is authenticated
+    if (!authState.isAuthenticated) {
 
-            alert(getErrorMessage(error, 'Ocurrió un error al procesar tu voto. Por favor intenta de nuevo.'));
-        } finally {
-            setLoading(false);
-        }
-    };
+      alert('Please log in to vote');
+      return;
+    }
 
-    const upvoteColor = userVote > 0 ? 'primary' : 'default';
-    const downvoteColor = userVote < 0 ? 'primary' : 'default';
-    const isDisabled = loading || !authState.isAuthenticated;
 
-    // Tooltip text for upvote button - special message for content suggestions
-    const upvoteTooltip = type === 'content_suggestion' 
-        ? 'Es una buena referencia de contenido para este tema'
-        : 'Votar a favor';
+    setLoading(true);
 
-    return (
-        <Box display="flex" alignItems="center">
+    try {
+      let response;
+      switch (type) {
+        case 'content':
+          response = await votesApi.voteContent(ids.topicId, ids.contentId, action);
+          break;
+        case 'comment':
+          response = await votesApi.voteComment(ids.commentId, action);
+          break;
+        case 'knowledge_path':
+          response = await votesApi.voteKnowledgePath(ids.pathId, action);
+          break;
+        case 'publication':
+          response = await votesApi.votePublication(ids.publicationId, action);
+          break;
+        case 'content_suggestion':
+          response = await votesApi.voteContentSuggestion(ids.suggestionId, action);
+          break;
+        default:
+          throw new Error('Invalid vote type');
+      }
+
+
+      // Update with server values
+      const newVoteCount = Number(response.vote_count) || 0;
+      const newUserVote = Number(response.user_vote) || 0;
+
+
+      setVoteCount(newVoteCount);
+      setUserVote(newUserVote);
+    } catch (error) {
+      console.error('Error in handleVote:', error);
+
+      const authResult = handleAuthError(error, {
+        strategy: AUTH_ERROR_STRATEGY.MESSAGE,
+        message: 'Por favor inicia sesión para votar'
+      });
+      if (authResult.handled) {
+        alert(authResult.message);
+        return;
+      }
+
+      alert(getErrorMessage(error, 'Ocurrió un error al procesar tu voto. Por favor intenta de nuevo.'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const upvoteColor = userVote > 0 ? 'primary' : 'default';
+  const downvoteColor = userVote < 0 ? 'primary' : 'default';
+  const isDisabled = loading || !authState.isAuthenticated;
+
+  // Tooltip text for upvote button - special message for content suggestions
+  const upvoteTooltip = type === 'content_suggestion' ?
+  'Es una buena referencia de contenido para este tema' :
+  'Votar a favor';
+
+  return (
+    <Box display="flex" alignItems="center">
             <Tooltip title={upvoteTooltip}>
                 <span>
-                    <IconButton 
-                        onClick={() => handleVote('upvote')}
-                        color={upvoteColor}
-                        disabled={isDisabled}
-                        className={upvoteColor === 'primary' ? 'MuiIconButton-colorPrimary' : ''}
-                        sx={{
-                            color: upvoteColor === 'primary' ? '#1976d2 !important' : '#757575 !important',
-                            '&.MuiIconButton-colorPrimary': {
-                                color: '#1976d2 !important'
-                            },
-                            '&:hover': {
-                                backgroundColor: upvoteColor === 'primary' ? 'primary.light' : 'action.hover'
-                            }
-                        }}
-                    >
+                    <IconButton
+            onClick={() => handleVote('upvote')}
+            color={upvoteColor}
+            disabled={isDisabled}
+            className={upvoteColor === 'primary' ? 'MuiIconButton-colorPrimary' : ''}
+            sx={{
+              color: upvoteColor === 'primary' ? '#1976d2 !important' : '#757575 !important',
+              '&.MuiIconButton-colorPrimary': {
+                color: '#1976d2 !important'
+              },
+              '&:hover': {
+                backgroundColor: upvoteColor === 'primary' ? 'primary.light' : 'action.hover'
+              }
+            }}>
+            
                         <ThumbUpIcon />
                     </IconButton>
                 </span>
@@ -180,32 +146,32 @@ const VoteComponent = ({ type, ids, initialVoteCount = 0, initialUserVote = 0 })
             <Typography variant="body1" sx={{ mx: 1, minWidth: '20px', textAlign: 'center', color: 'text.primary' }}>
                 {voteCount}
             </Typography>
-            <IconButton 
-                onClick={() => handleVote('downvote')}
-                color={downvoteColor}
-                disabled={isDisabled}
-                className={downvoteColor === 'primary' ? 'MuiIconButton-colorPrimary' : ''}
-                sx={{
-                    color: downvoteColor === 'primary' ? '#1976d2 !important' : '#757575 !important',
-                    '&.MuiIconButton-colorPrimary': {
-                        color: '#1976d2 !important'
-                    },
-                    '&:hover': {
-                        backgroundColor: downvoteColor === 'primary' ? 'primary.light' : 'action.hover'
-                    }
-                }}
-            >
+            <IconButton
+        onClick={() => handleVote('downvote')}
+        color={downvoteColor}
+        disabled={isDisabled}
+        className={downvoteColor === 'primary' ? 'MuiIconButton-colorPrimary' : ''}
+        sx={{
+          color: downvoteColor === 'primary' ? '#1976d2 !important' : '#757575 !important',
+          '&.MuiIconButton-colorPrimary': {
+            color: '#1976d2 !important'
+          },
+          '&:hover': {
+            backgroundColor: downvoteColor === 'primary' ? 'primary.light' : 'action.hover'
+          }
+        }}>
+        
                 <ThumbDownIcon />
             </IconButton>
-        </Box>
-    );
+        </Box>);
+
 };
 
 VoteComponent.propTypes = {
-    type: PropTypes.oneOf(['content', 'comment', 'knowledge_path', 'publication', 'content_suggestion']).isRequired,
-    ids: PropTypes.object.isRequired,
-    initialVoteCount: PropTypes.number,
-    initialUserVote: PropTypes.number
+  type: PropTypes.oneOf(['content', 'comment', 'knowledge_path', 'publication', 'content_suggestion']).isRequired,
+  ids: PropTypes.object.isRequired,
+  initialVoteCount: PropTypes.number,
+  initialUserVote: PropTypes.number
 };
 
-export default VoteComponent; 
+export default VoteComponent;

--- a/scripts/remove-console-logs.js
+++ b/scripts/remove-console-logs.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * AST-based removal of console.log, console.debug, and console.info.
+ * Preserves console.error and console.warn.
+ */
+const fs = require('fs');
+const path = require('path');
+const frontendNodeModules = path.join(__dirname, '../frontend/node_modules');
+const parser = require(path.join(frontendNodeModules, '@babel/parser'));
+const traverse = require(path.join(frontendNodeModules, '@babel/traverse')).default;
+let babelGenerate;
+try {
+  babelGenerate = require(path.join(frontendNodeModules, '@babel/generator')).default;
+} catch {
+  // @babel/generator optional
+}
+
+const METHODS = new Set(['log', 'debug', 'info']);
+
+function isConsoleDebugCall(node) {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.object.name === 'console' &&
+    node.callee.property.type === 'Identifier' &&
+    METHODS.has(node.callee.property.name)
+  );
+}
+
+function removeFromSource(source, filePath) {
+  const isTs = /\.tsx?$/.test(filePath);
+  const isJsx = /\.(jsx|tsx)$/.test(filePath);
+
+  const ast = parser.parse(source, {
+    sourceType: 'module',
+    plugins: [
+      'jsx',
+      ...(isTs ? ['typescript'] : []),
+      'classProperties',
+      'dynamicImport',
+      'importMeta',
+      'topLevelAwait',
+    ],
+  });
+
+  traverse(ast, {
+    ExpressionStatement(path) {
+      if (isConsoleDebugCall(path.node.expression)) {
+        path.remove();
+      }
+    },
+    JSXExpressionContainer(path) {
+      const expr = path.node.expression;
+      if (expr.type === 'CallExpression' && isConsoleDebugCall(expr)) {
+        path.remove();
+      }
+    },
+  });
+
+  // Remove if-blocks that became empty after console.log removal
+  traverse(ast, {
+    IfStatement(path) {
+      const consequent = path.node.consequent;
+      if (
+        consequent.type === 'BlockStatement' &&
+        consequent.body.length === 0
+      ) {
+        if (path.node.alternate) {
+          path.replaceWith(path.node.alternate);
+        } else {
+          path.remove();
+        }
+      }
+    },
+  });
+
+  // Use babel generator if available, otherwise manual slice approach
+  if (babelGenerate) {
+    const output = babelGenerate(ast, {
+      retainLines: true,
+      compact: false,
+      jsescOption: { minimal: true },
+    });
+    return cleanupOutput(output.code);
+  }
+
+  throw new Error('@babel/generator is required');
+}
+
+function cleanupOutput(source) {
+  let result = source;
+
+  result = result.replace(/^\s*\/\/\s*Debug logging\s*\n/gm, '');
+  result = result.replace(/^\s*\/\/\s*Added to track render cycles\s*\n/gm, '');
+  result = result.replace(/^\s*\/\/\s*Track render count to detect potential infinite loops\s*\n/gm, '');
+  result = result.replace(/^let renderCount = 0;\n\n?/m, '');
+  result = result.replace(/^\s*renderCount\+\+;\n/gm, '');
+  result = result.replace(/^\s*\/\/ Reset renderCount on path\/node change\s*\n\s*renderCount = 1;\n/gm, '');
+  result = result.replace(
+    /^\s*\/\/ Log environment variables to verify they're accessible\s*\n/gm,
+    ''
+  );
+
+  result = result.replace(/\n{4,}/g, '\n\n\n');
+
+  return result;
+}
+
+function processDirectory(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let changed = 0;
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      changed += processDirectory(fullPath);
+    } else if (/\.(jsx?|tsx?)$/.test(entry.name)) {
+      const original = fs.readFileSync(fullPath, 'utf8');
+      if (!/console\.(log|debug|info)/.test(original)) continue;
+
+      try {
+        const cleaned = removeFromSource(original, fullPath);
+        if (cleaned !== original) {
+          fs.writeFileSync(fullPath, cleaned);
+          console.log(`Cleaned: ${fullPath}`);
+          changed++;
+        }
+      } catch (err) {
+        console.error(`Failed: ${fullPath}: ${err.message}`);
+      }
+    }
+  }
+
+  return changed;
+}
+
+const targetDir = process.argv[2] || path.join(__dirname, '../frontend/src');
+const count = processDirectory(targetDir);
+console.log(`\nDone. Modified ${count} file(s).`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

El frontend en producción estaba emitiendo información sensible e innecesaria en la consola del navegador:

- Google Client ID y API URL en `Login.jsx`
- Credenciales y respuestas de login (`Submitting login form with`, `Login API response`)
- Logs repetitivos de `VoteComponent` en cada render y `useEffect`
- Decenas de `console.log` de depuración repartidos en componentes y módulos API

## Solución

Se eliminaron todas las llamadas a `console.log`, `console.debug` y `console.info` en **33 archivos** del frontend (`frontend/src/`).

Se **conservaron** `console.error` y `console.warn` en bloques `catch` para errores reales.

### Archivos principales afectados

| Área | Archivos |
|------|----------|
| Autenticación | `Login.jsx`, `Register.jsx`, `SocialLogin.jsx`, `Logout.jsx` |
| Votos | `VoteComponent.jsx`, `KnowledgePathList.jsx` |
| API | `profilesApi.js`, `contentApi.js`, `knowledgePathsApi.js`, `quizzesApi.js`, etc. |
| Contenido | `UploadContentForm.jsx`, `ContentDisplay.jsx`, `CollectionEditContent.jsx` |
| Rutas de conocimiento | `NodeDetail.jsx`, `NodeEdit.jsx`, `NodeCreate.jsx` |

### Script de mantenimiento

Se añadió `scripts/remove-console-logs.js`, un script basado en AST (`@babel/parser`) para futuras limpiezas seguras.

## Verificación

- `npm run build` — compila correctamente
- Búsqueda en `frontend/src/`: 0 coincidencias de `console.log|debug|info`

## Notas

- Tras el despliegue, conviene verificar en producción que la consola ya no muestra los logs reportados.
- Los `console.error` en flujos de error se mantienen intencionalmente; si se desea silenciarlos también en producción, se puede abordar en un PR separado (p. ej. con Sentry o un wrapper de logging condicional).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3091b84-eab6-4914-99af-9e7dce298e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3091b84-eab6-4914-99af-9e7dce298e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

