### PR TITLE
Fix certificate notification target link and profile URL sync

### DIFF
--- a/acbc_app/profiles/serializers.py
+++ b/acbc_app/profiles/serializers.py
@@ -303,6 +303,21 @@ class NotificationSerializer(serializers.ModelSerializer):
             # Pending file suggestions list lives on the library content view
             if obj.verb == 'sugirió un archivo para tu contenido' and obj.target:
                 return f'/content/{obj.target.id}/library' if hasattr(obj.target, 'id') else None
+
+            # Certificate request notifications link to the certificates section
+            if obj.verb == 'solicitó un certificado para tu camino de conocimiento':
+                request = self.context.get('request')
+                recipient = obj.recipient
+                if request and request.user.is_authenticated and request.user.id == recipient.id:
+                    return '/profiles/my_profile?section=certificates&tab=requests'
+                return f'/profiles/user_profile/{recipient.id}?section=certificates&tab=requests' if recipient else None
+
+            if obj.verb in ['aprobó tu solicitud de certificado para', 'rechazó tu solicitud de certificado para']:
+                request = self.context.get('request')
+                recipient = obj.recipient
+                if request and request.user.is_authenticated and request.user.id == recipient.id:
+                    return '/profiles/my_profile?section=certificates'
+                return f'/profiles/user_profile/{recipient.id}?section=certificates' if recipient else None
                 
             return None
         except Exception as e:

--- a/acbc_app/profiles/tests.py
+++ b/acbc_app/profiles/tests.py
@@ -1000,6 +1000,10 @@ class NotificationTests(APITestCase):
         self.assertIn('testuser solicitó un certificado para tu camino de conocimiento', notification['description'])
         self.assertIn('Test Knowledge Path', notification['description'])
         self.assertTrue(notification['unread'])
+        self.assertEqual(
+            notification['target_url'],
+            '/profiles/my_profile?section=certificates&tab=requests'
+        )
 
     def test_certificate_approval_notification(self):
         """Test notification when a teacher approves a certificate request"""
@@ -1048,6 +1052,10 @@ class NotificationTests(APITestCase):
         self.assertIn('testuser aprobó tu solicitud de certificado para', notification['description'])
         self.assertIn('Test Knowledge Path', notification['description'])
         self.assertTrue(notification['unread'])
+        self.assertEqual(
+            notification['target_url'],
+            '/profiles/my_profile?section=certificates'
+        )
 
     def test_certificate_rejection_notification(self):
         """Test notification when a teacher rejects a certificate request"""
@@ -1096,6 +1104,10 @@ class NotificationTests(APITestCase):
         self.assertIn('testuser rechazó tu solicitud de certificado para', notification['description'])
         self.assertIn('Test Knowledge Path', notification['description'])
         self.assertTrue(notification['unread'])
+        self.assertEqual(
+            notification['target_url'],
+            '/profiles/my_profile?section=certificates'
+        )
 
     def test_certificate_request_notification_spam_protection(self):
         """Test that multiple certificate requests within 1 hour don't create duplicate notifications"""

--- a/frontend/src/profiles/Certificates.jsx
+++ b/frontend/src/profiles/Certificates.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, Link, useLocation } from "react-router-dom";
 import certificatesApi from "../api/certificatesApi";
 import { AuthContext } from "../context/AuthContext";
 import {
@@ -36,6 +36,16 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
   const [approveNote, setApproveNote] = useState("");
   const { authState } = useContext(AuthContext);
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const tabParam = new URLSearchParams(location.search).get('tab');
+    if (tabParam === 'requests' && isOwnProfile) {
+      setActiveTab('requests');
+    } else if (tabParam === 'certificates') {
+      setActiveTab('certificates');
+    }
+  }, [location.search, isOwnProfile]);
 
   useEffect(() => {
     if (activeTab === "certificates") {
@@ -205,6 +215,12 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
 
   const handleTabChange = (event, newValue) => {
     setActiveTab(newValue);
+    if (isOwnProfile) {
+      const searchParams = new URLSearchParams(location.search);
+      searchParams.set('section', 'certificates');
+      searchParams.set('tab', newValue);
+      navigate({ pathname: location.pathname, search: searchParams.toString() });
+    }
   };
 
   return (

--- a/frontend/src/profiles/Profile.jsx
+++ b/frontend/src/profiles/Profile.jsx
@@ -214,13 +214,21 @@ const Profile = () => {
     const badgesUserId = isOwnProfile ? null : (profileId || profile?.user?.id);
     const { badges: userBadges, loading: badgesLoading, error: badgesError } = useBadges(badgesUserId);
 
+    const updateProfileSectionUrl = (newSection, { tab = null } = {}) => {
+        const searchParams = new URLSearchParams(location.search);
+        searchParams.set('section', newSection);
+        if (tab) {
+            searchParams.set('tab', tab);
+        } else if (newSection !== 'certificates') {
+            searchParams.delete('tab');
+        }
+        navigate({ pathname: location.pathname, search: searchParams.toString() });
+    };
+
     // Function to handle section changes from external navigation (like header menu)
     const handleExternalSectionChange = (newSection) => {
         setActiveSection(newSection);
-        // Update URL without reloading
-        const url = new URL(window.location);
-        url.searchParams.set('section', newSection);
-        window.history.pushState({}, '', url);
+        updateProfileSectionUrl(newSection);
     };
 
     // Expose the function globally for header navigation
@@ -384,6 +392,9 @@ const Profile = () => {
 
     const handleSectionChange = (event, newSection) => {
         setActiveSection(newSection);
+        if (isOwnProfile) {
+            updateProfileSectionUrl(newSection);
+        }
     };
 
     const handleSuggestionClick = () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

Las notificaciones de solicitud de certificado no mostraban el icono de enlace (`target_url` era `null`), y la navegación del perfil no actualizaba la URL al cambiar de sección (p. ej. Certificados).

## Solución

### Backend
- `NotificationSerializer.get_target_url` ahora devuelve URLs para notificaciones de certificados:
  - **Solicitud recibida** (autor del camino): `/profiles/my_profile?section=certificates&tab=requests`
  - **Aprobación / rechazo** (estudiante): `/profiles/my_profile?section=certificates`

### Frontend
- El sidebar del perfil sincroniza la sección activa con `?section=` en la URL (React Router).
- `Certificates` lee `?tab=requests` para abrir directamente la pestaña "Solicitudes de certificados".
- Al cambiar de pestaña dentro de Certificados, la URL se actualiza con `?section=certificates&tab=...`.

## Verificación

```bash
cd acbc_app && . .venv/bin/activate && ENVIRONMENT=DEVELOPMENT python manage.py test profiles.tests.NotificationTests.test_certificate_request_notification profiles.tests.NotificationTests.test_certificate_approval_notification profiles.tests.NotificationTests.test_certificate_rejection_notification -v 2
```

Tras desplegar, al hacer clic en el icono de enlace de una notificación de solicitud de certificado debería abrirse la sección Certificados → Solicitudes para revisar.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88dc7970-fd4a-44fa-bce8-a9d2ff794b4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88dc7970-fd4a-44fa-bce8-a9d2ff794b4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

