### PR TITLE
Ocultar pestaña de línea de tiempo cuando no hay entradas (excepto creador/moderadores)

### DIFF
--- a/frontend/src/topics/TopicDetail.jsx
+++ b/frontend/src/topics/TopicDetail.jsx
@@ -453,7 +453,7 @@ const TopicDetail = () => {
     const isCreator = isAuthenticated && creatorId != null && userId != null && String(creatorId) === String(userId);
     const canEditTimeline = isCreator || isModerator;
     const canSuggestTimeline = isAuthenticated && !canEditTimeline;
-    const showTimelineTab = canEditTimeline || timelineEntryCount > 0 || canSuggestTimeline;
+    const showTimelineTab = canEditTimeline || timelineEntryCount > 0;
 
     useEffect(() => {
         const tab = searchParams.get('tab');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

En temas sin entradas en la línea de tiempo, la pestaña **Línea de tiempo** era visible para cualquier usuario autenticado (por ejemplo, `AlejandroVeintimilla` viendo un tema creado por `anon401` con `?tab=timeline`).

## Comportamiento esperado (documentación)

Según `docs/architecture/topics-and-knowledge-paths.md`:

- La pestaña es visible si el usuario es **creador/moderador** **o** si la línea de tiempo tiene **al menos una entrada**.
- Los visitantes autenticados ven la pestaña solo cuando ya hay contenido publicado en la línea de tiempo.

## Cambio

En `TopicDetail.jsx`, se eliminó `canSuggestTimeline` de la condición `showTimelineTab`:

```js
// Antes
const showTimelineTab = canEditTimeline || timelineEntryCount > 0 || canSuggestTimeline;

// Después
const showTimelineTab = canEditTimeline || timelineEntryCount > 0;
```

La redirección existente cuando se accede a `?tab=timeline` sin permiso sigue funcionando.

## Verificación

- Usuario no creador/moderador + timeline vacía → pestaña oculta
- Creador o moderador + timeline vacía → pestaña visible (para crear la primera entrada)
- Cualquier usuario + al menos una entrada → pestaña visible
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0c844fa-8623-4c22-a7a7-61d9a4dd01da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0c844fa-8623-4c22-a7a7-61d9a4dd01da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

