### PR TITLE
fix(sentry): no reportar eventos desde entornos de desarrollo

### DIFF
--- a/acbc_app/academia_blockchain/sentry_config.py
+++ b/acbc_app/academia_blockchain/sentry_config.py
@@ -33,6 +33,15 @@ _SUPPRESSED_EXCEPTION_FQNS = frozenset(
 )
 
 
+# Environments that must NOT report to Sentry (local development / tests).
+# Sentry is reserved for production / beta, so development noise (e.g. transient
+# SyntaxError picked up by the runserver auto-reloader) does not create issues
+# or trigger alert emails.
+_DISABLED_SENTRY_ENVIRONMENTS = frozenset(
+    {"development", "dev", "local", "test", "testing"}
+)
+
+
 def _sentry_before_send(event, hint):
     """
     Drop noise from expected 4xx-class failures. Prefer fixing log levels at the source;
@@ -54,6 +63,16 @@ def configure_sentry():
     if not dsn:
         return
 
+    # Only report from production / beta. Skip local/development (and tests) so
+    # dev-only noise does not open Sentry issues or send alert emails.
+    env = os.environ.get("ENVIRONMENT", "development").strip()
+    if env.lower() in _DISABLED_SENTRY_ENVIRONMENTS:
+        logging.getLogger(__name__).info(
+            "Sentry disabled for ENVIRONMENT=%s (enabled only in production/beta).",
+            env,
+        )
+        return
+
     try:
         import sentry_sdk
         from sentry_sdk.integrations.django import DjangoIntegration
@@ -67,7 +86,6 @@ def configure_sentry():
         event_level=logging.ERROR  # Send errors as events
     )
 
-    env = os.environ.get("ENVIRONMENT", "development")
     # Lower sample rates in production to control volume; use 1.0 for beta if desired
     traces_sample_rate = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.1"))
     profiles_sample_rate = float(os.environ.get("SENTRY_PROFILES_SAMPLE_RATE", "0.0"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

Se recibían correos de alerta de Sentry por errores que en realidad ocurrían en **desarrollo** (p. ej. `SyntaxError` transitorios capturados por el auto-reloader de `runserver` al guardar archivos a medio editar). Todos los eventos tenían `environment: DEVELOPMENT`, `transaction`/`url` vacíos y `mechanism: threading` (hilo del reloader).

**Causa raíz:** `configure_sentry()` inicializaba Sentry con solo que existiera `SENTRY_DSN`, **sin mirar el entorno**, por lo que los errores de dev iban al mismo proyecto que producción y disparaban las reglas de alerta por *new issue*.

## Cambio

En `academia_blockchain/sentry_config.py`, `configure_sentry()` ahora omite la inicialización cuando `ENVIRONMENT` es de desarrollo/tests (`development`, `dev`, `local`, `test`, `testing`, sin distinción de mayúsculas). Coincide con el docstring del archivo: *"Initializes when SENTRY_DSN is set (e.g. production / beta)"*.

- **Producción y beta no cambian**: siguen reportando exactamente igual.
- Cambio mínimo (19 líneas), sin tocar otras rutas de código.

## Verificación

`python manage.py check` → *System check identified no issues*. Prueba de los escenarios de `configure_sentry()` con un DSN de formato válido:

| `ENVIRONMENT` | `SENTRY_DSN` | Sentry activo |
|---|---|---|
| `DEVELOPMENT` | sí | ❌ OFF (arregla los correos) |
| `development` | sí | ❌ OFF |
| `PRODUCTION` | sí | ✅ ON (sin cambios) |
| `PRODUCTION` | no | ❌ OFF |
| `beta` | sí | ✅ ON |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-945b4636-9a33-438a-a5aa-2d6789264def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-945b4636-9a33-438a-a5aa-2d6789264def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

