### PR TITLE
Track embedding readiness on transcript ingest

### DIFF
--- a/acbc_app/content/admin.py
+++ b/acbc_app/content/admin.py
@@ -42,15 +42,30 @@ class FileDetailsAdmin(admin.ModelAdmin):
 @admin.register(ContentTranscript)
 class ContentTranscriptAdmin(admin.ModelAdmin):
     list_display = [
-        'id', 'content', 'format', 'language', 'text_length', 'text_hash', 'updated_at',
+        'id',
+        'content',
+        'format',
+        'language',
+        'text_length',
+        'text_hash',
+        'embedding_status',
+        'chunk_count',
+        'updated_at',
     ]
-    list_filter = ['format', 'language', 'updated_at']
-    search_fields = ['content__original_title', 'processed_plain', 'text_hash']
+    list_filter = ['format', 'language', 'embedding_status', 'updated_at']
+    search_fields = [
+        'content__original_title',
+        'processed_plain',
+        'text_hash',
+        'embedded_text_hash',
+    ]
     readonly_fields = [
         'segments',
         'obsidian_frontmatter',
         'text_length',
         'text_hash',
+        'embedded_text_hash',
+        'embedded_at',
         'created_at',
         'updated_at',
     ]

--- a/acbc_app/content/migrations/0025_contenttranscript_embedding_status.py
+++ b/acbc_app/content/migrations/0025_contenttranscript_embedding_status.py
@@ -1,0 +1,89 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('content', '0024_topic_activity_score'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contenttranscript',
+            name='chunk_count',
+            field=models.PositiveIntegerField(
+                blank=True,
+                help_text='Number of chunks upserted to the vector DB on last successful index.',
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name='contenttranscript',
+            name='embedded_at',
+            field=models.DateTimeField(
+                blank=True,
+                help_text='When the vector DB was last successfully updated for this transcript.',
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name='contenttranscript',
+            name='embedded_text_hash',
+            field=models.CharField(
+                blank=True,
+                help_text='text_hash that was indexed; compared to text_hash to detect stale.',
+                max_length=64,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name='contenttranscript',
+            name='embedding_dims',
+            field=models.PositiveSmallIntegerField(
+                blank=True,
+                help_text='Vector dimensions for embedding_model.',
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name='contenttranscript',
+            name='embedding_error',
+            field=models.TextField(
+                blank=True,
+                help_text='Last embed-worker error message when status=failed.',
+            ),
+        ),
+        migrations.AddField(
+            model_name='contenttranscript',
+            name='embedding_model',
+            field=models.CharField(
+                blank=True,
+                help_text='Embedding model last used when status=indexed (set by embed worker ack).',
+                max_length=64,
+            ),
+        ),
+        migrations.AddField(
+            model_name='contenttranscript',
+            name='embedding_status',
+            field=models.CharField(
+                choices=[
+                    ('pending', 'Pending'),
+                    ('indexed', 'Indexed'),
+                    ('stale', 'Stale'),
+                    ('failed', 'Failed'),
+                    ('skipped', 'Skipped'),
+                ],
+                db_index=True,
+                default='pending',
+                help_text='Whether current text_hash is indexed in the external vector DB.',
+                max_length=16,
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='contenttranscript',
+            index=models.Index(
+                fields=['embedded_text_hash'],
+                name='content_tr_emb_hash_idx',
+            ),
+        ),
+    ]

--- a/acbc_app/content/models.py
+++ b/acbc_app/content/models.py
@@ -253,10 +253,25 @@ class ContentTranscript(models.Model):
     Stores the three artifacts produced by the external worker pipeline:
     parsed_plain → processed_plain → obsidian_markdown.
     Optional source_subtitles (SRT/VTT) enables timed segments for the player.
+
+    Embedding vectors live in an external vector DB; this model only tracks
+    whether the current text_hash still needs indexing (see embedding_status).
     """
     FORMAT_CHOICES = [
         ('SRT', 'SubRip (.srt)'),
         ('VTT', 'WebVTT (.vtt)'),
+    ]
+    EMBEDDING_STATUS_PENDING = 'pending'
+    EMBEDDING_STATUS_INDEXED = 'indexed'
+    EMBEDDING_STATUS_STALE = 'stale'
+    EMBEDDING_STATUS_FAILED = 'failed'
+    EMBEDDING_STATUS_SKIPPED = 'skipped'
+    EMBEDDING_STATUS_CHOICES = [
+        (EMBEDDING_STATUS_PENDING, 'Pending'),
+        (EMBEDDING_STATUS_INDEXED, 'Indexed'),
+        (EMBEDDING_STATUS_STALE, 'Stale'),
+        (EMBEDDING_STATUS_FAILED, 'Failed'),
+        (EMBEDDING_STATUS_SKIPPED, 'Skipped'),
     ]
 
     content = models.OneToOneField(
@@ -307,6 +322,43 @@ class ContentTranscript(models.Model):
         blank=True,
         help_text='ISO 639-1 language code, e.g. es or en.',
     )
+    embedding_status = models.CharField(
+        max_length=16,
+        choices=EMBEDDING_STATUS_CHOICES,
+        default=EMBEDDING_STATUS_PENDING,
+        db_index=True,
+        help_text='Whether current text_hash is indexed in the external vector DB.',
+    )
+    embedding_model = models.CharField(
+        max_length=64,
+        blank=True,
+        help_text='Embedding model last used when status=indexed (set by embed worker ack).',
+    )
+    embedding_dims = models.PositiveSmallIntegerField(
+        blank=True,
+        null=True,
+        help_text='Vector dimensions for embedding_model.',
+    )
+    chunk_count = models.PositiveIntegerField(
+        blank=True,
+        null=True,
+        help_text='Number of chunks upserted to the vector DB on last successful index.',
+    )
+    embedded_text_hash = models.CharField(
+        max_length=64,
+        blank=True,
+        null=True,
+        help_text='text_hash that was indexed; compared to text_hash to detect stale.',
+    )
+    embedded_at = models.DateTimeField(
+        blank=True,
+        null=True,
+        help_text='When the vector DB was last successfully updated for this transcript.',
+    )
+    embedding_error = models.TextField(
+        blank=True,
+        help_text='Last embed-worker error message when status=failed.',
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -314,6 +366,10 @@ class ContentTranscript(models.Model):
         indexes = [
             models.Index(fields=['text_hash'], name='content_transcript_hash_idx'),
             models.Index(fields=['language'], name='content_transcript_lang_idx'),
+            models.Index(
+                fields=['embedded_text_hash'],
+                name='content_tr_emb_hash_idx',
+            ),
         ]
 
     def __str__(self):

--- a/acbc_app/content/serializers.py
+++ b/acbc_app/content/serializers.py
@@ -1345,6 +1345,12 @@ class ContentTranscriptIngestSummarySerializer(serializers.ModelSerializer):
             'has_processed_plain',
             'has_obsidian_markdown',
             'obsidian_frontmatter',
+            'embedding_status',
+            'embedding_model',
+            'embedding_dims',
+            'chunk_count',
+            'embedded_text_hash',
+            'embedded_at',
             'created_at',
             'updated_at',
         ]

--- a/acbc_app/content/tests.py
+++ b/acbc_app/content/tests.py
@@ -4192,6 +4192,28 @@ Hola, bienvenidos al podcast. Hoy hablamos de blockchain.
         self.assertEqual(transcript.language, 'es')
         self.assertEqual(transcript.obsidian_frontmatter.get('title'), 'Demo')
         self.assertIn('blockchain', transcript.processed_plain)
+        self.assertEqual(transcript.embedding_status, 'pending')
+
+    def test_save_marks_stale_when_indexed_hash_drifts(self):
+        from content.models import ContentTranscript
+
+        transcript = ContentTranscript.objects.create(
+            content=self.content,
+            processed_plain='Texto original indexado.',
+            language='es',
+        )
+        transcript.embedding_status = ContentTranscript.EMBEDDING_STATUS_INDEXED
+        transcript.embedded_text_hash = transcript.text_hash
+        transcript.embedding_model = 'text-embedding-3-large'
+        transcript.chunk_count = 1
+        transcript.save()
+
+        transcript.processed_plain = 'Texto original indexado. Más contenido.'
+        transcript.save()
+
+        self.assertEqual(transcript.embedding_status, 'stale')
+        self.assertNotEqual(transcript.text_hash, transcript.embedded_text_hash)
+        self.assertEqual(transcript.embedding_model, 'text-embedding-3-large')
 
     def test_save_parses_vtt_segments_when_optional_source_provided(self):
         from content.models import ContentTranscript
@@ -4401,6 +4423,71 @@ Hola, bienvenidos al podcast. Hoy hablamos de blockchain.
         transcript = ContentTranscript.objects.get(content=self.video)
         self.assertEqual(transcript.language, 'es')
         self.assertEqual(transcript.obsidian_frontmatter.get('title'), 'Demo')
+        self.assertEqual(transcript.embedding_status, 'pending')
+        self.assertIsNone(transcript.embedded_text_hash)
+        self.assertEqual(response.data['transcript']['embedding_status'], 'pending')
+
+    def test_put_marks_stale_when_indexed_text_changes(self):
+        ContentTranscript.objects.create(
+            content=self.video,
+            parsed_plain=self.PARSED_PLAIN,
+            processed_plain=self.PROCESSED_PLAIN,
+            language='es',
+        )
+        transcript = ContentTranscript.objects.get(content=self.video)
+        transcript.embedding_status = 'indexed'
+        transcript.embedded_text_hash = transcript.text_hash
+        transcript.embedding_model = 'text-embedding-3-large'
+        transcript.embedding_dims = 3072
+        transcript.chunk_count = 3
+        transcript.save()
+
+        updated_processed = self.PROCESSED_PLAIN + ' Cierre del episodio.'
+        response = self.client.put(
+            f'/api/content/transcript-ingest/{self.video.id}/',
+            {
+                'parsed_plain': self.PARSED_PLAIN,
+                'processed_plain': updated_processed,
+                'language': 'es',
+            },
+            format='json',
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        transcript.refresh_from_db()
+        self.assertEqual(transcript.embedding_status, 'stale')
+        self.assertNotEqual(transcript.text_hash, transcript.embedded_text_hash)
+        self.assertEqual(response.data['transcript']['embedding_status'], 'stale')
+        # Prior index metadata retained until embed worker acks again.
+        self.assertEqual(transcript.embedding_model, 'text-embedding-3-large')
+        self.assertEqual(transcript.chunk_count, 3)
+
+    def test_put_keeps_indexed_when_text_hash_unchanged(self):
+        ContentTranscript.objects.create(
+            content=self.video,
+            processed_plain=self.PROCESSED_PLAIN,
+            language='es',
+        )
+        transcript = ContentTranscript.objects.get(content=self.video)
+        transcript.embedding_status = 'indexed'
+        transcript.embedded_text_hash = transcript.text_hash
+        transcript.chunk_count = 2
+        transcript.save()
+
+        response = self.client.put(
+            f'/api/content/transcript-ingest/{self.video.id}/',
+            {
+                'processed_plain': self.PROCESSED_PLAIN,
+                'language': 'es',
+            },
+            format='json',
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        transcript.refresh_from_db()
+        self.assertEqual(transcript.embedding_status, 'indexed')
+        self.assertEqual(transcript.text_hash, transcript.embedded_text_hash)
+        self.assertEqual(response.data['transcript']['embedding_status'], 'indexed')
 
     def test_put_accepts_optional_source_subtitles_for_segments(self):
         response = self.client.put(

--- a/acbc_app/content/transcript_utils.py
+++ b/acbc_app/content/transcript_utils.py
@@ -194,6 +194,35 @@ def resolve_hash_source_text(transcript):
     return extract_obsidian_body(transcript.obsidian_markdown)
 
 
+def sync_embedding_status_for_text_hash(transcript):
+    """
+    Keep embedding_status aligned with text_hash vs embedded_text_hash.
+
+    Called on transcript save (including transcript-ingest PUT). Does not write
+    vectors; only marks pending/stale so a later embed worker can pick work up.
+    """
+    status = (transcript.embedding_status or '').strip() or 'pending'
+    if status == 'skipped':
+        return
+
+    current_hash = (transcript.text_hash or '').strip()
+    embedded_hash = (transcript.embedded_text_hash or '').strip()
+
+    if not current_hash:
+        transcript.embedding_status = 'pending'
+        return
+
+    if embedded_hash and embedded_hash == current_hash:
+        # Corpus unchanged since last successful index (or same hash after failed retry).
+        return
+
+    if embedded_hash and embedded_hash != current_hash:
+        transcript.embedding_status = 'stale'
+        return
+
+    transcript.embedding_status = 'pending'
+
+
 def sync_transcript_derived_fields(transcript):
     """
     Populate segments (optional SRT/VTT), obsidian_frontmatter, text_length and text_hash.
@@ -240,3 +269,4 @@ def sync_transcript_derived_fields(transcript):
     normalized = normalize_plain_text_for_hash(hash_source)
     transcript.text_length = len(normalized) if normalized else None
     transcript.text_hash = compute_text_hash(hash_source)
+    sync_embedding_status_for_text_hash(transcript)

--- a/docs/api/transcript-ingest.md
+++ b/docs/api/transcript-ingest.md
@@ -191,6 +191,25 @@ curl -X PUT "http://localhost:8000/api/content/transcript-ingest/101/" \
 
 Invalid optional subtitles → **400**. Missing all three text artifacts → **400**.
 
+### Embedding status (Postgres only)
+
+Each transcript tracks whether its current `text_hash` still needs vector indexing later.
+Vectors themselves are **not** stored in Django; these fields prepare an embed worker:
+
+| Field | Meaning |
+|-------|---------|
+| `embedding_status` | `pending` \| `indexed` \| `stale` \| `failed` \| `skipped` |
+| `embedded_text_hash` | Hash that was last indexed (compare to `text_hash`) |
+| `embedding_model` / `embedding_dims` / `chunk_count` / `embedded_at` | Filled by a future embed-worker ack |
+
+On every successful PUT/save:
+
+- new transcript → `pending`
+- text changes while previously indexed → `stale` (keeps prior `embedding_model` / `chunk_count` until re-acked)
+- same `text_hash` as `embedded_text_hash` and already `indexed` → stays `indexed`
+
+The ingest summary returns these fields. Embed-queue / chat endpoints are out of scope for this API.
+
 ---
 
 ## Recommended worker flow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares `ContentTranscript` for a future embed worker **without** implementing vector storage, chunking, or chat yet.

On every transcript save / ingest PUT, Django now tracks whether the current `text_hash` still needs indexing in an external vector DB.

## Postgres (`0025_contenttranscript_embedding_status`)

New fields on `ContentTranscript`:

- `embedding_status`: `pending` | `indexed` | `stale` | `failed` | `skipped`
- `embedding_model`, `embedding_dims`, `chunk_count`
- `embedded_text_hash`, `embedded_at`, `embedding_error`

## Ingest behavior

- New transcript → `pending`
- Text changes after an index (`text_hash` ≠ `embedded_text_hash`) → `stale` (keeps prior model/chunk metadata)
- Same hash while already `indexed` → stays `indexed`
- `skipped` is left alone (manual opt-out)

Ingest summary JSON now includes these fields. Documented in `docs/api/transcript-ingest.md`.

## Out of scope (next)

- `embed-queue` / ack endpoints
- Qdrant upserts / chunks
- Topic chat API

## Tests

`ContentTranscriptModelTests` + `ContentTranscriptIngestAPITests` — 24 passing.

**Note:** This branch is based on the transcript-ingest worker API work (`topic_id` queue, YouTube/S3 hints). If that PR lands first, this PR will rebase cleanly onto the embedding-status commit alone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c14660e-9236-4f75-9214-e5fc717fc9bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c14660e-9236-4f75-9214-e5fc717fc9bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

