### PR TITLE
Club: mostrar en Comunidad solo quienes ya se presentaron

### DIFF
--- a/acbc_app/book_clubs/models.py
+++ b/acbc_app/book_clubs/models.py
@@ -139,6 +139,11 @@ class BookClubMembership(models.Model):
     def can_manage(self):
         return self.role in (MembershipRole.MENTOR, MembershipRole.ADMIN)
 
+    @property
+    def has_introduced(self):
+        """True once the member saved a non-empty club presentation."""
+        return bool((self.intro_description or '').strip())
+
 
 class BookClubEvent(models.Model):
     """Links live sessions to a book club without altering the Event model."""

--- a/acbc_app/book_clubs/models.py
+++ b/acbc_app/book_clubs/models.py
@@ -141,8 +141,8 @@ class BookClubMembership(models.Model):
 
     @property
     def has_introduced(self):
-        """True once the member saved a non-empty club presentation."""
-        return bool((self.intro_description or '').strip())
+        """True once the member completed Preséntate for this club."""
+        return self.intro_updated_at is not None
 
 
 class BookClubEvent(models.Model):

--- a/acbc_app/book_clubs/serializers.py
+++ b/acbc_app/book_clubs/serializers.py
@@ -27,58 +27,98 @@ class BookClubMembershipSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class BookClubMemberIntroductionSerializer(serializers.ModelSerializer):
+def _normalize_optional_url(value):
+    from django.core.exceptions import ValidationError as DjangoValidationError
+    from django.core.validators import URLValidator
+
+    value = (value or '').strip()
+    if not value:
+        return ''
+    if not value.lower().startswith(('http://', 'https://')):
+        value = f'https://{value}'
+    try:
+        URLValidator()(value)
+    except DjangoValidationError as exc:
+        raise serializers.ValidationError(
+            'Introduce un enlace válido, por ejemplo https://linkedin.com/in/usuario'
+        ) from exc
+    return value
+
+
+def _profile_for(user):
+    from profiles.models import Profile
+
+    profile, _ = Profile.objects.get_or_create(user=user)
+    return profile
+
+
+class BookClubMemberIntroductionSerializer(serializers.Serializer):
+    """
+    Club presentation form backed by Profile (source of truth).
+
+    - intro_description → Profile.profile_description
+    - social_url → Profile.external_url
+    - additional_url → BookClubMembership.additional_url (extra optional link)
+    Membership.intro_updated_at marks that the user presented themselves in this club.
+    """
+
+    intro_description = serializers.CharField(
+        required=True, allow_blank=False, max_length=1000
+    )
     social_url = serializers.CharField(
         required=False, allow_blank=True, max_length=500
     )
     additional_url = serializers.CharField(
         required=False, allow_blank=True, max_length=500
     )
-
-    class Meta:
-        model = BookClubMembership
-        fields = [
-            'intro_description',
-            'social_url',
-            'additional_url',
-            'intro_updated_at',
-        ]
-        read_only_fields = ['intro_updated_at']
-        extra_kwargs = {
-            'intro_description': {
-                'required': True,
-                'allow_blank': False,
-                'max_length': 1000,
-            },
-        }
-
-    @staticmethod
-    def _normalize_url(value):
-        from django.core.exceptions import ValidationError as DjangoValidationError
-        from django.core.validators import URLValidator
-
-        value = (value or '').strip()
-        if not value:
-            return ''
-        if not value.lower().startswith(('http://', 'https://')):
-            value = f'https://{value}'
-        try:
-            URLValidator()(value)
-        except DjangoValidationError as exc:
-            raise serializers.ValidationError(
-                'Introduce un enlace válido, por ejemplo https://linkedin.com/in/usuario'
-            ) from exc
-        return value
+    intro_updated_at = serializers.DateTimeField(read_only=True)
+    sourced_from_profile = serializers.BooleanField(read_only=True)
 
     def validate_social_url(self, value):
-        return self._normalize_url(value)
+        return _normalize_optional_url(value)
 
     def validate_additional_url(self, value):
-        return self._normalize_url(value)
+        return _normalize_optional_url(value)
 
-    def update(self, instance, validated_data):
-        validated_data['intro_updated_at'] = timezone.now()
-        return super().update(instance, validated_data)
+    def to_representation(self, membership):
+        profile = getattr(membership.user, 'profile', None)
+        profile_description = (getattr(profile, 'profile_description', None) or '').strip()
+        profile_url = (getattr(profile, 'external_url', None) or '').strip()
+        # Prefer Profile; fall back to legacy membership copies if profile empty.
+        intro = profile_description or (membership.intro_description or '').strip()
+        social = profile_url or (membership.social_url or '').strip()
+        return {
+            'intro_description': intro,
+            'social_url': social,
+            'additional_url': membership.additional_url or '',
+            'intro_updated_at': membership.intro_updated_at,
+            'sourced_from_profile': bool(profile_description or profile_url),
+        }
+
+    def update(self, membership, validated_data):
+        profile = _profile_for(membership.user)
+        intro = validated_data['intro_description'].strip()
+        social = validated_data.get('social_url', '') or ''
+        additional = validated_data.get('additional_url', '') or ''
+
+        profile.profile_description = intro
+        profile.external_url = social
+        profile.save(update_fields=['profile_description', 'external_url'])
+
+        # Keep membership mirrors for roster fallback / admin, and mark presented.
+        membership.intro_description = intro
+        membership.social_url = social
+        membership.additional_url = additional
+        membership.intro_updated_at = timezone.now()
+        membership.save(
+            update_fields=[
+                'intro_description',
+                'social_url',
+                'additional_url',
+                'intro_updated_at',
+            ]
+        )
+        return membership
 
 
 class BookClubMemberPublicSerializer(serializers.ModelSerializer):
@@ -86,6 +126,8 @@ class BookClubMemberPublicSerializer(serializers.ModelSerializer):
     user_id = serializers.IntegerField(source='user.id', read_only=True)
     is_me = serializers.SerializerMethodField()
     has_introduced = serializers.BooleanField(read_only=True)
+    intro_description = serializers.SerializerMethodField()
+    social_url = serializers.SerializerMethodField()
 
     class Meta:
         model = BookClubMembership
@@ -103,6 +145,19 @@ class BookClubMemberPublicSerializer(serializers.ModelSerializer):
             'is_me',
         ]
         read_only_fields = fields
+
+    def _profile(self, obj):
+        return getattr(obj.user, 'profile', None)
+
+    def get_intro_description(self, obj):
+        profile = self._profile(obj)
+        description = (getattr(profile, 'profile_description', None) or '').strip()
+        return description or (obj.intro_description or '').strip()
+
+    def get_social_url(self, obj):
+        profile = self._profile(obj)
+        url = (getattr(profile, 'external_url', None) or '').strip()
+        return url or (obj.social_url or '').strip()
 
     def get_is_me(self, obj):
         request = self.context.get('request')

--- a/acbc_app/book_clubs/serializers.py
+++ b/acbc_app/book_clubs/serializers.py
@@ -85,6 +85,7 @@ class BookClubMemberPublicSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username', read_only=True)
     user_id = serializers.IntegerField(source='user.id', read_only=True)
     is_me = serializers.SerializerMethodField()
+    has_introduced = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = BookClubMembership
@@ -98,6 +99,7 @@ class BookClubMemberPublicSerializer(serializers.ModelSerializer):
             'additional_url',
             'joined_at',
             'intro_updated_at',
+            'has_introduced',
             'is_me',
         ]
         read_only_fields = fields

--- a/acbc_app/book_clubs/tests.py
+++ b/acbc_app/book_clubs/tests.py
@@ -105,13 +105,27 @@ class BookClubAPITestCase(APITestCase):
         self.assertEqual(response2.status_code, status.HTTP_200_OK)
 
     def test_member_can_save_introduction_and_view_roster(self):
+        from profiles.models import Profile
+
         membership = BookClubMembership.objects.create(
             book_club=self.club,
             user=self.member,
             role=MembershipRole.MEMBER,
         )
-        # Admin is a member without introduction — should not appear in roster.
+        # Prefill comes from Profile when present.
+        Profile.objects.create(
+            user=self.member,
+            profile_description='Ya tenía bio en mi perfil.',
+            external_url='https://example.com/me',
+        )
         self.auth(self.member)
+
+        prefill = self.client.get('/api/book_clubs/cypherpunk/membership/introduction/')
+        self.assertEqual(prefill.status_code, status.HTTP_200_OK, prefill.data)
+        self.assertEqual(prefill.data['intro_description'], 'Ya tenía bio en mi perfil.')
+        self.assertEqual(prefill.data['social_url'], 'https://example.com/me')
+        self.assertTrue(prefill.data['sourced_from_profile'])
+
         empty_roster = self.client.get('/api/book_clubs/cypherpunk/members/')
         self.assertEqual(empty_roster.status_code, status.HTTP_200_OK, empty_roster.data)
         self.assertEqual(empty_roster.data, [])
@@ -127,14 +141,10 @@ class BookClubAPITestCase(APITestCase):
         )
         self.assertEqual(update.status_code, status.HTTP_200_OK, update.data)
         membership.refresh_from_db()
-        self.assertEqual(
-            membership.intro_description,
-            'Construyo productos educativos.',
-        )
-        self.assertEqual(
-            membership.social_url,
-            'https://linkedin.com/in/member',
-        )
+        profile = Profile.objects.get(user=self.member)
+        self.assertEqual(profile.profile_description, 'Construyo productos educativos.')
+        self.assertEqual(profile.external_url, 'https://linkedin.com/in/member')
+        self.assertEqual(membership.additional_url, 'https://member.example.com')
         self.assertIsNotNone(membership.intro_updated_at)
         self.assertTrue(membership.has_introduced)
 
@@ -143,10 +153,10 @@ class BookClubAPITestCase(APITestCase):
         self.assertEqual(len(roster.data), 1)
         own = roster.data[0]
         self.assertEqual(own['user_id'], self.member.id)
-        self.assertEqual(own['intro_description'], membership.intro_description)
+        self.assertEqual(own['intro_description'], profile.profile_description)
+        self.assertEqual(own['social_url'], profile.external_url)
         self.assertTrue(own['has_introduced'])
         self.assertTrue(own['is_me'])
-        # Members without intro_description stay hidden
         self.assertFalse(
             any(item['user_id'] == self.admin.id for item in roster.data)
         )

--- a/acbc_app/book_clubs/tests.py
+++ b/acbc_app/book_clubs/tests.py
@@ -319,6 +319,63 @@ class BookClubAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(BookClubEvent.objects.filter(book_club=self.club).count(), 2)
 
+    def test_unlink_event_and_admin_member_management(self):
+        membership = BookClubMembership.objects.create(
+            book_club=self.club, user=self.member, role=MembershipRole.MEMBER
+        )
+        self.auth(self.mentor)
+
+        # Public roster empty until presentation
+        public_roster = self.client.get('/api/book_clubs/cypherpunk/members/')
+        self.assertEqual(public_roster.status_code, status.HTTP_200_OK)
+        self.assertEqual(public_roster.data, [])
+
+        # Admin roster includes everyone
+        admin_roster = self.client.get(
+            '/api/book_clubs/cypherpunk/members/', {'include_all': 1}
+        )
+        self.assertEqual(admin_roster.status_code, status.HTTP_200_OK)
+        ids = {item['user_id'] for item in admin_roster.data}
+        self.assertIn(self.member.id, ids)
+        self.assertIn(self.admin.id, ids)
+
+        role_update = self.client.patch(
+            f'/api/book_clubs/cypherpunk/members/{membership.id}/',
+            {'role': MembershipRole.MENTOR},
+            format='json',
+        )
+        self.assertEqual(role_update.status_code, status.HTTP_200_OK, role_update.data)
+        membership.refresh_from_db()
+        self.assertEqual(membership.role, MembershipRole.MENTOR)
+
+        unlink = self.client.delete(
+            '/api/book_clubs/cypherpunk/events/',
+            {'event_id': self.event.id},
+            format='json',
+        )
+        self.assertEqual(unlink.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(
+            BookClubEvent.objects.filter(book_club=self.club, event=self.event).exists()
+        )
+
+        # Plain member cannot change roles; include_all is ignored without manage perms.
+        reader = User.objects.create_user(username='reader', password='pass123')
+        reader_membership = BookClubMembership.objects.create(
+            book_club=self.club, user=reader, role=MembershipRole.MEMBER
+        )
+        self.auth(reader)
+        public_as_reader = self.client.get(
+            '/api/book_clubs/cypherpunk/members/', {'include_all': 1}
+        )
+        self.assertEqual(public_as_reader.status_code, status.HTTP_200_OK)
+        self.assertEqual(public_as_reader.data, [])
+        denied_role = self.client.patch(
+            f'/api/book_clubs/cypherpunk/members/{reader_membership.id}/',
+            {'role': MembershipRole.ADMIN},
+            format='json',
+        )
+        self.assertEqual(denied_role.status_code, status.HTTP_403_FORBIDDEN)
+
     def _open_question_with_member_answer(self):
         BookClubMembership.objects.create(
             book_club=self.club, user=self.member, role=MembershipRole.MEMBER

--- a/acbc_app/book_clubs/tests.py
+++ b/acbc_app/book_clubs/tests.py
@@ -110,7 +110,11 @@ class BookClubAPITestCase(APITestCase):
             user=self.member,
             role=MembershipRole.MEMBER,
         )
+        # Admin is a member without introduction — should not appear in roster.
         self.auth(self.member)
+        empty_roster = self.client.get('/api/book_clubs/cypherpunk/members/')
+        self.assertEqual(empty_roster.status_code, status.HTTP_200_OK, empty_roster.data)
+        self.assertEqual(empty_roster.data, [])
 
         update = self.client.patch(
             '/api/book_clubs/cypherpunk/membership/introduction/',
@@ -132,12 +136,20 @@ class BookClubAPITestCase(APITestCase):
             'https://linkedin.com/in/member',
         )
         self.assertIsNotNone(membership.intro_updated_at)
+        self.assertTrue(membership.has_introduced)
 
         roster = self.client.get('/api/book_clubs/cypherpunk/members/')
         self.assertEqual(roster.status_code, status.HTTP_200_OK, roster.data)
-        own = next(item for item in roster.data if item['user_id'] == self.member.id)
+        self.assertEqual(len(roster.data), 1)
+        own = roster.data[0]
+        self.assertEqual(own['user_id'], self.member.id)
         self.assertEqual(own['intro_description'], membership.intro_description)
+        self.assertTrue(own['has_introduced'])
         self.assertTrue(own['is_me'])
+        # Members without intro_description stay hidden
+        self.assertFalse(
+            any(item['user_id'] == self.admin.id for item in roster.data)
+        )
 
     def test_non_member_cannot_edit_introduction_or_view_roster(self):
         self.auth(self.outsider)

--- a/acbc_app/book_clubs/urls.py
+++ b/acbc_app/book_clubs/urls.py
@@ -20,6 +20,11 @@ urlpatterns = [
         views.BookClubMemberListView.as_view(),
         name='book-club-members',
     ),
+    path(
+        '<slug:slug>/members/<int:membership_id>/',
+        views.BookClubMemberRoleUpdateView.as_view(),
+        name='book-club-member-role',
+    ),
     path('<slug:slug>/hub/', views.BookClubHubView.as_view(), name='book-club-hub'),
     path('<slug:slug>/events/', views.BookClubEventListCreateView.as_view(), name='book-club-events'),
     path(

--- a/acbc_app/book_clubs/views.py
+++ b/acbc_app/book_clubs/views.py
@@ -379,9 +379,10 @@ class BookClubMemberListView(APIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
         # Only members who completed "Preséntate al club" appear in the roster.
+        # Content comes from Profile; intro_updated_at marks club presentation.
         memberships = (
-            club.memberships.select_related('user')
-            .exclude(intro_description='')
+            club.memberships.select_related('user', 'user__profile')
+            .filter(intro_updated_at__isnull=False)
             .order_by('joined_at')
         )
         return Response(

--- a/acbc_app/book_clubs/views.py
+++ b/acbc_app/book_clubs/views.py
@@ -367,29 +367,77 @@ class BookClubMemberIntroductionView(APIView):
 
 
 class BookClubMemberListView(APIView):
-    """Member-only roster with club-specific introductions."""
+    """Member roster with club-specific introductions."""
 
     permission_classes = [IsAuthenticated]
 
     def get(self, request, slug):
         club = _get_club(slug)
-        if not club.user_is_member(request.user):
+        can_manage = club.user_can_manage(request.user)
+        if not club.user_is_member(request.user) and not can_manage:
             return Response(
                 {'detail': 'Debes ser miembro para ver la comunidad del club.'},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        # Only members who completed "Preséntate al club" appear in the roster.
-        # Content comes from Profile; intro_updated_at marks club presentation.
-        memberships = (
-            club.memberships.select_related('user', 'user__profile')
-            .filter(intro_updated_at__isnull=False)
-            .order_by('joined_at')
+        # Public community: only members who completed "Preséntate".
+        # Managers can pass ?include_all=1 to see everyone (roles / pending intros).
+        include_all = (
+            can_manage
+            and request.query_params.get('include_all', '').lower() in ('1', 'true', 'yes')
         )
+        memberships = club.memberships.select_related('user', 'user__profile').order_by(
+            'joined_at'
+        )
+        if not include_all:
+            memberships = memberships.filter(intro_updated_at__isnull=False)
         return Response(
             BookClubMemberPublicSerializer(
                 memberships,
                 many=True,
                 context={'request': request},
+            ).data
+        )
+
+
+class BookClubMemberRoleUpdateView(APIView):
+    """Mentor/admin can change a member's role in the club."""
+
+    permission_classes = [IsAuthenticated]
+
+    def patch(self, request, slug, membership_id):
+        club = _get_club(slug)
+        if not club.user_can_manage(request.user):
+            return Response({'detail': 'Forbidden.'}, status=status.HTTP_403_FORBIDDEN)
+        membership = get_object_or_404(
+            BookClubMembership.objects.select_related('user', 'user__profile'),
+            pk=membership_id,
+            book_club=club,
+        )
+        role = request.data.get('role')
+        valid_roles = {c.value for c in MembershipRole}
+        if role not in valid_roles:
+            return Response(
+                {'detail': f'Invalid role. Choose one of: {", ".join(sorted(valid_roles))}.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        # Prevent demoting the last admin accidentally.
+        if (
+            membership.role == MembershipRole.ADMIN
+            and role != MembershipRole.ADMIN
+            and not club.memberships.filter(role=MembershipRole.ADMIN)
+            .exclude(pk=membership.pk)
+            .exists()
+            and not (request.user.is_staff or request.user.is_superuser)
+        ):
+            return Response(
+                {'detail': 'No puedes quitar el último admin del club.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        membership.role = role
+        membership.save(update_fields=['role'])
+        return Response(
+            BookClubMemberPublicSerializer(
+                membership, context={'request': request}
             ).data
         )
 
@@ -672,6 +720,7 @@ class BookClubEventListCreateView(APIView):
         club = _get_club(slug)
         user = request.user if request.user.is_authenticated else None
         is_member = bool(user and club.user_is_member(user))
+        can_manage = bool(user and club.user_can_manage(user))
         guest_result, _ = _resolve_guest_payload(request, slug)
         if guest_result in ('expired', 'invalid'):
             return Response(
@@ -679,7 +728,7 @@ class BookClubEventListCreateView(APIView):
                 status=status.HTTP_401_UNAUTHORIZED,
             )
         is_guest = isinstance(guest_result, dict)
-        if not is_member and not is_guest:
+        if not is_member and not is_guest and not can_manage:
             if user:
                 return Response(
                     {'detail': 'Join the club to view events.'},
@@ -711,6 +760,29 @@ class BookClubEventListCreateView(APIView):
             BookClubEventSerializer(link).data, status=status.HTTP_201_CREATED
         )
 
+    def delete(self, request, slug):
+        """Unlink an event from the club. Body: { "event_id": N }."""
+        if not request.user.is_authenticated:
+            return Response({'detail': 'Authentication required.'}, status=status.HTTP_401_UNAUTHORIZED)
+        club = _get_club(slug)
+        if not club.user_can_manage(request.user):
+            return Response({'detail': 'Forbidden.'}, status=status.HTTP_403_FORBIDDEN)
+        event_id = request.data.get('event_id')
+        if not event_id:
+            return Response(
+                {'detail': 'event_id is required.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        deleted, _ = BookClubEvent.objects.filter(
+            book_club=club, event_id=event_id
+        ).delete()
+        if not deleted:
+            return Response(
+                {'detail': 'Event link not found.'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 class DiscussionQuestionListCreateView(APIView):
     permission_classes = [AllowAny]
@@ -719,6 +791,7 @@ class DiscussionQuestionListCreateView(APIView):
         club = _get_club(slug)
         user = request.user if request.user.is_authenticated else None
         is_member = bool(user and club.user_is_member(user))
+        can_manage = bool(user and club.user_can_manage(user))
         guest_result, _ = _resolve_guest_payload(request, slug)
         if guest_result in ('expired', 'invalid'):
             return Response(
@@ -726,7 +799,7 @@ class DiscussionQuestionListCreateView(APIView):
                 status=status.HTTP_401_UNAUTHORIZED,
             )
         is_guest = isinstance(guest_result, dict)
-        if not is_member and not is_guest:
+        if not is_member and not is_guest and not can_manage:
             if user:
                 return Response(
                     {'detail': 'Join the club to view discussion questions.'},
@@ -748,7 +821,6 @@ class DiscussionQuestionListCreateView(APIView):
             .select_related('node', 'event')
             .order_by('order', 'created_at')
         )
-        can_manage = bool(user and club.user_can_manage(user))
         if not can_manage:
             qs = [q for q in qs if q.status != DiscussionQuestionStatus.DRAFT]
         return Response(

--- a/acbc_app/book_clubs/views.py
+++ b/acbc_app/book_clubs/views.py
@@ -378,8 +378,11 @@ class BookClubMemberListView(APIView):
                 {'detail': 'Debes ser miembro para ver la comunidad del club.'},
                 status=status.HTTP_403_FORBIDDEN,
             )
-        memberships = club.memberships.select_related('user').order_by(
-            'joined_at'
+        # Only members who completed "Preséntate al club" appear in the roster.
+        memberships = (
+            club.memberships.select_related('user')
+            .exclude(intro_description='')
+            .order_by('joined_at')
         )
         return Response(
             BookClubMemberPublicSerializer(

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,7 @@ import BookClubAdminGeneral from './bookClubs/admin/BookClubAdminGeneral.jsx';
 import BookClubAdminConnections from './bookClubs/admin/BookClubAdminConnections.jsx';
 import BookClubAdminMeetings from './bookClubs/admin/BookClubAdminMeetings.jsx';
 import BookClubAdminQuestions from './bookClubs/admin/BookClubAdminQuestions.jsx';
+import BookClubAdminMembers from './bookClubs/admin/BookClubAdminMembers.jsx';
 import MainLayout from './layouts/MainLayout.jsx';
 import ProfilePageLayout from './layouts/ProfilePageLayout.jsx';
 import Profile from './profiles/Profile.jsx';
@@ -241,6 +242,7 @@ const AppContent = () => {
                 <Route path="conexiones" element={<BookClubAdminConnections />} />
                 <Route path="reuniones" element={<BookClubAdminMeetings />} />
                 <Route path="preguntas" element={<BookClubAdminQuestions />} />
+                <Route path="miembros" element={<BookClubAdminMembers />} />
               </Route>
             </Route>
             <Route path="welcome" element={<Welcome />} />

--- a/frontend/src/api/bookClubsApi.js
+++ b/frontend/src/api/bookClubsApi.js
@@ -5,6 +5,9 @@ const appendIfPresent = (formData, key, value) => {
   formData.append(key, value);
 };
 
+/** Fields that may be intentionally cleared with an empty string. */
+const CLEARABLE_STRING_FIELDS = new Set(['telegram_group_url', 'description']);
+
 /** Prefer JSON; use FormData only when uploading a cover image. */
 const toRequestBody = (payload) => {
   const hasFile = payload?.cover_image instanceof File;
@@ -12,7 +15,9 @@ const toRequestBody = (payload) => {
     const body = { ...payload };
     delete body.cover_image;
     Object.keys(body).forEach((key) => {
-      if (body[key] === undefined || body[key] === '') {
+      if (body[key] === undefined) {
+        delete body[key];
+      } else if (body[key] === '' && !CLEARABLE_STRING_FIELDS.has(key)) {
         delete body[key];
       }
     });
@@ -22,6 +27,8 @@ const toRequestBody = (payload) => {
   Object.entries(payload).forEach(([key, value]) => {
     if (value instanceof File) {
       formData.append(key, value);
+    } else if (value === '' && CLEARABLE_STRING_FIELDS.has(key)) {
+      formData.append(key, '');
     } else {
       appendIfPresent(formData, key, value);
     }
@@ -75,8 +82,18 @@ const bookClubsApi = {
     return response.data;
   },
 
-  listMembers: async (slug) => {
-    const response = await axiosInstance.get(`/book_clubs/${slug}/members/`);
+  listMembers: async (slug, { includeAll = false } = {}) => {
+    const response = await axiosInstance.get(`/book_clubs/${slug}/members/`, {
+      params: includeAll ? { include_all: 1 } : undefined,
+    });
+    return response.data;
+  },
+
+  updateMemberRole: async (slug, membershipId, role) => {
+    const response = await axiosInstance.patch(
+      `/book_clubs/${slug}/members/${membershipId}/`,
+      { role }
+    );
     return response.data;
   },
 
@@ -110,6 +127,20 @@ const bookClubsApi = {
     const response = await axiosInstance.post(`/book_clubs/${slug}/events/`, {
       event_id: eventId,
     });
+    return response.data;
+  },
+
+  unlinkEvent: async (slug, eventId) => {
+    const response = await axiosInstance.delete(`/book_clubs/${slug}/events/`, {
+      data: { event_id: eventId },
+    });
+    return response.data;
+  },
+
+  deleteDiscussionQuestion: async (slug, questionId) => {
+    const response = await axiosInstance.delete(
+      `/book_clubs/${slug}/discussion-questions/${questionId}/`
+    );
     return response.data;
   },
 

--- a/frontend/src/bookClubs/BookClubCommunity.jsx
+++ b/frontend/src/bookClubs/BookClubCommunity.jsx
@@ -101,6 +101,10 @@ const BookClubCommunity = () => {
           </Box>
         ) : membersError ? (
           <Alert severity="error">{membersError}</Alert>
+        ) : members.length === 0 ? (
+          <Alert severity="info" sx={{ bgcolor: 'rgba(255,255,255,0.04)', color: '#fff' }}>
+            Todavía nadie se ha presentado. Sé el primero con «Editar mi presentación».
+          </Alert>
         ) : (
           <Box
             sx={{
@@ -135,14 +139,12 @@ const BookClubCommunity = () => {
                 </Typography>
                 <Typography
                   sx={{
-                    color: member.intro_description
-                      ? 'rgba(255,255,255,0.78)'
-                      : 'rgba(255,255,255,0.45)',
+                    color: 'rgba(255,255,255,0.78)',
                     mt: 1.25,
                     whiteSpace: 'pre-wrap',
                   }}
                 >
-                  {member.intro_description || 'Aún no se ha presentado.'}
+                  {member.intro_description}
                 </Typography>
                 {(member.social_url || member.additional_url) && (
                   <Stack direction="row" spacing={2} sx={{ mt: 1.5 }} flexWrap="wrap" useFlexGap>

--- a/frontend/src/bookClubs/BookClubIntroduction.jsx
+++ b/frontend/src/bookClubs/BookClubIntroduction.jsx
@@ -175,8 +175,8 @@ const BookClubIntroduction = () => {
         Preséntate al club
       </Typography>
       <Typography sx={{ color: 'rgba(255,255,255,0.65)', mt: 1, mb: 3 }}>
-        Comparte una presentación breve con los miembros de {club.title}. Podrás
-        editarla cuando quieras.
+        Esto actualiza tu perfil público (Sobre ti y tu enlace). Si ya los tenías,
+        aparecen aquí listos para confirmar o editar para {club.title}.
       </Typography>
 
       {generalError && (
@@ -187,7 +187,7 @@ const BookClubIntroduction = () => {
 
       <Stack spacing={2.5}>
         <TextField
-          label="¿Qué haces?"
+          label="Sobre ti"
           required
           fullWidth
           multiline
@@ -197,18 +197,21 @@ const BookClubIntroduction = () => {
           error={Boolean(errors.intro_description)}
           helperText={
             errors.intro_description?.message ||
-            `${descriptionLength}/1000 · Cuéntanos a qué te dedicas o qué te interesa.`
+            `${descriptionLength}/1000 · Se guarda en tu perfil.`
           }
           sx={CLUB_TEXT_FIELD_SX}
         />
         <TextField
-          label="Link a red social"
+          label="Enlace de tu perfil"
           fullWidth
           placeholder="https://..."
           InputLabelProps={{ shrink: true }}
           {...register('social_url')}
           error={Boolean(errors.social_url)}
-          helperText={errors.social_url?.message || 'Opcional.'}
+          helperText={
+            errors.social_url?.message ||
+            'Opcional. Corresponde al enlace externo de tu perfil.'
+          }
           sx={CLUB_TEXT_FIELD_SX}
         />
         <TextField
@@ -218,7 +221,10 @@ const BookClubIntroduction = () => {
           InputLabelProps={{ shrink: true }}
           {...register('additional_url')}
           error={Boolean(errors.additional_url)}
-          helperText={errors.additional_url?.message || 'Opcional: web, proyecto, newsletter…'}
+          helperText={
+            errors.additional_url?.message ||
+            'Opcional y solo para este club: web, proyecto, newsletter…'
+          }
           sx={CLUB_TEXT_FIELD_SX}
         />
         <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>

--- a/frontend/src/bookClubs/admin/BookClubAdminLayout.jsx
+++ b/frontend/src/bookClubs/admin/BookClubAdminLayout.jsx
@@ -134,6 +134,19 @@ const BookClubAdminLayout = () => {
         >
           Preguntas
         </Box>
+        <Box
+          component={NavLink}
+          to="miembros"
+          style={({ isActive }) => ({
+            color: isActive ? 'inherit' : '#666',
+            borderBottom: isActive ? '2px solid' : '2px solid transparent',
+            fontWeight: isActive ? 700 : 500,
+            textDecoration: 'none',
+          })}
+          sx={{ px: 1.5, py: 1, fontSize: '0.9rem', whiteSpace: 'nowrap', borderColor: 'primary.main' }}
+        >
+          Miembros
+        </Box>
         <Button
           size="small"
           component={RouterLink}

--- a/frontend/src/bookClubs/admin/BookClubAdminMeetings.jsx
+++ b/frontend/src/bookClubs/admin/BookClubAdminMeetings.jsx
@@ -66,6 +66,23 @@ const BookClubAdminMeetings = () => {
     }
   };
 
+  const handleUnlink = async (linkedEventId) => {
+    if (!window.confirm('¿Desvincular esta reunión del club?')) return;
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await bookClubsApi.unlinkEvent(slug, linkedEventId);
+      setSuccess('Reunión desvinculada.');
+      await load();
+      await reload?.();
+    } catch (err) {
+      setError(extractApiError(err, 'No se pudo desvincular el evento.'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const linkedIds = new Set(linked.map((e) => e.event_id));
   const available = myEvents.filter((e) => !linkedIds.has(e.id));
 
@@ -131,9 +148,19 @@ const BookClubAdminMeetings = () => {
               <Typography variant="body2" color="text.secondary">
                 {formatClubDate(ev.date_start) || 'Sin fecha'}
               </Typography>
-              <Button size="small" component={RouterLink} to={`/events/${ev.event_id}`}>
-                Abrir evento
-              </Button>
+              <Stack direction="row" spacing={1} sx={{ mt: 0.5 }}>
+                <Button size="small" component={RouterLink} to={`/events/${ev.event_id}`}>
+                  Abrir evento
+                </Button>
+                <Button
+                  size="small"
+                  color="error"
+                  disabled={saving}
+                  onClick={() => handleUnlink(ev.event_id)}
+                >
+                  Desvincular
+                </Button>
+              </Stack>
             </Box>
           ))}
         </Stack>

--- a/frontend/src/bookClubs/admin/BookClubAdminMembers.jsx
+++ b/frontend/src/bookClubs/admin/BookClubAdminMembers.jsx
@@ -1,0 +1,158 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useOutletContext, useParams } from 'react-router-dom';
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+import bookClubsApi from '../../api/bookClubsApi';
+import { extractApiError, formatClubDate } from '../clubTheme';
+
+const ROLE_OPTIONS = [
+  { value: 'member', label: 'Member' },
+  { value: 'mentor', label: 'Mentor' },
+  { value: 'admin', label: 'Admin' },
+];
+
+const BookClubAdminMembers = () => {
+  const { slug } = useParams();
+  const { reload } = useOutletContext();
+  const [members, setMembers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
+  const [updatingId, setUpdatingId] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await bookClubsApi.listMembers(slug, { includeAll: true });
+      setMembers(Array.isArray(data) ? data : []);
+      setError(null);
+    } catch (err) {
+      setError(extractApiError(err, 'No se pudieron cargar los miembros.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [slug]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleRoleChange = async (membershipId, role) => {
+    setUpdatingId(membershipId);
+    setError(null);
+    setSuccess(null);
+    try {
+      await bookClubsApi.updateMemberRole(slug, membershipId, role);
+      setSuccess('Rol actualizado.');
+      await load();
+      await reload?.({ silent: true });
+    } catch (err) {
+      setError(extractApiError(err, 'No se pudo cambiar el rol.'));
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Miembros del club
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3, maxWidth: 720 }}>
+        Lista completa para administración. En la pestaña Comunidad del club público solo se muestran
+        quienes completaron «Preséntate» (bio del perfil).
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      {success && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(null)}>
+          {success}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={28} />
+        </Box>
+      ) : !members.length ? (
+        <Typography color="text.secondary">Aún no hay miembros en este club.</Typography>
+      ) : (
+        <Stack spacing={1.5}>
+          {members.map((m) => (
+            <Box
+              key={m.id}
+              sx={{
+                py: 1.5,
+                borderBottom: 1,
+                borderColor: 'divider',
+                display: 'flex',
+                flexDirection: { xs: 'column', sm: 'row' },
+                gap: 2,
+                justifyContent: 'space-between',
+                alignItems: { sm: 'center' },
+              }}
+            >
+              <Box sx={{ minWidth: 0, flex: 1 }}>
+                <Typography fontWeight={700}>
+                  @{m.username}
+                  {m.is_me ? ' · Tú' : ''}
+                </Typography>
+                <Stack direction="row" spacing={1} sx={{ mt: 0.5 }} flexWrap="wrap" useFlexGap>
+                  <Chip
+                    size="small"
+                    color={m.has_introduced ? 'success' : 'default'}
+                    label={m.has_introduced ? 'Presentado' : 'Sin presentación'}
+                  />
+                  <Typography variant="caption" color="text.secondary">
+                    Desde {formatClubDate(m.joined_at) || '—'}
+                  </Typography>
+                </Stack>
+                {m.intro_description && (
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mt: 0.75, whiteSpace: 'pre-wrap' }}
+                  >
+                    {m.intro_description}
+                  </Typography>
+                )}
+              </Box>
+              <FormControl size="small" sx={{ minWidth: 160 }}>
+                <InputLabel id={`role-${m.id}`}>Rol</InputLabel>
+                <Select
+                  labelId={`role-${m.id}`}
+                  label="Rol"
+                  value={m.role}
+                  disabled={updatingId === m.id}
+                  onChange={(e) => handleRoleChange(m.id, e.target.value)}
+                >
+                  {ROLE_OPTIONS.map((opt) => (
+                    <MenuItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+};
+
+export default BookClubAdminMembers;

--- a/frontend/src/bookClubs/admin/BookClubAdminQuestions.jsx
+++ b/frontend/src/bookClubs/admin/BookClubAdminQuestions.jsx
@@ -5,26 +5,59 @@ import {
   Box,
   Button,
   Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
   Stack,
   TextField,
   Typography,
 } from '@mui/material';
 import bookClubsApi from '../../api/bookClubsApi';
-import { extractApiError } from '../clubTheme';
+import knowledgePathsApi from '../../api/knowledgePathsApi';
+import {
+  extractApiError,
+  formatClubDate,
+  toDatetimeLocal,
+  toIsoOrNull,
+} from '../clubTheme';
+
+const STATUS_OPTIONS = [
+  { value: 'draft', label: 'Borrador' },
+  { value: 'open', label: 'Abierta' },
+  { value: 'closed', label: 'Cerrada' },
+];
+
+const emptyForm = {
+  body: '',
+  status: 'open',
+  node: '',
+  event: '',
+  opens_at: '',
+  closes_at: '',
+  order: '',
+};
 
 const BookClubAdminQuestions = () => {
   const { slug } = useParams();
   const { club } = useOutletContext();
   const [questions, setQuestions] = useState([]);
-  const [body, setBody] = useState('');
+  const [nodes, setNodes] = useState([]);
+  const [events, setEvents] = useState([]);
+  const [form, setForm] = useState(emptyForm);
+  const [editingId, setEditingId] = useState(null);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
   const [saving, setSaving] = useState(false);
 
   const load = useCallback(async () => {
     try {
-      const data = await bookClubsApi.listDiscussionQuestions(slug);
-      setQuestions(Array.isArray(data) ? data : []);
+      const [qs, clubEvents] = await Promise.all([
+        bookClubsApi.listDiscussionQuestions(slug),
+        bookClubsApi.listEvents(slug).catch(() => []),
+      ]);
+      setQuestions(Array.isArray(qs) ? qs : []);
+      setEvents(Array.isArray(clubEvents) ? clubEvents : []);
       setError(null);
     } catch (err) {
       setError(extractApiError(err, 'No se pudieron cargar las preguntas.'));
@@ -35,24 +68,124 @@ const BookClubAdminQuestions = () => {
     load();
   }, [load]);
 
-  const handleCreate = async () => {
-    if (!body.trim()) return;
+  useEffect(() => {
+    if (!club?.knowledge_path) {
+      setNodes([]);
+      return;
+    }
+    knowledgePathsApi
+      .getKnowledgePath(club.knowledge_path)
+      .then((path) => setNodes(Array.isArray(path?.nodes) ? path.nodes : []))
+      .catch(() => setNodes([]));
+  }, [club?.knowledge_path]);
+
+  const setField = (field) => (event) => {
+    setForm((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const startEdit = (q) => {
+    setEditingId(q.id);
+    setForm({
+      body: q.body || '',
+      status: q.status || 'open',
+      node: q.node != null ? String(q.node) : '',
+      event: q.event != null ? String(q.event) : '',
+      opens_at: toDatetimeLocal(q.opens_at),
+      closes_at: toDatetimeLocal(q.closes_at),
+      order: q.order != null ? String(q.order) : '',
+    });
+    setSuccess(null);
+    setError(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setForm(emptyForm);
+  };
+
+  const buildPayload = () => {
+    if (!form.body.trim()) {
+      throw new Error('El texto de la pregunta es obligatorio.');
+    }
+    const payload = {
+      body: form.body.trim(),
+      status: form.status,
+      node: form.node === '' ? null : Number(form.node),
+      event: form.event === '' ? null : Number(form.event),
+    };
+    if (form.order !== '') {
+      payload.order = Number(form.order);
+    }
+    if (form.opens_at) {
+      const iso = toIsoOrNull(form.opens_at);
+      if (!iso) throw new Error('opens_at no es válida.');
+      payload.opens_at = iso;
+    } else if (editingId) {
+      payload.opens_at = null;
+    }
+    if (form.closes_at) {
+      const iso = toIsoOrNull(form.closes_at);
+      if (!iso) throw new Error('closes_at no es válida.');
+      payload.closes_at = iso;
+    } else if (editingId) {
+      payload.closes_at = null;
+    }
+    return payload;
+  };
+
+  const handleSave = async () => {
     setSaving(true);
     setError(null);
     setSuccess(null);
     try {
-      await bookClubsApi.createDiscussionQuestion(slug, {
-        body: body.trim(),
-        status: 'open',
-        order: questions.length + 1,
-      });
-      setBody('');
-      setSuccess('Pregunta publicada.');
+      const payload = buildPayload();
+      if (editingId) {
+        await bookClubsApi.updateDiscussionQuestion(slug, editingId, payload);
+        setSuccess('Pregunta actualizada.');
+      } else {
+        await bookClubsApi.createDiscussionQuestion(slug, {
+          ...payload,
+          order: payload.order ?? questions.length + 1,
+        });
+        setSuccess(
+          payload.status === 'draft'
+            ? 'Borrador guardado.'
+            : 'Pregunta publicada.'
+        );
+      }
+      cancelEdit();
       await load();
     } catch (err) {
-      setError(extractApiError(err, 'No se pudo crear la pregunta.'));
+      setError(
+        err?.message && !err?.response
+          ? err.message
+          : extractApiError(err, 'No se pudo guardar la pregunta.')
+      );
     } finally {
       setSaving(false);
+    }
+  };
+
+  const quickStatus = async (q, status) => {
+    setError(null);
+    try {
+      await bookClubsApi.updateDiscussionQuestion(slug, q.id, { status });
+      await load();
+    } catch (err) {
+      setError(extractApiError(err, 'No se pudo cambiar el estado.'));
+    }
+  };
+
+  const handleDelete = async (q) => {
+    if (!window.confirm('¿Eliminar esta pregunta de debate?')) return;
+    setError(null);
+    try {
+      await bookClubsApi.deleteDiscussionQuestion(slug, q.id);
+      if (editingId === q.id) cancelEdit();
+      setSuccess('Pregunta eliminada.');
+      await load();
+    } catch (err) {
+      setError(extractApiError(err, 'No se pudo eliminar.'));
     }
   };
 
@@ -62,7 +195,8 @@ const BookClubAdminQuestions = () => {
         Preguntas de debate
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        Gestiona las preguntas visibles en el club. También puedes publicarlas desde el hub si eres mentor.
+        Crea, programa y cierra preguntas ligadas a misiones o reuniones. Se muestran en el hub
+        (Debates) según su estado y fechas.
       </Typography>
 
       {error && (
@@ -76,25 +210,121 @@ const BookClubAdminQuestions = () => {
         </Alert>
       )}
 
-      <Stack spacing={1.5} sx={{ mb: 3, maxWidth: 640 }}>
+      <Stack
+        spacing={2}
+        sx={{
+          mb: 4,
+          maxWidth: 720,
+          p: 2,
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: 1,
+        }}
+      >
+        <Typography variant="subtitle1" fontWeight={700}>
+          {editingId ? `Editando pregunta #${editingId}` : 'Nueva pregunta'}
+        </Typography>
         <TextField
-          label="Nueva pregunta"
+          label="Texto de la pregunta"
           fullWidth
           multiline
           minRows={2}
-          value={body}
-          onChange={(e) => setBody(e.target.value)}
+          value={form.body}
+          onChange={setField('body')}
+          required
         />
-        <Button
-          variant="contained"
-          onClick={handleCreate}
-          disabled={saving || !body.trim()}
-          sx={{ alignSelf: 'flex-start' }}
-        >
-          Publicar abierta
-        </Button>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+          <FormControl fullWidth>
+            <InputLabel id="q-status">Estado</InputLabel>
+            <Select
+              labelId="q-status"
+              label="Estado"
+              value={form.status}
+              onChange={setField('status')}
+            >
+              {STATUS_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            label="Orden"
+            type="number"
+            fullWidth
+            value={form.order}
+            onChange={setField('order')}
+            helperText="Opcional"
+          />
+        </Stack>
+        <FormControl fullWidth>
+          <InputLabel id="q-node">Después de la misión</InputLabel>
+          <Select
+            labelId="q-node"
+            label="Después de la misión"
+            value={form.node}
+            onChange={setField('node')}
+          >
+            <MenuItem value="">Sin misión vinculada</MenuItem>
+            {nodes.map((n) => (
+              <MenuItem key={n.id} value={String(n.id)}>
+                Misión {n.order}: {n.title}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl fullWidth>
+          <InputLabel id="q-event">Después del directo</InputLabel>
+          <Select
+            labelId="q-event"
+            label="Después del directo"
+            value={form.event}
+            onChange={setField('event')}
+          >
+            <MenuItem value="">Sin reunión vinculada</MenuItem>
+            {events.map((ev) => (
+              <MenuItem key={ev.event_id} value={String(ev.event_id)}>
+                {ev.title}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+          <TextField
+            label="Abrir en"
+            type="datetime-local"
+            fullWidth
+            InputLabelProps={{ shrink: true }}
+            value={form.opens_at}
+            onChange={setField('opens_at')}
+            helperText="Opcional · auto-abre borradores"
+          />
+          <TextField
+            label="Cerrar en"
+            type="datetime-local"
+            fullWidth
+            InputLabelProps={{ shrink: true }}
+            value={form.closes_at}
+            onChange={setField('closes_at')}
+            helperText="Opcional · auto-cierra abiertas"
+          />
+        </Stack>
+        <Stack direction="row" spacing={1}>
+          <Button variant="contained" onClick={handleSave} disabled={saving || !form.body.trim()}>
+            {saving ? 'Guardando…' : editingId ? 'Guardar cambios' : 'Crear pregunta'}
+          </Button>
+          {editingId && (
+            <Button onClick={cancelEdit} disabled={saving}>
+              Cancelar
+            </Button>
+          )}
+        </Stack>
       </Stack>
 
+      <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>
+        Preguntas del club ({questions.length})
+      </Typography>
       {!questions.length ? (
         <Typography color="text.secondary">Todavía no hay preguntas.</Typography>
       ) : (
@@ -106,23 +336,57 @@ const BookClubAdminQuestions = () => {
                 py: 1.5,
                 borderBottom: 1,
                 borderColor: 'divider',
-                display: 'flex',
-                gap: 2,
-                justifyContent: 'space-between',
-                alignItems: 'flex-start',
               }}
             >
-              <Box>
-                <Typography fontWeight={600}>{q.body}</Typography>
-                <Chip size="small" label={q.effective_status || q.status} sx={{ mt: 0.5 }} />
-              </Box>
-              <Button
-                size="small"
-                component={RouterLink}
-                to={`/club-de-lectura/${club.slug}/preguntas/${q.id}`}
+              <Stack
+                direction={{ xs: 'column', sm: 'row' }}
+                justifyContent="space-between"
+                alignItems={{ sm: 'flex-start' }}
+                spacing={1}
               >
-                Abrir
-              </Button>
+                <Box>
+                  <Typography fontWeight={600}>{q.body}</Typography>
+                  <Stack direction="row" spacing={1} sx={{ mt: 0.75 }} flexWrap="wrap" useFlexGap>
+                    <Chip size="small" label={q.effective_status || q.status} />
+                    {q.mission_label && (
+                      <Chip size="small" variant="outlined" label={q.mission_label} />
+                    )}
+                    {q.event_title && (
+                      <Chip size="small" variant="outlined" label={`Directo: ${q.event_title}`} />
+                    )}
+                  </Stack>
+                  <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.5 }}>
+                    {q.answer_count} respuesta{q.answer_count === 1 ? '' : 's'}
+                    {q.opens_at ? ` · abre ${formatClubDate(q.opens_at)}` : ''}
+                    {q.closes_at ? ` · cierra ${formatClubDate(q.closes_at)}` : ''}
+                  </Typography>
+                </Box>
+                <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+                  {q.status !== 'open' && (
+                    <Button size="small" onClick={() => quickStatus(q, 'open')}>
+                      Abrir
+                    </Button>
+                  )}
+                  {q.status === 'open' && (
+                    <Button size="small" onClick={() => quickStatus(q, 'closed')}>
+                      Cerrar
+                    </Button>
+                  )}
+                  <Button size="small" onClick={() => startEdit(q)}>
+                    Editar
+                  </Button>
+                  <Button
+                    size="small"
+                    component={RouterLink}
+                    to={`/club-de-lectura/${club.slug}/preguntas/${q.id}`}
+                  >
+                    Ver
+                  </Button>
+                  <Button size="small" color="error" onClick={() => handleDelete(q)}>
+                    Eliminar
+                  </Button>
+                </Stack>
+              </Stack>
             </Box>
           ))}
         </Stack>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Clarifies that **Preséntate al club** saves on `BookClubMembership`, not on `Profile`.
- Comunidad roster (`GET /api/book_clubs/:slug/members/`) now returns only members with a non-empty `intro_description`.
- Adds `has_introduced` on the membership model/serializer and an empty-state message in the UI.

### Where presentation fields live
| UI field | DB field | Table |
|----------|----------|-------|
| ¿Qué haces? | `intro_description` | `book_clubs_bookclubmembership` |
| Link a red social | `social_url` | same |
| Otro link más | `additional_url` | same |
| (auto) | `intro_updated_at` | set on save |

Criterion for “se presentó”: `intro_description` no vacío.

## Test plan
- [x] `python manage.py test book_clubs.tests.BookClubAPITestCase.test_member_can_save_introduction_and_view_roster`
- [ ] Presentarse como Vincent → aparece en Comunidad
- [ ] Admin sin presentación → ya no aparece
- [ ] Lista vacía muestra el mensaje de “Sé el primero…”
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd354143-89b2-456e-a88d-454bad7b2785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd354143-89b2-456e-a88d-454bad7b2785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

