### PR TITLE
fix: accept legacy dict notes in certificate request serializer

### DIFF
--- a/acbc_app/certificates/serializers.py
+++ b/acbc_app/certificates/serializers.py
@@ -8,6 +8,20 @@ from knowledge_paths.models import KnowledgePath
 from events.models import Event
 
 
+class CertificateNotesField(serializers.Field):
+    """Accept plain text or legacy JSON-shaped notes and normalize to TextField."""
+
+    default_empty_value = ''
+
+    def to_internal_value(self, data):
+        return normalize_notes_value(data)
+
+    def to_representation(self, value):
+        if value is None:
+            return ''
+        return value
+
+
 class CertificateRequestSerializer(serializers.ModelSerializer):
     requester = serializers.CharField(source='requester.username', read_only=True)
     requester_id = serializers.IntegerField(source='requester.id', read_only=True)
@@ -23,6 +37,7 @@ class CertificateRequestSerializer(serializers.ModelSerializer):
     event = serializers.PrimaryKeyRelatedField(
         queryset=Event.objects.all(), required=False, allow_null=True
     )
+    notes = CertificateNotesField(required=False, allow_null=True, default='')
 
     class Meta:
         model = CertificateRequest
@@ -45,9 +60,6 @@ class CertificateRequestSerializer(serializers.ModelSerializer):
             'notes'
         ]
         read_only_fields = ['status', 'response_date', 'rejection_reason', 'requester', 'requester_id', 'knowledge_path_title', 'knowledge_path_author', 'knowledge_path_author_id', 'event_title', 'event_owner', 'event_owner_id']
-
-    def validate_notes(self, value):
-        return normalize_notes_value(value)
 
     def create(self, validated_data):
         validated_data['requester'] = self.context['request'].user

--- a/acbc_app/certificates/tests.py
+++ b/acbc_app/certificates/tests.py
@@ -248,3 +248,46 @@ class CertificateRequestFlowTest(TestCase):
 
         stored = CertificateRequest.objects.get(id=response.data['id'])
         self.assertEqual(stored.notes, note)
+
+
+class CertificateRequestSerializerNotesTests(TestCase):
+    def setUp(self):
+        self.teacher = User.objects.create_user(
+            username='teacher',
+            email='teacher@test.com',
+            password='testpass123',
+        )
+        self.student = User.objects.create_user(
+            username='student',
+            email='student@test.com',
+            password='testpass123',
+        )
+        self.knowledge_path = KnowledgePath.objects.create(
+            title='Test Knowledge Path',
+            description='Test Description',
+            author=self.teacher,
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.student)
+        self.request_url = reverse(
+            'certificates:certificate-request',
+            args=[self.knowledge_path.id],
+        )
+
+    def test_accepts_legacy_dict_notes_payload(self):
+        response = self.client.post(
+            self.request_url,
+            {'notes': {'message': 'Please review my completion'}},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['notes'], 'Please review my completion')
+
+    def test_accepts_plain_string_notes_payload(self):
+        response = self.client.post(
+            self.request_url,
+            {'notes': 'Muchas gracias por completar Ucronía'},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['notes'], 'Muchas gracias por completar Ucronía')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes certificate request creation returning `400 Bad Request` when clients send the legacy notes format `{"message": "..."}` after the `notes` field migration from `JSONField` to `TextField`.

## Root cause

`CertificateRequestSerializer` inferred `notes` as a DRF `CharField` from the model's `TextField`. DRF validates field type **before** `validate_notes()` runs, so dict payloads failed with:

```
{'notes': [ErrorDetail(string='Not a valid string.', code='invalid')]}
```

The existing `normalize_notes_value()` helper was never reached for dict input.

## Fix

Introduce `CertificateNotesField`, a custom serializer field that normalizes input in `to_internal_value()` using the shared `normalize_notes_value()` helper. This accepts:

- Plain strings: `"Muchas gracias por Ucronía"`
- Legacy dicts: `{"message": "Please review my completion"}`

Both are stored as plain text in the `TextField`.

## Tests affected in CI

This should restore **6 failing certificate tests** (4 errors + 2 failures) and **4 notification tests** that depend on successful certificate request creation with dict notes.

Also adds `CertificateRequestSerializerNotesTests` covering both payload formats.

## Related

Complements #76, which fixes notification creation independently.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55d9180d-05ea-4c8a-95bd-854282ae3292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55d9180d-05ea-4c8a-95bd-854282ae3292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

