### PR TITLE
fix: stop infinite recursion in create_notification

### DIFF
--- a/acbc_app/utils/notification_utils.py
+++ b/acbc_app/utils/notification_utils.py
@@ -25,7 +25,7 @@ def create_notification(**kwargs):
     for field in ('description', 'verb'):
         if field in kwargs and kwargs[field]:
             kwargs[field] = prepare_text_for_db(kwargs[field])
-    return create_notification(**kwargs)
+    return Notification.objects.create(**kwargs)
 
 def notify_comment_reply(comment):
     """

--- a/acbc_app/utils/tests/test_notification_utils.py
+++ b/acbc_app/utils/tests/test_notification_utils.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from utils.notification_utils import create_notification
+
+
+class CreateNotificationTests(TestCase):
+    @patch('notifications.models.Notification.objects.create')
+    def test_create_notification_persists_via_model(self, mock_create):
+        mock_create.return_value = MagicMock()
+        recipient = User.objects.create_user(
+            username='recipient',
+            email='recipient@example.com',
+            password='testpass123',
+        )
+
+        create_notification(
+            recipient=recipient,
+            verb='solicitó un certificado',
+            description='Detalle de la solicitud',
+        )
+
+        mock_create.assert_called_once_with(
+            recipient=recipient,
+            verb='solicitó un certificado',
+            description='Detalle de la solicitud',
+        )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a regression introduced in #0f4430c where `create_notification()` called itself instead of `Notification.objects.create()`, causing `RecursionError: maximum recursion depth exceeded` on every notification path.

## Root cause

```python
def create_notification(**kwargs):
    ...
    return create_notification(**kwargs)  # should delegate to the model
```

## Fix

Delegate to `Notification.objects.create(**kwargs)` after applying `prepare_text_for_db` to text fields.

## Tests affected in CI

This should restore **9 failing tests**:
- `test_create_file_suggestion_success`
- All 8 `profiles.tests.NotificationTests` notification scenarios (upvotes, comments, certificate notifications)

## Verification

Added `utils/tests/test_notification_utils.py` to assert the wrapper delegates to the model layer instead of recursing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55d9180d-05ea-4c8a-95bd-854282ae3292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55d9180d-05ea-4c8a-95bd-854282ae3292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

