### PR TITLE
Ocultar CommunityBubble en páginas de detalle de tema

### DIFF
--- a/frontend/src/generalComponents/CommunityBubble.jsx
+++ b/frontend/src/generalComponents/CommunityBubble.jsx
@@ -25,7 +25,7 @@ const isBubbleRoute = (pathname) => {
   if (pathname === '/search' || pathname.startsWith('/content/search/')) {
     return true;
   }
-  if (pathname === '/content/topics' || pathname.startsWith('/content/topics/')) {
+  if (pathname === '/content/topics') {
     return true;
   }
   if (pathname === '/knowledge_path' || pathname.startsWith('/knowledge_path/')) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

El `CommunityBubble` (burbuja flotante del proyecto comunitario) se renderizaba globalmente en `App.jsx` y su visibilidad se controlaba con `isBubbleRoute()` en `CommunityBubble.jsx`.

La condición anterior mostraba el bubble en `/content/topics` **y en todas las subrutas** (`/content/topics/:topicId`, edición, sugerencias, etc.), lo que hacía que apareciera encima del contenido en la página de detalle de cada tema.

## Cambio

Se restringe la visibilidad del bubble en rutas de temas a la lista únicamente:

- **Visible:** `/content/topics` (lista de temas)
- **Oculto:** `/content/topics/:topicId` y subrutas (detalle, edición, sugerencias, timeline, etc.)

El bubble sigue visible en las demás rutas donde ya estaba configurado (`/search`, `/knowledge_path`, etc.).

## Archivo modificado

- `frontend/src/generalComponents/CommunityBubble.jsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f18232e2-d151-441b-b6f8-75152f3b9f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f18232e2-d151-441b-b6f8-75152f3b9f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

