### PR TITLE
Transcript ingest API ready for external workers

### DIFF
--- a/acbc_app/content/serializers.py
+++ b/acbc_app/content/serializers.py
@@ -1363,8 +1363,14 @@ class ContentTranscriptIngestSummarySerializer(serializers.ModelSerializer):
 
 
 class ContentTranscriptQueueItemSerializer(serializers.ModelSerializer):
+    """Manifest row for an external transcript worker (S3 key + optional YouTube URL)."""
+
     has_file = serializers.SerializerMethodField()
     file_key = serializers.SerializerMethodField()
+    file_size = serializers.SerializerMethodField()
+    is_youtube = serializers.SerializerMethodField()
+    youtube_video_id = serializers.SerializerMethodField()
+    has_transcript = serializers.SerializerMethodField()
 
     class Meta:
         model = Content
@@ -1374,20 +1380,50 @@ class ContentTranscriptQueueItemSerializer(serializers.ModelSerializer):
             'original_title',
             'original_author',
             'url',
+            'is_youtube',
+            'youtube_video_id',
             'has_file',
             'file_key',
+            'file_size',
+            'has_spanish_subtitles',
+            'has_spanish_dubbing',
+            'has_transcript',
             'created_at',
         ]
 
+    def _file_details(self, obj):
+        return getattr(obj, 'file_details', None)
+
     def get_has_file(self, obj):
-        file_details = getattr(obj, 'file_details', None)
+        file_details = self._file_details(obj)
         return bool(file_details and file_details.file)
 
     def get_file_key(self, obj):
-        file_details = getattr(obj, 'file_details', None)
+        file_details = self._file_details(obj)
         if not file_details or not file_details.file:
             return None
         return file_details.file.name
+
+    def get_file_size(self, obj):
+        file_details = self._file_details(obj)
+        if not file_details:
+            return None
+        return file_details.file_size
+
+    def get_is_youtube(self, obj):
+        from content.youtube_migration_utils import is_youtube_url
+        return is_youtube_url(obj.url)
+
+    def get_youtube_video_id(self, obj):
+        from content.youtube_migration_utils import extract_youtube_video_id
+        return extract_youtube_video_id(obj.url) if obj.url else None
+
+    def get_has_transcript(self, obj):
+        # OneToOne: select_related('transcript') leaves a reverse cache; missing row raises.
+        try:
+            return obj.transcript is not None
+        except ContentTranscript.DoesNotExist:
+            return False
 
 
 class TopicCreationRequestSerializer(serializers.ModelSerializer):

--- a/acbc_app/content/tests.py
+++ b/acbc_app/content/tests.py
@@ -4252,19 +4252,32 @@ Hola, bienvenidos al podcast. Hoy hablamos de blockchain.
             email='ingest@example.com',
             password='testpass123',
         )
+        self.topic = Topic.objects.create(
+            title='Tema transcripts',
+            description='Para worker externo',
+            creator=self.user,
+        )
+        self.other_topic = Topic.objects.create(
+            title='Otro tema',
+            description='Sin estos videos',
+            creator=self.user,
+        )
         self.video = Content.objects.create(
             uploaded_by=self.user,
             media_type='VIDEO',
             original_title='Video pendiente',
             url='https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+            has_spanish_subtitles=True,
         )
-        FileDetails.objects.create(content=self.video)
+        FileDetails.objects.create(content=self.video, file_size=123456)
+        self.video.topics.add(self.topic)
         self.audio = Content.objects.create(
             uploaded_by=self.user,
             media_type='AUDIO',
             original_title='Podcast pendiente',
         )
-        FileDetails.objects.create(content=self.audio)
+        FileDetails.objects.create(content=self.audio, file_size=999)
+        self.audio.topics.add(self.topic)
 
     def test_queue_requires_api_key(self):
         response = self.client.get('/api/content/transcript-ingest/')
@@ -4274,8 +4287,97 @@ Hola, bienvenidos al podcast. Hoy hablamos de blockchain.
         response = self.client.get('/api/content/transcript-ingest/', **self.auth_header)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 2)
+        self.assertFalse(response.data['include_completed'])
+        self.assertIsNone(response.data['topic_id'])
         content_ids = {item['id'] for item in response.data['items']}
         self.assertEqual(content_ids, {self.video.id, self.audio.id})
+
+    def test_queue_item_exposes_youtube_and_s3_hints(self):
+        response = self.client.get(
+            '/api/content/transcript-ingest/',
+            {'content_id': self.video.id},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        item = response.data['items'][0]
+        self.assertTrue(item['is_youtube'])
+        self.assertEqual(item['youtube_video_id'], 'dQw4w9WgXcQ')
+        self.assertEqual(item['file_size'], 123456)
+        self.assertTrue(item['has_spanish_subtitles'])
+        self.assertFalse(item['has_transcript'])
+        self.assertIn('file_key', item)
+        self.assertIn('has_file', item)
+
+    def test_queue_filters_by_topic_id(self):
+        orphan = Content.objects.create(
+            uploaded_by=self.user,
+            media_type='VIDEO',
+            original_title='Fuera del tema',
+        )
+        FileDetails.objects.create(content=orphan)
+
+        response = self.client.get(
+            '/api/content/transcript-ingest/',
+            {'topic_id': self.topic.id},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['topic_id'], self.topic.id)
+        self.assertEqual(response.data['count'], 2)
+        content_ids = {item['id'] for item in response.data['items']}
+        self.assertEqual(content_ids, {self.video.id, self.audio.id})
+        self.assertNotIn(orphan.id, content_ids)
+
+        empty = self.client.get(
+            '/api/content/transcript-ingest/',
+            {'topic_id': self.other_topic.id},
+            **self.auth_header,
+        )
+        self.assertEqual(empty.status_code, status.HTTP_200_OK)
+        self.assertEqual(empty.data['count'], 0)
+
+    def test_queue_unknown_topic_returns_404(self):
+        response = self.client.get(
+            '/api/content/transcript-ingest/',
+            {'topic_id': 999999},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_queue_include_completed_returns_items_with_transcript(self):
+        ContentTranscript.objects.create(
+            content=self.video,
+            processed_plain=self.PROCESSED_PLAIN,
+            language='es',
+        )
+        pending_only = self.client.get(
+            '/api/content/transcript-ingest/',
+            {'topic_id': self.topic.id},
+            **self.auth_header,
+        )
+        self.assertEqual(pending_only.data['count'], 1)
+        self.assertEqual(pending_only.data['items'][0]['id'], self.audio.id)
+
+        with_done = self.client.get(
+            '/api/content/transcript-ingest/',
+            {'topic_id': self.topic.id, 'include_completed': 'true'},
+            **self.auth_header,
+        )
+        self.assertEqual(with_done.status_code, status.HTTP_200_OK)
+        self.assertTrue(with_done.data['include_completed'])
+        self.assertEqual(with_done.data['count'], 2)
+        by_id = {item['id']: item for item in with_done.data['items']}
+        self.assertTrue(by_id[self.video.id]['has_transcript'])
+        self.assertFalse(by_id[self.audio.id]['has_transcript'])
+
+    def test_queue_accepts_bearer_auth(self):
+        response = self.client.get(
+            '/api/content/transcript-ingest/',
+            HTTP_AUTHORIZATION='Bearer test-ingest-key',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 2)
 
     def test_put_creates_transcript(self):
         response = self.client.put(
@@ -4355,6 +4457,9 @@ Hola, bienvenidos al podcast. Hoy hablamos de blockchain.
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data['has_transcript'])
         self.assertTrue(response.data['transcript']['has_processed_plain'])
+        self.assertTrue(response.data['content']['is_youtube'])
+        self.assertEqual(response.data['content']['youtube_video_id'], 'dQw4w9WgXcQ')
+        self.assertTrue(response.data['content']['has_transcript'])
 
     def test_put_requires_at_least_one_artifact(self):
         response = self.client.put(

--- a/acbc_app/content/views_transcript_ingest.py
+++ b/acbc_app/content/views_transcript_ingest.py
@@ -1,4 +1,27 @@
-"""API endpoints for external async transcript extraction workers."""
+"""API endpoints for external async transcript extraction workers.
+
+Contract (machine-to-machine, header ``X-Transcript-Ingest-Key`` or ``Authorization: Bearer``):
+
+* ``GET  /api/content/transcript-ingest/``
+  Work queue / topic manifest. Default: VIDEO/AUDIO without a transcript.
+  Query params:
+  - ``topic_id`` — only contents linked to this topic
+  - ``media_type`` — ``VIDEO`` or ``AUDIO``
+  - ``content_id`` — single content
+  - ``include_completed`` — ``true``/``1`` to also return items that already have a transcript
+  - ``limit`` / ``offset`` — pagination (default limit 100, max 500)
+
+* ``GET  /api/content/transcript-ingest/<content_id>/``
+  One-item manifest + transcript summary (if any).
+
+* ``PUT  /api/content/transcript-ingest/<content_id>/``
+  Idempotent upsert of transcript artifacts. Body may include any of
+  ``parsed_plain``, ``processed_plain``, ``obsidian_markdown`` (at least one required),
+  plus optional ``source_subtitles`` (SRT/VTT), ``format``, ``language``.
+
+Queue items expose ``file_key`` (S3 object key) for workers with bucket credentials;
+they do not return pre-signed download URLs.
+"""
 import logging
 
 from django.core.exceptions import ValidationError
@@ -7,7 +30,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from content.models import Content, ContentTranscript
+from content.models import Content, ContentTranscript, Topic
 from content.permissions import TranscriptIngestPermission
 from content.serializers import (
     ContentTranscriptIngestSerializer,
@@ -22,6 +45,12 @@ DEFAULT_QUEUE_LIMIT = 100
 MAX_QUEUE_LIMIT = 500
 
 
+def _parse_bool(value):
+    if value is None:
+        return False
+    return str(value).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
 class TranscriptIngestAPIView(APIView):
     """Shared auth for machine-to-machine transcript ingest."""
 
@@ -33,8 +62,8 @@ class ContentTranscriptIngestQueueView(TranscriptIngestAPIView):
     """
     GET /api/content/transcript-ingest/
 
-    List video/audio content that still has no transcript (work queue for external jobs).
-    Optional query params: media_type, content_id, limit, offset.
+    List video/audio content for an external transcript worker.
+    Optional query params: topic_id, media_type, content_id, include_completed, limit, offset.
     """
 
     def get(self, request):
@@ -44,6 +73,21 @@ class ContentTranscriptIngestQueueView(TranscriptIngestAPIView):
                 {'error': 'media_type debe ser VIDEO o AUDIO.'},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        topic_id = request.query_params.get('topic_id')
+        if topic_id is not None:
+            try:
+                topic_id = int(topic_id)
+            except (TypeError, ValueError):
+                return Response(
+                    {'error': 'topic_id debe ser un entero.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if not Topic.objects.filter(pk=topic_id).exists():
+                return Response(
+                    {'error': f'No existe el tema {topic_id}.'},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
 
         content_id = request.query_params.get('content_id')
         if content_id is not None:
@@ -73,14 +117,19 @@ class ContentTranscriptIngestQueueView(TranscriptIngestAPIView):
             )
         offset = max(0, offset)
 
+        include_completed = _parse_bool(request.query_params.get('include_completed'))
+
         queryset = (
             Content.objects.filter(media_type__in=TRANSCRIPT_MEDIA_TYPES)
-            .exclude(transcript__isnull=False)
-            .select_related('file_details')
+            .select_related('file_details', 'transcript')
             .order_by('id')
         )
+        if not include_completed:
+            queryset = queryset.filter(transcript__isnull=True)
         if media_type:
             queryset = queryset.filter(media_type=media_type)
+        if topic_id is not None:
+            queryset = queryset.filter(topics__id=topic_id).distinct()
         if content_id is not None:
             queryset = queryset.filter(pk=content_id)
 
@@ -92,6 +141,8 @@ class ContentTranscriptIngestQueueView(TranscriptIngestAPIView):
             'count': total,
             'limit': limit,
             'offset': offset,
+            'include_completed': include_completed,
+            'topic_id': topic_id,
             'items': serializer.data,
         })
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Complete API reference and usage guides:
 - [API Index](api/README.md) - API documentation overview
 - [Authentication](api/authentication.md) - Authentication endpoints and flows
 - [Endpoints](api/endpoints.md) - Complete endpoint reference
+- [Transcript ingest](api/transcript-ingest.md) - External worker queue + transcript upsert (S3 / YouTube)
 - [Examples](api/examples.md) - API usage examples
 - [Errors](api/errors.md) - Error codes and handling
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -36,6 +36,7 @@ The API uses JWT (JSON Web Tokens) for authentication. See [Authentication Guide
 - **[Certificates](endpoints.md#certificates)** - Certificate management
 - **[Search](endpoints.md#search)** - Search functionality
 - **[Notifications](endpoints.md#notifications)** - In-app notifications (`/api/profiles/notifications/`). See also [backend notifications](../backend/notifications.md).
+- **[Transcript ingest (workers)](transcript-ingest.md)** - Machine-to-machine queue + upsert for external Whisper/captions workers
 
 ## Request/Response Format
 
@@ -98,6 +99,7 @@ See [API Examples](examples.md) for code examples and common use cases.
 
 - [Authentication](authentication.md) - Authentication flows and endpoints
 - [Endpoints](endpoints.md) - Complete endpoint reference
+- [Transcript ingest](transcript-ingest.md) - External worker contract (S3 + YouTube)
 - [Examples](examples.md) - Usage examples
 - [Errors](errors.md) - Error codes and handling
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -88,6 +88,29 @@ See [Authentication Documentation](authentication.md) for detailed authenticatio
 - **DELETE** `/api/content/{id}/`
 - **Auth**: Required (must be owner)
 
+## Content — Transcript ingest (external workers)
+
+Machine-to-machine API for an external transcript worker (local Whisper, YouTube captions, S3 `file_key`). Not JWT-authenticated.
+
+Full contract: [transcript-ingest.md](transcript-ingest.md).
+
+### List transcript queue / topic manifest
+- **GET** `/api/content/transcript-ingest/`
+- **Auth**: `X-Transcript-Ingest-Key` or `Authorization: Bearer` (`TRANSCRIPT_INGEST_API_KEY`)
+- **Query**: `topic_id`, `include_completed`, `media_type`, `content_id`, `limit`, `offset`
+- **Response**: `{ count, limit, offset, include_completed, topic_id, items[] }` with YouTube/S3 hints per item
+
+### Get transcript job detail
+- **GET** `/api/content/transcript-ingest/{content_id}/`
+- **Auth**: Ingest API key
+- **Response**: `{ content, has_transcript, transcript }` (summary metadata only)
+
+### Upsert transcript
+- **PUT** `/api/content/transcript-ingest/{content_id}/`
+- **Auth**: Ingest API key
+- **Body**: at least one of `parsed_plain`, `processed_plain`, `obsidian_markdown`; optional `source_subtitles`, `format`, `language`
+- **Response**: `{ content_id, created, transcript }` (201 create / 200 update)
+
 ## Topics — Timeline
 
 Editorial timeline attached to a topic. One timeline per topic; entries are ordered and can link topic content.

--- a/docs/api/examples.md
+++ b/docs/api/examples.md
@@ -296,9 +296,33 @@ try {
 }
 ```
 
+## Transcript ingest (external worker)
+
+Full contract: [transcript-ingest.md](transcript-ingest.md).
+
+### List pending items for a topic
+
+```bash
+curl -s "http://localhost:8000/api/content/transcript-ingest/?topic_id=12" \
+  -H "X-Transcript-Ingest-Key: $TRANSCRIPT_INGEST_API_KEY"
+```
+
+### Upsert a transcript
+
+```bash
+curl -X PUT "http://localhost:8000/api/content/transcript-ingest/101/" \
+  -H "Content-Type: application/json" \
+  -H "X-Transcript-Ingest-Key: $TRANSCRIPT_INGEST_API_KEY" \
+  -d '{
+    "processed_plain": "Hola, bienvenidos al podcast.",
+    "language": "es"
+  }'
+```
+
 ## Related Documentation
 
 - [API Endpoints](endpoints.md)
+- [Transcript ingest](transcript-ingest.md)
 - [Authentication](authentication.md)
 - [Error Handling](errors.md)
 

--- a/docs/api/transcript-ingest.md
+++ b/docs/api/transcript-ingest.md
@@ -1,0 +1,238 @@
+# Transcript ingest API (external workers)
+
+Machine-to-machine API for an **external** transcript worker (typically run on a laptop with local Whisper and optional YouTube captions). The worker is **not** part of this monorepo.
+
+Workers:
+
+1. Pull a work queue / topic manifest of VIDEO/AUDIO content
+2. Obtain media via **S3 object key** (`file_key`) and/or **YouTube URL**
+3. Produce text artifacts (and optional SRT/VTT)
+4. Upsert them with `PUT`
+
+User-facing JWT auth is **not** used. Media download URLs are **not** pre-signed; give the worker read-only AWS credentials to your bucket.
+
+**Implementation**: `acbc_app/content/views_transcript_ingest.py`  
+**Env var**: [`TRANSCRIPT_INGEST_API_KEY`](../deployment/environment-variables.md#transcript_ingest_api_key)
+
+---
+
+## Authentication
+
+Set `TRANSCRIPT_INGEST_API_KEY` on the backend. If it is empty, every ingest endpoint returns **403**.
+
+Send one of:
+
+```http
+X-Transcript-Ingest-Key: <TRANSCRIPT_INGEST_API_KEY>
+```
+
+```http
+Authorization: Bearer <TRANSCRIPT_INGEST_API_KEY>
+```
+
+Do not use a user JWT for these routes.
+
+---
+
+## Endpoints
+
+Base path: `/api/content/transcript-ingest/`
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/content/transcript-ingest/` | Queue / topic manifest |
+| `GET` | `/api/content/transcript-ingest/{content_id}/` | One item + transcript status |
+| `PUT` | `/api/content/transcript-ingest/{content_id}/` | Create or replace transcript (idempotent) |
+
+Only `media_type` **VIDEO** and **AUDIO** are accepted. TEXT/IMAGE return **400** on detail/PUT.
+
+---
+
+## `GET /api/content/transcript-ingest/`
+
+Lists VIDEO/AUDIO contents for the worker.
+
+### Query parameters
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `topic_id` | int | — | Only contents linked to this topic. Unknown id → **404**. |
+| `include_completed` | bool | `false` | If `true`/`1`/`yes`/`on`, also return items that already have a transcript (for local reconciliation). Default queue = pending only. |
+| `media_type` | string | — | `VIDEO` or `AUDIO` |
+| `content_id` | int | — | Single content filter |
+| `limit` | int | `100` | Page size (max `500`) |
+| `offset` | int | `0` | Pagination offset |
+
+### Response
+
+```json
+{
+  "count": 2,
+  "limit": 100,
+  "offset": 0,
+  "include_completed": false,
+  "topic_id": 12,
+  "items": [
+    {
+      "id": 101,
+      "media_type": "VIDEO",
+      "original_title": "Intro a Bitcoin",
+      "original_author": "Satoshi",
+      "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "is_youtube": true,
+      "youtube_video_id": "dQw4w9WgXcQ",
+      "has_file": true,
+      "file_key": "content/video/3/abc123_intro.mp4",
+      "file_size": 52428800,
+      "has_spanish_subtitles": true,
+      "has_spanish_dubbing": false,
+      "has_transcript": false,
+      "created_at": "2026-07-01T12:00:00Z"
+    }
+  ]
+}
+```
+
+### Manifest fields (per item)
+
+| Field | Meaning for the worker |
+|-------|-------------------------|
+| `url` | Canonical external URL if any (often YouTube) |
+| `is_youtube` / `youtube_video_id` | Prefer caption fetch before ASR when true |
+| `has_file` / `file_key` | S3 object key under your media bucket; download with AWS SDK |
+| `file_size` | Bytes when known (plan audio-only vs full video) |
+| `has_spanish_subtitles` / `has_spanish_dubbing` | Accessibility flags from upload (not proof a `ContentTranscript` exists) |
+| `has_transcript` | Whether Django already stores a transcript |
+
+`file_key` is the storage key only (e.g. `content/video/...`). There is **no** pre-signed URL in this API.
+
+---
+
+## `GET /api/content/transcript-ingest/{content_id}/`
+
+```json
+{
+  "content": { "...same manifest fields as queue items..." },
+  "has_transcript": true,
+  "transcript": {
+    "format": "SRT",
+    "language": "es",
+    "text_length": 420,
+    "text_hash": "sha256...",
+    "segment_count": 12,
+    "has_parsed_plain": true,
+    "has_processed_plain": true,
+    "has_obsidian_markdown": true,
+    "obsidian_frontmatter": { "title": "Demo", "language_code": "es" },
+    "created_at": "...",
+    "updated_at": "..."
+  }
+}
+```
+
+`transcript` is `null` when none exists. Summary never returns full text bodies (only flags + metadata).
+
+---
+
+## `PUT /api/content/transcript-ingest/{content_id}/`
+
+Idempotent upsert: creates (**201**, `created: true`) or replaces (**200**, `created: false`).
+
+### Body
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `parsed_plain` | one of three* | Plain text before NLP cleanup |
+| `processed_plain` | one of three* | Cleaned plain text (primary for hash / future RAG) |
+| `obsidian_markdown` | one of three* | Note with optional YAML frontmatter + body |
+| `source_subtitles` | no | Raw SRT or VTT; server parses timed `segments` |
+| `format` | no | `SRT` (default) or `VTT` |
+| `language` | no | ISO 639-1, e.g. `es` |
+
+\*At least one of `parsed_plain`, `processed_plain`, `obsidian_markdown` must be non-empty.
+
+### Example
+
+```bash
+curl -X PUT "http://localhost:8000/api/content/transcript-ingest/101/" \
+  -H "Content-Type: application/json" \
+  -H "X-Transcript-Ingest-Key: $TRANSCRIPT_INGEST_API_KEY" \
+  -d '{
+    "parsed_plain": "Hola mundo.\nSegunda línea.",
+    "processed_plain": "Hola mundo. Segunda línea.",
+    "obsidian_markdown": "---\ntitle: Demo\nlanguage_code: es\n---\nHola mundo. Segunda línea.",
+    "source_subtitles": "1\n00:00:01,000 --> 00:00:04,000\nHola mundo.\n",
+    "format": "SRT",
+    "language": "es"
+  }'
+```
+
+### Response
+
+```json
+{
+  "content_id": 101,
+  "created": true,
+  "transcript": {
+    "format": "SRT",
+    "language": "es",
+    "text_length": 28,
+    "text_hash": "...",
+    "segment_count": 1,
+    "has_parsed_plain": true,
+    "has_processed_plain": true,
+    "has_obsidian_markdown": true,
+    "obsidian_frontmatter": { "title": "Demo", "language_code": "es" },
+    "created_at": "...",
+    "updated_at": "..."
+  }
+}
+```
+
+Invalid optional subtitles → **400**. Missing all three text artifacts → **400**.
+
+---
+
+## Recommended worker flow
+
+1. Configure `BASE_URL`, `TRANSCRIPT_INGEST_API_KEY`, and AWS read-only access to the media bucket.
+2. Fetch pending work for a topic:
+
+   ```bash
+   curl -s "http://localhost:8000/api/content/transcript-ingest/?topic_id=12" \
+     -H "X-Transcript-Ingest-Key: $TRANSCRIPT_INGEST_API_KEY"
+   ```
+
+3. For each item (suggested order):
+   - Skip if already done locally **and** `has_transcript` is true (optional check via detail GET).
+   - If `is_youtube`: try captions first (`youtube-transcript-api` / TimedText / similar).
+   - Else if `has_file` / `file_key`: `s3.get_object` (or download audio-only) → Whisper.
+   - Else if YouTube URL without captions: `yt-dlp` audio → Whisper.
+   - Else mark failed / needs manual.
+4. `PUT` artifacts (include `source_subtitles` when you have SRT/VTT so the server stores timed segments).
+5. Optionally reconcile:
+
+   ```bash
+   curl -s "http://localhost:8000/api/content/transcript-ingest/?topic_id=12&include_completed=true" \
+     -H "X-Transcript-Ingest-Key: $TRANSCRIPT_INGEST_API_KEY"
+   ```
+
+Keep a local cache keyed by `content_id` (media + outputs) so re-runs do not re-download from S3.
+
+---
+
+## Errors
+
+| Status | When |
+|--------|------|
+| **403** | Missing/wrong API key, or `TRANSCRIPT_INGEST_API_KEY` unset |
+| **404** | Unknown `topic_id` on queue, or unknown `content_id` on detail/PUT |
+| **400** | Bad query params; non VIDEO/AUDIO content; empty PUT body; invalid SRT/VTT |
+
+---
+
+## Related
+
+- Env: [environment-variables.md](../deployment/environment-variables.md#transcript_ingest_api_key)
+- Model: `ContentTranscript` in `acbc_app/content/models.py`
+- Tests: `ContentTranscriptIngestAPITests` in `acbc_app/content/tests.py`

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -112,6 +112,14 @@ Location: `acbc_app/.env`
 - **Example**: `GOOGLE_OAUTH_SECRET_KEY=GOCSPX-abcdefghijklmnop`
 - **Get from**: [Google Cloud Console](https://console.cloud.google.com/)
 
+### Transcript ingest (external workers)
+
+#### `TRANSCRIPT_INGEST_API_KEY`
+- **Description**: Shared secret for machine-to-machine access to `/api/content/transcript-ingest/`. External workers authenticate with header `X-Transcript-Ingest-Key: <key>` or `Authorization: Bearer <key>`. If unset/empty, all ingest endpoints return 403.
+- **Required**: No (required to run transcript workers against this API)
+- **Example**: `TRANSCRIPT_INGEST_API_KEY=long-random-secret`
+- **Note**: Workers with AWS credentials use the S3 `file_key` from the queue response to download media; this key only gates the Django ingest API.
+
 ### AWS Configuration (Production)
 
 #### `AWS_ACCESS_KEY_ID`

--- a/docs/security/endpoint-permissions-map.md
+++ b/docs/security/endpoint-permissions-map.md
@@ -78,6 +78,16 @@ Objects must have `author` (FK to User). Used for:
 
 - **Gamification**: Admin-only action (e.g. grant badge) via `@action(..., permission_classes=[IsAdminUser])`.
 
+## Machine-to-machine (shared API key)
+
+| Method | Endpoint | Auth |
+|--------|----------|------|
+| GET | `/api/content/transcript-ingest/` | `TRANSCRIPT_INGEST_API_KEY` via `X-Transcript-Ingest-Key` or `Authorization: Bearer` |
+| GET | `/api/content/transcript-ingest/<content_id>/` | same |
+| PUT | `/api/content/transcript-ingest/<content_id>/` | same |
+
+Not JWT. Empty/unset key → all ingest routes **403**. Full contract: [transcript-ingest.md](../api/transcript-ingest.md).
+
 ## OAuth / Google
 
 - `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_SECRET_KEY`: server-side only.  


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the machine-to-machine transcript ingest API so an external local worker (Whisper + optional YouTube captions, S3 credentials on the laptop) can list topic contents, choose YouTube vs S3 sources, and upsert transcripts.

## API changes

Auth: `X-Transcript-Ingest-Key: <TRANSCRIPT_INGEST_API_KEY>` or `Authorization: Bearer <key>`

- `GET /api/content/transcript-ingest/` — queue/manifest with `topic_id`, `include_completed`, plus YouTube/S3 hints (`is_youtube`, `youtube_video_id`, `file_key`, `file_size`, …)
- `GET|PUT /api/content/transcript-ingest/<content_id>/` — detail + idempotent upsert

No pre-signed URLs; workers use `file_key` with bucket IAM credentials.

## Documentation

- `docs/api/transcript-ingest.md` — full worker contract (auth, params, payloads, recommended flow, curl)
- Linked from `docs/api/README.md`, `endpoints.md`, `examples.md`, `docs/README.md`
- Permissions map + `TRANSCRIPT_INGEST_API_KEY` in environment variables

## Tests

`ContentTranscriptIngestAPITests` + model tests — 21 passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c14660e-9236-4f75-9214-e5fc717fc9bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c14660e-9236-4f75-9214-e5fc717fc9bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

