### PR TITLE
Fix duplicate completion notifications and require path completion for certificates

### DIFF
--- a/acbc_app/certificates/test_helpers.py
+++ b/acbc_app/certificates/test_helpers.py
@@ -1,0 +1,50 @@
+"""Shared helpers for certificate / knowledge-path completion tests."""
+
+from django.utils import timezone
+
+from content.models import Content, ContentProfile
+from knowledge_paths.models import Node
+from profiles.models import UserNodeCompletion
+
+
+def ensure_path_completed(user, knowledge_path):
+    """
+    Ensure ``user`` has completed every node on ``knowledge_path``.
+
+    Creates a single node if the path is empty. Nodes without quizzes are
+    enough for ``is_knowledge_path_completed`` to return True.
+    """
+    nodes = list(knowledge_path.nodes.all())
+    if not nodes:
+        content = Content.objects.create(
+            original_title=f'Content for {knowledge_path.title}',
+            media_type='TEXT',
+            uploaded_by=user,
+        )
+        content_profile = ContentProfile.objects.create(
+            content=content,
+            title=f'Profile for {knowledge_path.title}',
+            user=user,
+        )
+        nodes = [
+            Node.objects.create(
+                knowledge_path=knowledge_path,
+                content_profile=content_profile,
+                title='Node 1',
+                description='Required for certificate eligibility',
+                order=1,
+                media_type='TEXT',
+            )
+        ]
+
+    for node in nodes:
+        UserNodeCompletion.objects.update_or_create(
+            user=user,
+            knowledge_path=knowledge_path,
+            node=node,
+            defaults={
+                'is_completed': True,
+                'completed_at': timezone.now(),
+            },
+        )
+    return nodes

--- a/acbc_app/certificates/tests.py
+++ b/acbc_app/certificates/tests.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from django.contrib.auth.models import User
 from knowledge_paths.models import KnowledgePath
 from certificates.models import CertificateRequest, Certificate, CertificateTemplate
+from certificates.test_helpers import ensure_path_completed
 import json
 
 class CertificateRequestFlowTest(TestCase):
@@ -28,6 +29,7 @@ class CertificateRequestFlowTest(TestCase):
             author=self.teacher,
             certificates_enabled=True,
         )
+        ensure_path_completed(self.student, self.knowledge_path)
         
         # Setup API client
         self.client = APIClient()
@@ -200,6 +202,8 @@ class CertificateRequestFlowTest(TestCase):
             author=self.teacher,
             certificates_enabled=True,
         )
+        for path in (path1, path2, path3):
+            ensure_path_completed(self.student, path)
 
         # Create and approve first request
         self.client.force_authenticate(user=self.student)
@@ -272,6 +276,48 @@ class CertificateRequestFlowTest(TestCase):
             ).exists()
         )
 
+    def test_certificate_request_blocked_when_path_not_completed(self):
+        """Requests fail until the learner completes every node (and quizzes)."""
+        incomplete_path = KnowledgePath.objects.create(
+            title='Incomplete Path',
+            description='No nodes completed',
+            author=self.teacher,
+            certificates_enabled=True,
+        )
+        from content.models import Content, ContentProfile
+        from knowledge_paths.models import Node
+
+        content = Content.objects.create(
+            original_title='Incomplete content',
+            media_type='TEXT',
+            uploaded_by=self.teacher,
+        )
+        profile = ContentProfile.objects.create(
+            content=content,
+            title='Incomplete profile',
+            user=self.teacher,
+        )
+        Node.objects.create(
+            knowledge_path=incomplete_path,
+            content_profile=profile,
+            title='Node 1',
+            order=1,
+            media_type='TEXT',
+        )
+
+        self.client.force_authenticate(user=self.student)
+        url = reverse('certificates:certificate-request', args=[incomplete_path.id])
+        response = self.client.post(url, {'notes': 'Too early'}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get('code'), 'path_not_completed')
+        self.assertFalse(
+            CertificateRequest.objects.filter(
+                requester=self.student,
+                knowledge_path=incomplete_path,
+            ).exists()
+        )
+
 
 class CertificateRequestSerializerNotesTests(TestCase):
     def setUp(self):
@@ -291,6 +337,7 @@ class CertificateRequestSerializerNotesTests(TestCase):
             author=self.teacher,
             certificates_enabled=True,
         )
+        ensure_path_completed(self.student, self.knowledge_path)
         self.client = APIClient()
         self.client.force_authenticate(user=self.student)
         self.request_url = reverse(

--- a/acbc_app/certificates/views.py
+++ b/acbc_app/certificates/views.py
@@ -53,6 +53,23 @@ class CertificateRequestView(APIView):
                     },
                     status=status.HTTP_403_FORBIDDEN,
                 )
+
+            from knowledge_paths.services.node_user_activity_service import (
+                is_knowledge_path_completed,
+            )
+
+            if not is_knowledge_path_completed(request.user, knowledge_path):
+                logger.warning(
+                    f"Certificate request blocked - path not completed by user "
+                    f"{request.user.username} for path {knowledge_path.id}"
+                )
+                return Response(
+                    {
+                        'error': 'Debes completar este camino de conocimiento antes de solicitar un certificado',
+                        'code': 'path_not_completed',
+                    },
+                    status=status.HTTP_403_FORBIDDEN,
+                )
             
             # Check if user has already requested a certificate for this path
             existing_request = CertificateRequest.objects.filter(

--- a/acbc_app/gamification/signals.py
+++ b/acbc_app/gamification/signals.py
@@ -30,9 +30,12 @@ def check_node_completion_badges(sender, instance, created, **kwargs):
         # Check Knowledge Seeker badge (accumulated)
         rules.check_knowledge_seeker(user)
 
-        # Check if KnowledgePath is completed
-        from knowledge_paths.services.node_user_activity_service import is_knowledge_path_completed
-        if is_knowledge_path_completed(user, knowledge_path):
+        # Check if KnowledgePath is completed (notify only on this write event,
+        # not from progress/read helpers that also call is_knowledge_path_completed)
+        from knowledge_paths.services.node_user_activity_service import (
+            notify_if_knowledge_path_completed,
+        )
+        if notify_if_knowledge_path_completed(user, knowledge_path):
             rules.check_first_knowledge_path_completed(user, knowledge_path)
     except Exception as e:
         log_error(e, f"Error in check_node_completion_badges for user {instance.user.id}", instance.user.id)
@@ -128,16 +131,25 @@ def check_knowledge_path_creation_badge(sender, instance, created, **kwargs):
 @receiver(post_save, sender='quizzes.UserQuizAttempt')
 def check_quiz_badges(sender, instance, created, **kwargs):
     """
-    Check badges when a quiz attempt is completed:
+    Check badges when a quiz attempt scores 100:
     - Quiz Master: 5 quizzes with perfect score
+
+    Also notifies the knowledge-path author when a perfect score is what
+    finishes the path (all nodes were already marked complete).
     """
     try:
-        if not created:
+        if instance.score != 100:
             return
 
-        # Only check if score is perfect (100)
-        if instance.score == 100:
-            user = instance.user
-            rules.check_quiz_master(user)
+        user = instance.user
+        rules.check_quiz_master(user)
+
+        quiz = instance.quiz
+        node = getattr(quiz, 'node', None)
+        if node and node.knowledge_path_id:
+            from knowledge_paths.services.node_user_activity_service import (
+                notify_if_knowledge_path_completed,
+            )
+            notify_if_knowledge_path_completed(user, node.knowledge_path)
     except Exception as e:
         log_error(e, f"Error in check_quiz_badges for user {instance.user.id}", instance.user.id)

--- a/acbc_app/knowledge_paths/services/node_user_activity_service.py
+++ b/acbc_app/knowledge_paths/services/node_user_activity_service.py
@@ -118,7 +118,10 @@ def mark_node_as_completed(user, node):
 def is_knowledge_path_completed(user, knowledge_path):
     """
     Check if a user has completed all nodes and passed all quizzes in a knowledge path.
-    If completed, notify the knowledge path author.
+
+    Pure read: does not send notifications. Call
+    ``notify_if_knowledge_path_completed`` from write-side events
+    (node completion / perfect quiz) when a transition may have occurred.
     
     Args:
         user: The user to check
@@ -149,15 +152,24 @@ def is_knowledge_path_completed(user, knowledge_path):
         if quiz and not has_completed_quiz(user, quiz):
             return False
 
-    # If we get here, the path is completed
-    # Notify the knowledge path author
+    return True
+
+
+def notify_if_knowledge_path_completed(user, knowledge_path):
+    """
+    If the user has fully completed the path, notify the author once.
+
+    Safe to call repeatedly: ``notify_knowledge_path_completion`` deduplicates.
+    """
+    if not is_knowledge_path_completed(user, knowledge_path):
+        return False
+
     logger.info("Knowledge path completed, notifying author", extra={
         'user_id': user.id,
         'knowledge_path_id': knowledge_path.id,
         'knowledge_path_title': knowledge_path.title,
     })
     notify_knowledge_path_completion(user, knowledge_path)
-    
     return True
 
 

--- a/acbc_app/profiles/tests.py
+++ b/acbc_app/profiles/tests.py
@@ -7,6 +7,7 @@ from profiles.models import Profile, CryptoCurrency, AcceptedCrypto, ContactMeth
 from notifications.models import Notification
 from knowledge_paths.models import KnowledgePath, Node
 from certificates.models import CertificateRequest, Certificate, CertificateTemplate
+from certificates.test_helpers import ensure_path_completed
 from django.utils import timezone
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.conf import settings
@@ -1039,6 +1040,7 @@ class NotificationTests(APITestCase):
             author=teacher,
             certificates_enabled=True,
         )
+        ensure_path_completed(self.user, knowledge_path)
         
         # Student requests a certificate
         url = reverse('certificates:certificate-request', args=[knowledge_path.id])
@@ -1057,12 +1059,16 @@ class NotificationTests(APITestCase):
         self.assertEqual(notifications_response.status_code, status.HTTP_200_OK)
         notifications = notifications_response.data['notifications']
         
-        # Should have one notification
-        self.assertEqual(len(notifications), 1)
+        certificate_notifications = [
+            n for n in notifications
+            if to_ascii_safe(n['verb']) == to_ascii_safe(
+                'solicitó un certificado para tu camino de conocimiento'
+            )
+        ]
+        self.assertEqual(len(certificate_notifications), 1)
         
         # Verify notification content (app uses Spanish for notification verbs)
-        notification = notifications[0]
-        self.assertEqual(notification['verb'], 'solicitó un certificado para tu camino de conocimiento')
+        notification = certificate_notifications[0]
         self.assertIn('testuser solicitó un certificado para tu camino de conocimiento', notification['description'])
         self.assertIn('Test Knowledge Path', notification['description'])
         self.assertTrue(notification['unread'])
@@ -1191,6 +1197,7 @@ class NotificationTests(APITestCase):
             author=teacher,
             certificates_enabled=True,
         )
+        ensure_path_completed(self.user, knowledge_path)
         
         # Student requests a certificate
         url = reverse('certificates:certificate-request', args=[knowledge_path.id])
@@ -1222,13 +1229,15 @@ class NotificationTests(APITestCase):
         self.assertEqual(notifications_response.status_code, status.HTTP_200_OK)
         notifications = notifications_response.data['notifications']
         
-        # Should have only one notification due to spam protection
-        self.assertEqual(len(notifications), 1)
-        
-        # Verify notification content (app uses Spanish for notification verbs)
-        notification = notifications[0]
-        self.assertEqual(notification['verb'], 'solicitó un certificado para tu camino de conocimiento')
-        self.assertTrue(notification['unread'])
+        certificate_notifications = [
+            n for n in notifications
+            if to_ascii_safe(n['verb']) == to_ascii_safe(
+                'solicitó un certificado para tu camino de conocimiento'
+            )
+        ]
+        # Should have only one certificate notification due to spam protection
+        self.assertEqual(len(certificate_notifications), 1)
+        self.assertTrue(certificate_notifications[0]['unread'])
 
     def test_certificate_notification_no_self_notification(self):
         """Test that users don't get notifications for their own actions"""
@@ -1239,6 +1248,7 @@ class NotificationTests(APITestCase):
             author=self.user,  # Current user is the author
             certificates_enabled=True,
         )
+        ensure_path_completed(self.user, knowledge_path)
         
         # User requests a certificate for their own knowledge path
         url = reverse('certificates:certificate-request', args=[knowledge_path.id])
@@ -1257,9 +1267,93 @@ class NotificationTests(APITestCase):
         notifications = notifications_response.data['notifications']
         
         # Should have no certificate request notifications (no self-notification)
-        # But may have other notifications from setUp
-        certificate_notifications = [n for n in notifications if n['verb'] == 'requested a certificate for your knowledge path']
+        certificate_notifications = [
+            n for n in notifications
+            if to_ascii_safe(n['verb']) == to_ascii_safe(
+                'solicitó un certificado para tu camino de conocimiento'
+            )
+        ]
         self.assertEqual(len(certificate_notifications), 0)
+
+    def test_knowledge_path_completion_notification_once(self):
+        """Completing a path notifies the author once; progress reads do not re-notify."""
+        from knowledge_paths.services.node_user_activity_service import (
+            get_knowledge_path_progress,
+            notify_if_knowledge_path_completed,
+        )
+        from utils.notification_utils import notify_knowledge_path_completion
+
+        teacher = User.objects.create_user(
+            username='kp_teacher',
+            email='kp_teacher@example.com',
+            password='testpass123',
+        )
+        knowledge_path = KnowledgePath.objects.create(
+            title='Completion Path',
+            description='Test',
+            author=teacher,
+        )
+
+        ensure_path_completed(self.user, knowledge_path)
+
+        # Progress / badge re-checks must not create extra notifications
+        get_knowledge_path_progress(self.user, knowledge_path)
+        notify_if_knowledge_path_completed(self.user, knowledge_path)
+        notify_knowledge_path_completion(self.user, knowledge_path)
+
+        completion_verb = to_ascii_safe('completó tu camino de conocimiento')
+        notifications = Notification.objects.filter(
+            recipient=teacher,
+            actor_object_id=self.user.id,
+            target_object_id=knowledge_path.id,
+        )
+        completion_notifications = [
+            n for n in notifications
+            if to_ascii_safe(n.verb) == completion_verb
+        ]
+        self.assertEqual(len(completion_notifications), 1)
+
+    def test_knowledge_path_completion_dedup_with_ascii_verb(self):
+        """Dedup must treat accent-stripped verbs as the same notification."""
+        from utils.notification_utils import notify_knowledge_path_completion
+
+        teacher = User.objects.create_user(
+            username='ascii_teacher',
+            email='ascii_teacher@example.com',
+            password='testpass123',
+        )
+        knowledge_path = KnowledgePath.objects.create(
+            title='ASCII Path',
+            description='Test',
+            author=teacher,
+        )
+        ensure_path_completed(self.user, knowledge_path)
+
+        # Simulate a legacy SQL_ASCII row already stored without accents
+        Notification.objects.filter(
+            recipient=teacher,
+            actor_object_id=self.user.id,
+            target_object_id=knowledge_path.id,
+        ).delete()
+        kp_ct = ContentType.objects.get_for_model(KnowledgePath)
+        user_ct = ContentType.objects.get_for_model(User)
+        Notification.objects.create(
+            recipient=teacher,
+            actor_content_type=user_ct,
+            actor_object_id=self.user.id,
+            verb=to_ascii_safe('completó tu camino de conocimiento'),
+            target_content_type=kp_ct,
+            target_object_id=knowledge_path.id,
+            description=f'{self.user.username} completo tu camino de conocimiento "ASCII Path"',
+        )
+
+        notify_knowledge_path_completion(self.user, knowledge_path)
+
+        completion_notifications = [
+            n for n in Notification.objects.filter(recipient=teacher)
+            if to_ascii_safe(n.verb) == to_ascii_safe('completó tu camino de conocimiento')
+        ]
+        self.assertEqual(len(completion_notifications), 1)
 
     def test_content_upvote_notification(self):
         """Test notification when someone upvotes content"""

--- a/acbc_app/utils/notification_utils.py
+++ b/acbc_app/utils/notification_utils.py
@@ -2,6 +2,7 @@
 Utility functions for handling notifications across the application.
 """
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
 from notifications.models import Notification
 from knowledge_paths.models import KnowledgePath
 from content.models import (
@@ -27,6 +28,20 @@ def create_notification(**kwargs):
         if field in kwargs and kwargs[field]:
             kwargs[field] = prepare_text_for_db(kwargs[field])
     return Notification.objects.create(**kwargs)
+
+
+def matching_verb_q(verb):
+    """
+    Build a Q filter that matches a verb whether stored with accents or
+    ASCII-stripped (SQL_ASCII legacy clusters via prepare_text_for_db).
+    """
+    from utils.db_encoding import to_ascii_safe
+
+    accented = verb or ''
+    ascii_verb = to_ascii_safe(accented)
+    if accented == ascii_verb:
+        return Q(verb=accented)
+    return Q(verb=accented) | Q(verb=ascii_verb)
 
 def notify_comment_reply(comment):
     """
@@ -381,13 +396,15 @@ def notify_knowledge_path_completion(user, knowledge_path):
     user_ct = ContentType.objects.get_for_model(user)
     knowledge_path_ct = ContentType.objects.get_for_model(knowledge_path)
     logger.debug(f"Content types - User: {user_ct}, Knowledge Path: {knowledge_path_ct}")
+
+    completion_verb = 'completó tu camino de conocimiento'
     
-    # Check if notification already exists
+    # Check if notification already exists (match accented or ASCII-stripped verb)
     existing_notifications = Notification.objects.filter(
+        matching_verb_q(completion_verb),
         recipient=knowledge_path.author,
         actor_content_type=user_ct,
         actor_object_id=user.id,
-        verb='completó tu camino de conocimiento',
         target_content_type=knowledge_path_ct,
         target_object_id=knowledge_path.id
     )
@@ -405,7 +422,7 @@ def notify_knowledge_path_completion(user, knowledge_path):
         recipient=knowledge_path.author,
         actor_content_type=user_ct,
         actor_object_id=user.id,
-        verb='completó tu camino de conocimiento',
+        verb=completion_verb,
         target_content_type=knowledge_path_ct,
         target_object_id=knowledge_path.id,
         description=f'{user.username} completó tu camino de conocimiento "{knowledge_path.title}"'
@@ -471,12 +488,13 @@ def notify_certificate_request(certificate_request):
     from django.utils import timezone
     from datetime import timedelta
     
+    request_verb = 'solicitó un certificado para tu camino de conocimiento'
     recent_cutoff = timezone.now() - timedelta(hours=1)
     existing_notifications = Notification.objects.filter(
+        matching_verb_q(request_verb),
         recipient=certificate_request.knowledge_path.author,
         actor_content_type=requester_ct,
         actor_object_id=certificate_request.requester.id,
-        verb='solicitó un certificado para tu camino de conocimiento',
         target_content_type=knowledge_path_ct,
         target_object_id=certificate_request.knowledge_path.id,
         timestamp__gte=recent_cutoff
@@ -495,7 +513,7 @@ def notify_certificate_request(certificate_request):
         recipient=certificate_request.knowledge_path.author,
         actor_content_type=requester_ct,
         actor_object_id=certificate_request.requester.id,
-        verb='solicitó un certificado para tu camino de conocimiento',
+        verb=request_verb,
         target_content_type=knowledge_path_ct,
         target_object_id=certificate_request.knowledge_path.id,
         description=f'{certificate_request.requester.username} solicitó un certificado para tu camino de conocimiento "{certificate_request.knowledge_path.title}"'

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -426,9 +426,10 @@ Full product docs: [book-clubs.md](../architecture/book-clubs.md).
 - **Response**: User's certificates
 
 ### Request Certificate
-- **POST** `/api/certificates/request/`
+- **POST** `/api/certificates/request/{path_id}/`
 - **Auth**: Required
-- **Body**: Certificate request data
+- **Body**: Certificate request data (`notes` optional)
+- **Requirements**: Path must have `certificates_enabled`, requester must have path access, and requester must have **completed** the path (all nodes + perfect quiz scores). Otherwise `403` with `code: path_not_completed` (or `path_payment_required` / certificates disabled).
 
 ### Get Certificate Detail
 - **GET** `/api/certificates/{id}/`

--- a/docs/backend/models-and-notifications.md
+++ b/docs/backend/models-and-notifications.md
@@ -27,7 +27,8 @@ See **[notifications.md](notifications.md)** for the full API reference, verb ca
 
 Summary:
 
-- **Deduplication**: Helpers check for existing notifications (same `recipient`, `actor`, `verb`, `action_object`, `target`) before creating. Reduces duplicates from repeated triggers.
+- **Deduplication**: Helpers check for existing notifications (same `recipient`, `actor`, `verb`, `action_object`, `target`) before creating. Verb matching is accent-safe (`matching_verb_q`) so SQL_ASCII-stripped verbs still dedupe. Reduces duplicates from repeated triggers.
+- **Path completion**: Notifications fire only on write-side completion transitions (`notify_if_knowledge_path_completed`), not when progress APIs call `is_knowledge_path_completed`.
 - **Cleanup**: `GET /api/profiles/notifications/` deletes read notifications older than 30 days for the current user.
 - **Volume**: High-traffic features (e.g. comments, votes, suggestions) can create many notifications. Monitor DB size and consider limiting or throttling in `notification_utils` for bursty events.
 

--- a/docs/backend/notifications.md
+++ b/docs/backend/notifications.md
@@ -77,9 +77,30 @@ All endpoints require authentication (`IsAuthenticated`).
 
 ## Policies
 
+### Path completion notifications
+
+`is_knowledge_path_completed()` is a **pure read** used by progress APIs and badge rules. It does **not** create notifications.
+
+Completion notifications are sent only from write-side transitions via `notify_if_knowledge_path_completed()`:
+
+- When a node is marked completed (`UserNodeCompletion` signal)
+- When a quiz attempt scores 100 and that finishes the path (`UserQuizAttempt` signal)
+
+`notify_knowledge_path_completion` permanently deduplicates per (author, learner, path).
+
+### Certificate requests
+
+Learners may request a certificate for a knowledge path only when:
+
+1. `certificates_enabled` is true on the path
+2. The learner has path access (payment / unlock rules)
+3. The learner has **completed** the path (`is_knowledge_path_completed`)
+
+The frontend hides the request CTA until completion; the backend enforces the same rule.
+
 ### Deduplication
 
-Most helpers in `notification_utils.py` skip creation when an identical notification already exists (same `recipient`, `actor`, `verb`, `action_object`, `target`). Some high-frequency flows also throttle by time window (e.g. certificate requests within the last hour).
+Most helpers in `notification_utils.py` skip creation when an identical notification already exists (same `recipient`, `actor`, `verb`, `action_object`, `target`). Verb matching uses `matching_verb_q()` so accented verbs and ASCII-stripped forms (legacy SQL_ASCII storage via `prepare_text_for_db`) count as the same. Some high-frequency flows also throttle by time window (e.g. certificate requests within the last hour).
 
 ### Performance
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Authors were receiving multiple "completó tu camino de conocimiento" notifications for the same learner/path, and certificate requests could be submitted without completing the path.

## Root causes

1. **Side-effect in a read helper**: `is_knowledge_path_completed()` notified the author every time it returned `True`. Progress serializers, badge rules (which loop all paths), and node signals all called it — so each page load / check could try to create another notification.
2. **Broken dedup on SQL_ASCII**: Notifications store verbs via `prepare_text_for_db` (accents stripped on SQL_ASCII), but dedup filtered with the accented literal (`completó…`), so existing rows never matched and duplicates were created.
3. **Certificate request API had no completion check**: Frontend hid the CTA until completion, but `POST /api/certificates/request/{path_id}/` did not enforce it.

## Fix

- Make `is_knowledge_path_completed` a pure read; notify only via `notify_if_knowledge_path_completed` on node-completion and perfect-quiz write events.
- Add `matching_verb_q()` so completion/certificate-request dedup matches accented and ASCII verbs.
- Require path completion in `CertificateRequestView` (`403` + `code: path_not_completed`).
- Update docs and add/adjust tests.

## Verification

Backend tests for `certificates`, completion notification cases in `profiles`, and related notification utils.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-827b523b-f845-4c7d-a7dd-dcd7b6792d54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-827b523b-f845-4c7d-a7dd-dcd7b6792d54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

