### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a monorepo with three components:
+
+- **Backend** (`acbc_app/`): Django 5 REST API. Runs on `http://localhost:8000` (dev: `python manage.py runserver`; see `entrypoint.sh`). Swagger at `/swagger/`, admin at `/admin/`.
+- **Frontend** (`frontend/`): React 18 + Vite. Dev server on `http://localhost:5173` (`npm run dev`). Vite proxies `/api`, `/admin`, `/media` to `:8000` (see `vite.config.js`).
+- **Contracts** (`contracts/`): Solidity + Hardhat. Secondary/optional component.
+
+The dependency-refresh update script (Python venv + `pip install`, `npm install` for `frontend` and `contracts`) runs automatically on VM startup. The notes below are the non-obvious things it does NOT handle.
+
+### Backend (Django) — how to run
+
+Settings live in `acbc_app/academia_blockchain/settings.py`. **`settings.py` does NOT load a `.env` file for native (non-Docker) runs** — you must export env vars in the shell. The Python venv is at `acbc_app/.venv`.
+
+```bash
+cd acbc_app && . .venv/bin/activate
+export ENVIRONMENT=DEVELOPMENT DB_NAME=acbc_db POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres DB_HOST=localhost DB_PORT=5432
+python manage.py runserver 0.0.0.0:8000
+```
+
+- **PostgreSQL is installed natively (not Docker) and must be started manually** if not already running: `sudo pg_ctlcluster 16 main start`. Dev DB is `acbc_db`, user/password `postgres`/`postgres` on `localhost:5432`.
+- Superuser seeded by `python manage.py create_admin` is **`admin` / `admin`**.
+- Seed data commands (run in order, see `acbc_app/README.md`): `populate_cryptocurrencies`, `populate_users`, `populate_content`, `populate_knowledge_paths`, `populate_interactions`.
+
+### Backend tests
+
+Tests **automatically switch to in-memory SQLite** (see the `"test" in sys.argv` check in `settings.py`), so PostgreSQL is NOT required to run them:
+
+```bash
+cd acbc_app && . .venv/bin/activate && ENVIRONMENT=DEVELOPMENT python manage.py test profiles tests -v 1
+```
+
+### Frontend (Vite) — required env var gotcha
+
+**The app crashes to a blank "Algo salió mal" error page if `VITE_GOOGLE_OAUTH_CLIENT_ID` is unset** (`GoogleOAuthInitializer` throws). `frontend/.env` is gitignored, so if it is missing recreate it with:
+
+```
+VITE_API_URL=http://localhost:8000/api
+VITE_GOOGLE_OAUTH_CLIENT_ID=placeholder-for-testing
+```
+
+A placeholder value is fine for local dev (real Google login won't work, but username/password auth and everything else does). Start the backend before the frontend so API calls don't hit `ERR_CONNECTION_REFUSED`.
+
+### Frontend lint/test — pre-existing failures
+
+`npm run lint` (ESLint) and `npm run test` (Vitest) both currently report **pre-existing failures in the repo** (unused-var lint errors; a few Vitest assertions on Spanish UI text). These are code issues, not environment problems — the tooling itself works.
+
+### Contracts (Hardhat) — pre-existing compile error
+
+`npx hardhat compile` **fails on the pre-existing draft file `contracts/CF_contract_borrador.sol`** (uses a deprecated Chainlink Client API — `buildChainlinkRequest`/`sendChainlinkRequestTo`). There are no Hardhat tests (`contracts/test/` is empty). The toolchain installs and runs correctly; the failure is in that one draft contract.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the local development environment for this Django + React + Hardhat monorepo and documents durable, non-obvious startup instructions for future Cursor Cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to run the backend, frontend, and contracts, plus gotchas discovered during setup.
- The dependency-refresh update script (Python venv + `pip install`, `npm install` for `frontend`/`contracts`) is configured via the Cloud environment settings (not committed code).

## What was set up

- **PostgreSQL 15/16** installed natively; dev DB `acbc_db` (`postgres`/`postgres`).
- **Backend** (`acbc_app/`): Python venv + requirements; migrations applied; seeded superuser `admin`/`admin` and demo data. Runs at `http://localhost:8000` (`/swagger/`, `/admin/`).
- **Frontend** (`frontend/`): `npm install`; Vite dev server at `http://localhost:5173`.
- **Contracts** (`contracts/`): `npm install`; Hardhat toolchain.

## Key gotchas (documented in AGENTS.md)

- `settings.py` does **not** auto-load `.env` for native runs — export DB/env vars in the shell.
- The frontend crashes to a blank "Algo salió mal" page unless `VITE_GOOGLE_OAUTH_CLIENT_ID` is set (a placeholder value is fine for dev). `frontend/.env` is gitignored.
- Backend tests auto-use in-memory SQLite (no Postgres needed).
- Pre-existing (not environment) failures: ESLint + a few Vitest tests fail; `hardhat compile` fails on the draft `contracts/CF_contract_borrador.sol`.

## Verification

End-to-end "hello world": registered a new user and created a Knowledge Path via the running app.

[register_and_create_knowledge_path.mp4](https://cursor.com/agents/bc-945b4636-9a33-438a-a5aa-2d6789264def/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fregister_and_create_knowledge_path.mp4)

[Logged in as hellodev](https://cursor.com/agents/bc-945b4636-9a33-438a-a5aa-2d6789264def/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogged_in.webp)
[Knowledge path created](https://cursor.com/agents/bc-945b4636-9a33-438a-a5aa-2d6789264def/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fknowledge_path_created.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-945b4636-9a33-438a-a5aa-2d6789264def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-945b4636-9a33-438a-a5aa-2d6789264def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

