### PR TITLE
Fix default profile avatar when user has no photo

### DIFF
--- a/frontend/public/images/default-avatar.svg
+++ b/frontend/public/images/default-avatar.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-label="Avatar predeterminado">
+  <circle cx="60" cy="60" r="60" fill="#E8EAF6"/>
+  <circle cx="60" cy="46" r="22" fill="#5C6BC0"/>
+  <path d="M24 104c6-18 22-28 36-28s30 10 36 28" fill="#5C6BC0"/>
+</svg>

--- a/frontend/src/components/UserAvatar.jsx
+++ b/frontend/src/components/UserAvatar.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { Avatar } from '@mui/material';
+
+export const DEFAULT_AVATAR_SRC = '/images/default-avatar.svg';
+
+export function getAvatarInitial(username) {
+  const trimmed = (username || '').trim();
+  return trimmed ? trimmed[0].toUpperCase() : '?';
+}
+
+/**
+ * Profile avatar with a bundled default image and initials fallback.
+ */
+const UserAvatar = ({
+  src,
+  username,
+  alt,
+  size,
+  sx,
+  imgProps,
+  ...rest
+}) => {
+  const [imageFailed, setImageFailed] = useState(false);
+  const hasCustomImage = Boolean(src) && !imageFailed;
+  const resolvedSrc = hasCustomImage ? src : DEFAULT_AVATAR_SRC;
+  const dimension = size ? { width: size, height: size } : {};
+
+  return (
+    <Avatar
+      src={resolvedSrc}
+      alt={alt || (username ? `Avatar de ${username}` : 'Avatar de usuario')}
+      imgProps={{
+        ...imgProps,
+        onError: (event) => {
+          imgProps?.onError?.(event);
+          if (hasCustomImage) {
+            setImageFailed(true);
+          }
+        },
+      }}
+      sx={{
+        ...dimension,
+        fontSize: size ? `${Math.round(size * 0.4)}px` : undefined,
+        bgcolor: 'primary.light',
+        color: 'primary.dark',
+        ...sx,
+      }}
+      {...rest}
+    >
+      {getAvatarInitial(username)}
+    </Avatar>
+  );
+};
+
+export default UserAvatar;

--- a/frontend/src/components/__tests__/UserAvatar.test.jsx
+++ b/frontend/src/components/__tests__/UserAvatar.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import UserAvatar, { DEFAULT_AVATAR_SRC, getAvatarInitial } from '../UserAvatar';
+
+describe('UserAvatar', () => {
+  it('uses the default avatar when no profile picture is provided', () => {
+    render(<UserAvatar username="h4stur" size={48} />);
+    const image = screen.getByRole('img', { name: 'Avatar de h4stur' });
+    expect(image).toHaveAttribute('src', DEFAULT_AVATAR_SRC);
+  });
+
+  it('uses a custom profile picture when provided', () => {
+    render(
+      <UserAvatar
+        username="h4stur"
+        src="https://example.com/avatar.jpg"
+        size={48}
+      />
+    );
+    const image = screen.getByRole('img', { name: 'Avatar de h4stur' });
+    expect(image).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+  });
+});
+
+describe('getAvatarInitial', () => {
+  it('returns the first letter uppercased', () => {
+    expect(getAvatarInitial('h4stur')).toBe('H');
+  });
+
+  it('returns ? for empty usernames', () => {
+    expect(getAvatarInitial('')).toBe('?');
+  });
+});

--- a/frontend/src/content/ContentReferences.jsx
+++ b/frontend/src/content/ContentReferences.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Box, Typography, List, ListItem, ListItemText, Avatar } from '@mui/material';
+import { Box, Typography, List, ListItem, ListItemText } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { formatDate } from '../utils/dateUtils';
+import UserAvatar from '../components/UserAvatar';
 
 const ContentReferences = ({ references }) => {
     const navigate = useNavigate();
@@ -116,18 +117,12 @@ const ContentReferences = ({ references }) => {
                                     }
                                 }}
                             >
-                                <Avatar 
-                                    src={pub.profile_picture || '/default-avatar.png'} 
-                                    alt={pub.username}
-                                    sx={{ 
-                                        width: 40, 
-                                        height: 40, 
-                                        mr: 2,
-                                        bgcolor: 'grey.300'
-                                    }}
-                                >
-                                    {pub.username.charAt(0).toUpperCase()}
-                                </Avatar>
+                                <UserAvatar
+                                    src={pub.profile_picture}
+                                    username={pub.username}
+                                    size={40}
+                                    sx={{ mr: 2 }}
+                                />
                                 <ListItemText 
                                     primary={`Publicación por ${pub.username}`}
                                     secondary={formatDate(pub.published_at)}

--- a/frontend/src/profiles/EditProfile.jsx
+++ b/frontend/src/profiles/EditProfile.jsx
@@ -6,7 +6,6 @@ import {
     TextField, 
     Button, 
     Paper, 
-    Avatar, 
     CircularProgress,
     Chip,
     FormHelperText,
@@ -18,6 +17,7 @@ import DescriptionIcon from '@mui/icons-material/Description';
 import { AuthContext } from '../context/AuthContext';
 import { getAccessTokenFromLocalStorage } from '../context/localStorageUtils';
 import { getUserProfile, updateProfile } from '../api/profilesApi';
+import UserAvatar from '../components/UserAvatar';
 
 const EditProfile = () => {
     const navigate = useNavigate();
@@ -224,9 +224,11 @@ const EditProfile = () => {
                 <form onSubmit={handleSubmit}>
                     {/* Foto de perfil */}
                     <Box sx={{ mb: 4, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-                        <Avatar
-                            src={previewUrl || '/default-avatar.png'}
-                            sx={{ width: 120, height: 120, mb: 2 }}
+                        <UserAvatar
+                            src={previewUrl}
+                            username={formData.username}
+                            size={120}
+                            sx={{ mb: 2 }}
                         />
                         <Button
                             variant="outlined"

--- a/frontend/src/profiles/ProfileHeader.jsx
+++ b/frontend/src/profiles/ProfileHeader.jsx
@@ -13,6 +13,7 @@ import MessageIcon from '@mui/icons-material/Message';
 import EditIcon from '@mui/icons-material/Edit';
 import PostAddIcon from '@mui/icons-material/PostAdd';
 import BadgeDisplay from '../gamification/BadgeDisplay';
+import UserAvatar from '../components/UserAvatar';
 
 const ProfileHeader = ({ 
     profile, 
@@ -32,19 +33,12 @@ const ProfileHeader = ({
             <Grid container spacing={3}>
                 <Grid item xs={12} md={3}>
                     <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                        <img 
-                            src={profile.profile_picture || '/default-avatar.png'} 
-                            alt="Profile"
-                            width={150}
-                            height={150}
-                            loading="eager"
-                            fetchPriority="high"
-                            style={{ 
-                                width: '150px', 
-                                height: '150px', 
-                                borderRadius: '50%', 
-                                objectFit: 'cover',
-                                ...(!isOwnProfile && { cursor: 'pointer' })
+                        <UserAvatar
+                            src={profile.profile_picture}
+                            username={profile.user?.username}
+                            size={150}
+                            sx={{
+                                ...(!isOwnProfile && { cursor: 'pointer' }),
                             }}
                             {...(!isOwnProfile && { onClick: handleProfileClick })}
                         />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

Cuando un usuario no tenía foto de perfil, el header mostraba texto recortado (p. ej. `.ofile`) en lugar de un avatar. La causa era un `<img>` con `alt="Profile"` apuntando a `/default-avatar.png`, un archivo que no existía en el proyecto.

## Solución

- Añadido `frontend/public/images/default-avatar.svg` como avatar predeterminado.
- Nuevo componente reutilizable `UserAvatar` que:
  - Usa la foto del usuario si existe.
  - Si no, muestra el SVG por defecto.
  - Si la imagen falla al cargar, hace fallback al SVG y, en último caso, a la inicial del username.
- Actualizado `ProfileHeader`, `EditProfile` y `ContentReferences` para usar `UserAvatar`.

## Verificación

- `npm run test -- src/components/__tests__/UserAvatar.test.jsx` (4 tests, OK)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e79228e2-b471-4f2a-821c-ad249ed1bbc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e79228e2-b471-4f2a-821c-ad249ed1bbc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

