### PR TITLE
Fix: no cargar toda la biblioteca al editar un tema

### DIFF
--- a/acbc_app/content/serializers.py
+++ b/acbc_app/content/serializers.py
@@ -246,7 +246,9 @@ class ContentProfileSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'title', 'author', 'personal_note', 'thumbnail', 'thumbnail_preview',
             'is_visible', 'is_producer', 'collection', 'collection_name', 'content', 'user',
+            'created_at',
         ]
+        read_only_fields = ['created_at']
 
 
 class ContentWithSelectedProfileSerializer(ContentSerializer):

--- a/acbc_app/content/tests.py
+++ b/acbc_app/content/tests.py
@@ -859,6 +859,50 @@ class UserLibraryWithDetailsAPITests(APITestCase):
         self.assertEqual(r.status_code, status.HTTP_200_OK)
         self.assertEqual(r.data['count'], 1)
 
+    def test_collection_filter_and_exclude(self):
+        library = Library.objects.create(user=self.user, name='Lib')
+        collection = Collection.objects.create(library=library, name='Col A')
+        other = Collection.objects.create(library=library, name='Col B')
+
+        c1 = Content.objects.create(uploaded_by=self.user, media_type='TEXT', original_title='In A')
+        c2 = Content.objects.create(uploaded_by=self.user, media_type='TEXT', original_title='In B')
+        ContentProfile.objects.create(content=c1, user=self.user, title='In A', collection=collection)
+        ContentProfile.objects.create(content=c2, user=self.user, title='In B', collection=other)
+
+        r = self.client.get(self.url, {'collection': collection.id})
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(r.data['count'], 1)
+        self.assertEqual(r.data['results'][0]['title'], 'In A')
+
+        r2 = self.client.get(self.url, {'exclude_collection': collection.id})
+        self.assertEqual(r2.status_code, status.HTTP_200_OK)
+        self.assertEqual(r2.data['count'], 1)
+        self.assertEqual(r2.data['results'][0]['title'], 'In B')
+
+    def test_exclude_topic(self):
+        topic = Topic.objects.create(title='Tema', creator=self.user)
+        c_in = Content.objects.create(uploaded_by=self.user, media_type='TEXT', original_title='Already')
+        c_out = Content.objects.create(uploaded_by=self.user, media_type='TEXT', original_title='Available')
+        c_in.topics.add(topic)
+        ContentProfile.objects.create(content=c_in, user=self.user, title='Already')
+        ContentProfile.objects.create(content=c_out, user=self.user, title='Available')
+
+        r = self.client.get(self.url, {'exclude_topic': topic.id})
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(r.data['count'], 1)
+        self.assertEqual(r.data['results'][0]['title'], 'Available')
+
+    def test_ordering_title(self):
+        c1 = Content.objects.create(uploaded_by=self.user, media_type='TEXT', original_title='Z')
+        c2 = Content.objects.create(uploaded_by=self.user, media_type='TEXT', original_title='A')
+        ContentProfile.objects.create(content=c1, user=self.user, title='Zebra')
+        ContentProfile.objects.create(content=c2, user=self.user, title='Alpha')
+
+        r = self.client.get(self.url, {'ordering': 'title'})
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        titles = [item['title'] for item in r.data['results']]
+        self.assertEqual(titles, ['Alpha', 'Zebra'])
+
 
 class LibraryAPITests(APITestCase):
     """Test suite for Library API endpoints"""

--- a/acbc_app/content/tests.py
+++ b/acbc_app/content/tests.py
@@ -1611,6 +1611,55 @@ class TopicAPITests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_topic_content_simple_paginated_search_and_media_type(self):
+        items = []
+        for i, (title, media) in enumerate([
+            ('Alpha Book', 'TEXT'),
+            ('Beta Video', 'VIDEO'),
+            ('Gamma Book', 'TEXT'),
+        ]):
+            content = Content.objects.create(
+                uploaded_by=self.user,
+                media_type=media,
+                original_title=title,
+                original_author=f'Author {i}',
+            )
+            ContentProfile.objects.create(
+                content=content,
+                user=self.user,
+                title=title,
+                author=f'Author {i}',
+            )
+            items.append(content)
+        self.topic.contents.add(*items)
+
+        url = reverse('content:topic-content-simple', args=[self.topic.id])
+        response = self.client.get(url, {
+            'page': 1,
+            'page_size': 2,
+            'search': 'Book',
+            'ordering': 'title',
+        })
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 2)
+        self.assertEqual(response.data['current_page'], 1)
+        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(len(response.data['contents']), 2)
+        titles = [row['title'] for row in response.data['results']]
+        self.assertEqual(titles, ['Alpha Book', 'Gamma Book'])
+
+        video_response = self.client.get(url, {
+            'page': 1,
+            'page_size': 10,
+            'media_type': 'VIDEO',
+        })
+        self.assertEqual(video_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(video_response.data['count'], 1)
+        self.assertEqual(
+            video_response.data['results'][0]['content']['media_type'],
+            'VIDEO',
+        )
+
     def test_topic_timeline_create_list_and_attach_multiple_contents(self):
         content_video = Content.objects.create(
             uploaded_by=self.user,

--- a/acbc_app/content/views.py
+++ b/acbc_app/content/views.py
@@ -1122,7 +1122,7 @@ class UserContentWithDetailsView(APIView):
         try:
             queryset = ContentProfile.objects.filter(user=request.user).select_related(
                 'content', 'content__file_details', 'collection'
-            )
+            ).prefetch_related('content__topics')
 
             media_type = (request.query_params.get('media_type') or 'ALL').upper()
             if media_type != 'ALL':

--- a/acbc_app/content/views.py
+++ b/acbc_app/content/views.py
@@ -1107,13 +1107,22 @@ class UserContentWithDetailsView(APIView):
     """Paginated list of the current user's content profiles with file details for library display."""
     permission_classes = [IsAuthenticated]
 
+    ALLOWED_ORDERINGS = {
+        'title': 'title',
+        '-title': '-title',
+        'author': 'author',
+        '-author': '-author',
+        'created_at': 'created_at',
+        '-created_at': '-created_at',
+    }
+
     def get(self, request):
         user_id = request.user.id
         username = request.user.username
         try:
             queryset = ContentProfile.objects.filter(user=request.user).select_related(
-                'content', 'content__file_details'
-            ).order_by('-created_at')
+                'content', 'content__file_details', 'collection'
+            )
 
             media_type = (request.query_params.get('media_type') or 'ALL').upper()
             if media_type != 'ALL':
@@ -1128,6 +1137,40 @@ class UserContentWithDetailsView(APIView):
                     | Q(content__original_title__icontains=search)
                     | Q(content__media_type__icontains=search)
                 )
+
+            collection = (request.query_params.get('collection') or '').strip()
+            if collection:
+                try:
+                    queryset = queryset.filter(collection_id=int(collection))
+                except (TypeError, ValueError):
+                    return Response(
+                        {'error': 'Parámetro collection inválido'},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
+            exclude_collection = (request.query_params.get('exclude_collection') or '').strip()
+            if exclude_collection:
+                try:
+                    queryset = queryset.exclude(collection_id=int(exclude_collection))
+                except (TypeError, ValueError):
+                    return Response(
+                        {'error': 'Parámetro exclude_collection inválido'},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
+            exclude_topic = (request.query_params.get('exclude_topic') or '').strip()
+            if exclude_topic:
+                try:
+                    queryset = queryset.exclude(content__topics__id=int(exclude_topic))
+                except (TypeError, ValueError):
+                    return Response(
+                        {'error': 'Parámetro exclude_topic inválido'},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+
+            ordering_param = (request.query_params.get('ordering') or '-created_at').strip()
+            ordering = self.ALLOWED_ORDERINGS.get(ordering_param, '-created_at')
+            queryset = queryset.order_by(ordering, 'id')
 
             paginator = UserLibraryPagination()
             page = paginator.paginate_queryset(queryset, request)

--- a/acbc_app/content/views.py
+++ b/acbc_app/content/views.py
@@ -2136,11 +2136,27 @@ class TopicDetailView(APIView):
 
 
 class TopicContentSimpleView(APIView):
-    """Topic content view optimized for content management operations"""
+    """Topic content view optimized for content management operations.
+
+    Without ``page``, returns the full unpaginated list (legacy consumers).
+    With ``page``, returns a paginated payload supporting search / media_type /
+    ordering for pickers (e.g. timeline entry content selector).
+    """
     permission_classes = [IsAuthenticated]
 
+    ALLOWED_ORDERINGS = {
+        'title': 'original_title',
+        '-title': '-original_title',
+        'author': 'original_author',
+        '-author': '-original_author',
+        'created_at': 'created_at',
+        '-created_at': '-created_at',
+        'media_type': 'media_type',
+        '-media_type': '-media_type',
+    }
+
     def get(self, request, pk):
-        topic = get_object_or_404(Topic.objects.prefetch_related("contents"), pk=pk)
+        topic = get_object_or_404(Topic, pk=pk)
 
         if not topic.is_moderator_or_creator(request.user):
             return Response(
@@ -2150,37 +2166,22 @@ class TopicContentSimpleView(APIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        # Same ordering as the public topic view (vote buckets), then one query
-        # batch for profiles — avoids N+1 selects from per-content profile lookup.
-        ordered_contents = get_topic_contents_ordered_for_public_view(topic)
-        content_ids = [c.id for c in ordered_contents]
-        contents_by_id = (
-            {
-                c.id: c
-                for c in Content.objects.filter(id__in=content_ids).prefetch_related(
-                    "profiles"
-                )
-            }
-            if content_ids
-            else {}
-        )
-        ordered_loaded = [
-            contents_by_id[cid] for cid in content_ids if cid in contents_by_id
-        ]
+        if request.query_params.get('page') is not None:
+            return self._get_paginated(request, topic, pk)
 
-        profiles = []
-        for content in ordered_loaded:
+        return self._get_full_list(request, topic, pk)
+
+    def _serialize_profiles(self, request, topic, pk, contents):
+        response_data = []
+        for content in contents:
             profile = get_topic_content_profile_for_display(
                 content,
                 request,
                 topic,
                 prefetched_profiles=list(content.profiles.all()),
             )
-            if profile is not None:
-                profiles.append(profile)
-
-        response_data = []
-        for profile in profiles:
+            if profile is None:
+                continue
             try:
                 serializer = SimpleContentProfileSerializer(
                     profile,
@@ -2200,7 +2201,27 @@ class TopicContentSimpleView(APIView):
                     exc_info=True,
                 )
                 continue
+        return response_data
 
+    def _get_full_list(self, request, topic, pk):
+        # Same ordering as the public topic view (vote buckets), then one query
+        # batch for profiles — avoids N+1 selects from per-content profile lookup.
+        ordered_contents = get_topic_contents_ordered_for_public_view(topic)
+        content_ids = [c.id for c in ordered_contents]
+        contents_by_id = (
+            {
+                c.id: c
+                for c in Content.objects.filter(id__in=content_ids).prefetch_related(
+                    "profiles"
+                )
+            }
+            if content_ids
+            else {}
+        )
+        ordered_loaded = [
+            contents_by_id[cid] for cid in content_ids if cid in contents_by_id
+        ]
+        response_data = self._serialize_profiles(request, topic, pk, ordered_loaded)
         return Response(
             {
                 "topic": {
@@ -2212,6 +2233,44 @@ class TopicContentSimpleView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+
+    def _get_paginated(self, request, topic, pk):
+        queryset = Content.objects.filter(topics=topic).prefetch_related(
+            'profiles',
+            'profiles__user',
+        )
+
+        media_type = (request.query_params.get('media_type') or '').strip().upper()
+        if media_type and media_type != 'ALL':
+            queryset = queryset.filter(media_type=media_type)
+
+        search = (request.query_params.get('search') or '').strip()
+        if search:
+            queryset = queryset.filter(
+                Q(original_title__icontains=search)
+                | Q(original_author__icontains=search)
+                | Q(media_type__icontains=search)
+                | Q(profiles__title__icontains=search)
+                | Q(profiles__author__icontains=search)
+            ).distinct()
+
+        ordering_param = (request.query_params.get('ordering') or 'title').strip()
+        ordering = self.ALLOWED_ORDERINGS.get(ordering_param, 'original_title')
+        queryset = queryset.order_by(ordering, 'id')
+
+        paginator = TopicContentMediaTypePagination()
+        page = paginator.paginate_queryset(queryset, request)
+        response_data = self._serialize_profiles(request, topic, pk, page)
+        response = paginator.get_paginated_response(response_data)
+        response.data['topic'] = {
+            'id': topic.id,
+            'title': topic.title,
+            'description': topic.description,
+        }
+        # Alias for consumers that expect `contents` instead of `results`.
+        response.data['contents'] = response.data.get('results', [])
+        return response
+
 
 
 class TopicTimelineView(APIView):

--- a/frontend/src/api/contentApi.js
+++ b/frontend/src/api/contentApi.js
@@ -567,9 +567,19 @@ const contentApi = {
     }
   },
 
-  getTopicDetailsSimple: async (topicId) => {
+  getTopicDetailsSimple: async (topicId, params = {}) => {
     try {
-      const response = await axiosInstance.get(`/content/topics/${topicId}/content-simple/`);
+      const query = {};
+      if (params.page != null) query.page = params.page;
+      if (params.page_size != null) query.page_size = params.page_size;
+      if (params.search) query.search = params.search;
+      if (params.media_type && params.media_type !== 'ALL') {
+        query.media_type = params.media_type;
+      }
+      if (params.ordering) query.ordering = params.ordering;
+      const response = await axiosInstance.get(`/content/topics/${topicId}/content-simple/`, {
+        params: query,
+      });
       return response.data;
     } catch (error) {
       console.error('Error fetching topic details (simple):', error);

--- a/frontend/src/api/contentApi.js
+++ b/frontend/src/api/contentApi.js
@@ -26,6 +26,18 @@ const contentApi = {
       if (params.search) {
         query.search = params.search;
       }
+      if (params.collection != null && params.collection !== '') {
+        query.collection = params.collection;
+      }
+      if (params.exclude_collection != null && params.exclude_collection !== '') {
+        query.exclude_collection = params.exclude_collection;
+      }
+      if (params.exclude_topic != null && params.exclude_topic !== '') {
+        query.exclude_topic = params.exclude_topic;
+      }
+      if (params.ordering) {
+        query.ordering = params.ordering;
+      }
       const response = await axiosInstance.get('/content/user-content-with-details/', {
         params: query
       });

--- a/frontend/src/content/CollectionAddContent.jsx
+++ b/frontend/src/content/CollectionAddContent.jsx
@@ -28,25 +28,15 @@ const CollectionAddContent = () => {
     }
   };
 
-  const filterContent = (content) => {
-    // Filter out content that's already in this collection
-    const contentCollectionId =
-    content?.collection && typeof content.collection === 'object' ?
-    content.collection.id :
-    content?.collection;
-    const isInCollection = contentCollectionId === parseInt(collectionId, 10);
-
-
-    return !isInCollection;
-  };
-
   return (
     <LibrarySelectMultiple
       title="Add Content to Collection"
       description="Select content from your library to add to this collection"
       onCancel={handleCancel}
       onSave={handleSave}
-      filterFunction={filterContent} />);
+      excludeCollectionId={collectionId}
+    />
+  );
 
 
 };

--- a/frontend/src/content/CollectionEditContent.jsx
+++ b/frontend/src/content/CollectionEditContent.jsx
@@ -250,11 +250,6 @@ const CollectionEditContent = () => {
     }
   };
 
-  const filterContent = (content) => {
-    const isInCollection = content.collection === parseInt(collectionId);
-    return !isInCollection;
-  };
-
   if (loading && collectionData.length === 0 && !error) {
     return <Typography>Cargando contenido de la colección...</Typography>;
   }
@@ -269,7 +264,7 @@ const CollectionEditContent = () => {
         description="Selecciona contenido de tu biblioteca para agregar a esta colección"
         onCancel={handleCancelAdd}
         onSave={handleSaveAdd}
-        filterFunction={filterContent}
+        excludeCollectionId={collectionId}
         contextName={collectionName}
       />
     );

--- a/frontend/src/content/LibrarySelectMultiple.jsx
+++ b/frontend/src/content/LibrarySelectMultiple.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { 
-    Box, 
-    Typography, 
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+    Box,
+    Typography,
     Paper,
     Button,
     Alert,
@@ -20,7 +20,9 @@ import {
     MenuItem,
     FormControl,
     InputLabel,
-    IconButton
+    IconButton,
+    TablePagination,
+    CircularProgress,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SearchIcon from '@mui/icons-material/Search';
@@ -29,57 +31,49 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import contentApi from '../api/contentApi';
 import { formatDate } from '../utils/dateUtils';
 
-const LibrarySelectMultiple = ({ 
-    onCancel, 
-    onSave, 
+const DEFAULT_PAGE_SIZE = 25;
+
+const LibrarySelectMultiple = ({
+    onCancel,
+    onSave,
     onSelectionChange,
     title = "Seleccionar contenido de la biblioteca",
     description,
     filterFunction,
+    excludeTopicId = null,
+    excludeCollectionId = null,
     maxSelections,
     selectedIds = [],
     contextName = "",
     compact = false
 }) => {
-    const getCollectionId = (item) => {
-        const rawCollection = item?.collection;
-        if (rawCollection && typeof rawCollection === 'object') {
-            return rawCollection.id ?? null;
-        }
-        return rawCollection ?? null;
-    };
-
     const [userContent, setUserContent] = useState([]);
     const [selectedContentProfiles, setSelectedContentProfiles] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [saving, setSaving] = useState(false);
-    
-    // New states for search, collection, and sorting
+
     const [searchQuery, setSearchQuery] = useState('');
+    const [searchDebounced, setSearchDebounced] = useState('');
     const [selectedCollectionId, setSelectedCollectionId] = useState(null);
     const [sortField, setSortField] = useState(null);
     const [sortDirection, setSortDirection] = useState('asc');
     const [collections, setCollections] = useState([]);
+    const [page, setPage] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_PAGE_SIZE);
+    const [totalCount, setTotalCount] = useState(0);
 
     useEffect(() => {
-        const fetchUserContent = async () => {
-            try {
-                const data = await contentApi.getUserContent();
-                const filteredData = filterFunction ? data.filter(filterFunction) : data;
-                setUserContent(filteredData);
-                setLoading(false);
-            } catch (err) {
-                console.error('LibrarySelectMultiple: Error fetching content:', err);
-                setError('Error al obtener tu contenido');
-                setLoading(false);
-            }
-        };
+        const t = setTimeout(() => {
+            setSearchDebounced(searchQuery.trim());
+        }, 400);
+        return () => clearTimeout(t);
+    }, [searchQuery]);
 
-        fetchUserContent();
-    }, [filterFunction]);
+    useEffect(() => {
+        setPage(0);
+    }, [searchDebounced, selectedCollectionId, sortField, sortDirection, excludeTopicId, excludeCollectionId]);
 
-    // Fetch user collections
     useEffect(() => {
         const fetchCollections = async () => {
             try {
@@ -87,98 +81,88 @@ const LibrarySelectMultiple = ({
                 setCollections(data || []);
             } catch (err) {
                 console.error('LibrarySelectMultiple: Error fetching collections:', err);
-                // Don't set error state, just log it - collections are optional
             }
         };
-
         fetchCollections();
     }, []);
 
-    // Initialize selectedContentProfiles from selectedIds prop
+    // Seed selection from selectedIds once (IDs only until profiles are loaded from pages)
     useEffect(() => {
-        if (selectedIds && selectedIds.length > 0 && userContent.length > 0) {
-            const initialSelected = userContent.filter(item => 
-                selectedIds.includes(item.id)
-            );
-            if (initialSelected.length > 0) {
-                setSelectedContentProfiles(initialSelected);
+        if (!selectedIds?.length) return;
+        setSelectedContentProfiles((prev) => {
+            if (prev.length > 0) return prev;
+            return selectedIds.map((id) => ({ id }));
+        });
+    }, [selectedIds]);
+
+    const ordering = (() => {
+        if (!sortField) return '-created_at';
+        return sortDirection === 'desc' ? `-${sortField}` : sortField;
+    })();
+
+    const loadLibraryPage = useCallback(async () => {
+        try {
+            setLoading(true);
+            setError(null);
+            const data = await contentApi.getUserContentWithDetails({
+                page: page + 1,
+                page_size: rowsPerPage,
+                search: searchDebounced,
+                collection: selectedCollectionId || undefined,
+                exclude_topic: excludeTopicId || undefined,
+                exclude_collection: excludeCollectionId || undefined,
+                ordering,
+            });
+            let results = Array.isArray(data?.results) ? data.results : [];
+            if (filterFunction) {
+                results = results.filter(filterFunction);
             }
-        }
-    }, [selectedIds, userContent]);
+            setUserContent(results);
+            setTotalCount(typeof data?.count === 'number' ? data.count : 0);
 
-    // Filtered and sorted content using useMemo for optimization
-    const filteredContent = useMemo(() => {
-        let filtered = [...userContent];
-
-        // Apply collection filter
-        if (selectedCollectionId !== null) {
-            const collectionIdNum = typeof selectedCollectionId === 'string' 
-                ? parseInt(selectedCollectionId, 10) 
-                : selectedCollectionId;
-            
-            filtered = filtered.filter(item => {
-                const itemCollectionId = getCollectionId(item);
-                return itemCollectionId === collectionIdNum || itemCollectionId === selectedCollectionId;
-            });
-        }
-
-        // Apply search filter
-        if (searchQuery.trim()) {
-            const query = searchQuery.toLowerCase().trim();
-            filtered = filtered.filter(item => {
-                const title = (item.title || '').toLowerCase();
-                const author = (item.author || '').toLowerCase();
-                const mediaType = (item.content?.media_type || '').toLowerCase();
-                
-                return title.includes(query) || 
-                       author.includes(query) || 
-                       mediaType.includes(query);
-            });
-        }
-
-        // Apply sorting
-        if (sortField) {
-            filtered = [...filtered].sort((a, b) => {
-                let aValue, bValue;
-                
-                if (sortField === 'title') {
-                    aValue = (a.title || 'Sin título').toLowerCase();
-                    bValue = (b.title || 'Sin título').toLowerCase();
-                } else if (sortField === 'author') {
-                    aValue = (a.author || 'Desconocido').toLowerCase();
-                    bValue = (b.author || 'Desconocido').toLowerCase();
-                } else if (sortField === 'created_at') {
-                    aValue = a.created_at ? new Date(a.created_at).getTime() : 0;
-                    bValue = b.created_at ? new Date(b.created_at).getTime() : 0;
-                    if (aValue < bValue) {
-                        return sortDirection === 'asc' ? -1 : 1;
+            // Enrich stub selections with full profile data when they appear on a page
+            setSelectedContentProfiles((prev) => {
+                if (prev.length === 0) return prev;
+                const byId = new Map(results.map((item) => [item.id, item]));
+                let changed = false;
+                const next = prev.map((item) => {
+                    const full = byId.get(item.id);
+                    if (full && (!item.title || !item.content)) {
+                        changed = true;
+                        return full;
                     }
-                    if (aValue > bValue) {
-                        return sortDirection === 'asc' ? 1 : -1;
-                    }
-                    return 0;
-                } else {
-                    return 0;
-                }
-
-                if (aValue < bValue) {
-                    return sortDirection === 'asc' ? -1 : 1;
-                }
-                if (aValue > bValue) {
-                    return sortDirection === 'asc' ? 1 : -1;
-                }
-                return 0;
+                    return item;
+                });
+                return changed ? next : prev;
             });
+        } catch (err) {
+            console.error('LibrarySelectMultiple: Error fetching content:', err);
+            setError('Error al obtener tu contenido');
+            setUserContent([]);
+            setTotalCount(0);
+        } finally {
+            setLoading(false);
         }
+    }, [
+        page,
+        rowsPerPage,
+        searchDebounced,
+        selectedCollectionId,
+        excludeTopicId,
+        excludeCollectionId,
+        ordering,
+        filterFunction,
+    ]);
 
-        return filtered;
-    }, [userContent, selectedCollectionId, searchQuery, sortField, sortDirection]);
+    useEffect(() => {
+        loadLibraryPage();
+    }, [loadLibraryPage]);
 
     const handleContentToggle = (contentProfile) => {
-        setSelectedContentProfiles(prev => {
+        setSelectedContentProfiles((prev) => {
             let newSelection;
-            if (prev.some(p => p.id === contentProfile.id)) {
-                newSelection = prev.filter(p => p.id !== contentProfile.id);
+            if (prev.some((p) => p.id === contentProfile.id)) {
+                newSelection = prev.filter((p) => p.id !== contentProfile.id);
             } else if (maxSelections === 1) {
                 newSelection = [contentProfile];
             } else if (!maxSelections || prev.length < maxSelections) {
@@ -186,12 +170,11 @@ const LibrarySelectMultiple = ({
             } else {
                 return prev;
             }
-            
-            // Notify parent of selection change
+
             if (onSelectionChange) {
                 onSelectionChange(newSelection);
             }
-            
+
             return newSelection;
         });
     };
@@ -199,40 +182,43 @@ const LibrarySelectMultiple = ({
     const handleSelectAll = (event) => {
         let newSelection;
         if (event.target.checked) {
-            // Get currently selected items that are NOT in filteredContent
-            const selectedNotInFiltered = selectedContentProfiles.filter(
-                selected => !filteredContent.some(filtered => filtered.id === selected.id)
+            const selectedNotInPage = selectedContentProfiles.filter(
+                (selected) => !userContent.some((item) => item.id === selected.id)
             );
-            
-            // Add all filtered items (up to maxSelections if applicable)
-            const itemsToAdd = maxSelections 
-                ? filteredContent.slice(0, maxSelections - selectedNotInFiltered.length)
-                : filteredContent;
-            
-            newSelection = [...selectedNotInFiltered, ...itemsToAdd];
+            const itemsToAdd = maxSelections
+                ? userContent.slice(0, Math.max(0, maxSelections - selectedNotInPage.length))
+                : userContent;
+            newSelection = [...selectedNotInPage, ...itemsToAdd];
         } else {
             newSelection = selectedContentProfiles.filter(
-                selected => !filteredContent.some(filtered => filtered.id === selected.id)
+                (selected) => !userContent.some((item) => item.id === selected.id)
             );
         }
-        
+
         setSelectedContentProfiles(newSelection);
-        
-        // Notify parent of selection change
         if (onSelectionChange) {
             onSelectionChange(newSelection);
         }
     };
 
     const handleSortDirectionToggle = () => {
-        setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc');
+        setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    };
+
+    const handleChangePage = (_event, newPage) => {
+        setPage(newPage);
+    };
+
+    const handleChangeRowsPerPage = (event) => {
+        setRowsPerPage(parseInt(event.target.value, 10));
+        setPage(0);
     };
 
     const handleSubmit = async () => {
-        const selectedIds = selectedContentProfiles.map(p => p.id);
+        const ids = selectedContentProfiles.map((p) => p.id);
         setSaving(true);
         try {
-            await onSave(selectedIds);
+            await onSave(ids);
         } catch (err) {
             console.error('LibrarySelectMultiple.handleSubmit - Error:', err);
             setError('Error al guardar las selecciones');
@@ -240,8 +226,14 @@ const LibrarySelectMultiple = ({
         }
     };
 
-    if (loading) return <Typography>Cargando tu contenido...</Typography>;
-    if (error) return <Alert severity="error">{error}</Alert>;
+    if (error && userContent.length === 0 && !loading) {
+        return (
+            <Box sx={{ pt: compact ? 0 : 12, px: compact ? 0 : 3 }}>
+                <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>
+                <Button variant="contained" onClick={loadLibraryPage}>Reintentar</Button>
+            </Box>
+        );
+    }
 
     return (
         <Box sx={{ pt: compact ? 0 : 12, px: compact ? 0 : 3, maxWidth: compact ? '100%' : 1200, mx: compact ? 0 : 'auto' }}>
@@ -264,9 +256,7 @@ const LibrarySelectMultiple = ({
 
                 <Divider sx={{ my: compact ? 1.5 : 3 }} />
 
-                {/* Toolbar with search, collection selector, and sorting */}
                 <Box sx={{ mb: 3, display: 'flex', flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
-                    {/* Search field */}
                     <TextField
                         placeholder="Buscar contenido..."
                         value={searchQuery}
@@ -278,7 +268,6 @@ const LibrarySelectMultiple = ({
                         sx={{ flexGrow: 1, minWidth: 200 }}
                     />
 
-                    {/* Collection selector */}
                     <FormControl size="small" sx={{ minWidth: 200 }}>
                         <InputLabel>Colección</InputLabel>
                         <Select
@@ -297,7 +286,6 @@ const LibrarySelectMultiple = ({
                         </Select>
                     </FormControl>
 
-                    {/* Sort field selector */}
                     <FormControl size="small" sx={{ minWidth: 150 }}>
                         <InputLabel>Ordenar por</InputLabel>
                         <Select
@@ -314,7 +302,6 @@ const LibrarySelectMultiple = ({
                         </Select>
                     </FormControl>
 
-                    {/* Sort direction toggle */}
                     {sortField && (
                         <IconButton
                             onClick={handleSortDirectionToggle}
@@ -327,9 +314,12 @@ const LibrarySelectMultiple = ({
                     )}
                 </Box>
 
-                <Box sx={{ mb: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Box sx={{ mb: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}>
                     <Typography variant="h6">
-                        Contenido disponible ({filteredContent.length})
+                        Contenido disponible ({totalCount})
+                        {loading && (
+                            <CircularProgress size={16} sx={{ ml: 1, verticalAlign: 'middle' }} />
+                        )}
                     </Typography>
                     <Box sx={{ display: 'flex', gap: 2 }}>
                         <Button
@@ -350,6 +340,10 @@ const LibrarySelectMultiple = ({
                     </Box>
                 </Box>
 
+                {error && (
+                    <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>
+                )}
+
                 <TableContainer>
                     <Table>
                         <TableHead>
@@ -357,13 +351,13 @@ const LibrarySelectMultiple = ({
                                 <TableCell padding="checkbox">
                                     <Checkbox
                                         indeterminate={
-                                            filteredContent.length > 0 && 
-                                            filteredContent.some(item => selectedContentProfiles.some(p => p.id === item.id)) &&
-                                            !filteredContent.every(item => selectedContentProfiles.some(p => p.id === item.id))
+                                            userContent.length > 0 &&
+                                            userContent.some((item) => selectedContentProfiles.some((p) => p.id === item.id)) &&
+                                            !userContent.every((item) => selectedContentProfiles.some((p) => p.id === item.id))
                                         }
                                         checked={
-                                            filteredContent.length > 0 && 
-                                            filteredContent.every(item => selectedContentProfiles.some(p => p.id === item.id))
+                                            userContent.length > 0 &&
+                                            userContent.every((item) => selectedContentProfiles.some((p) => p.id === item.id))
                                         }
                                         onChange={handleSelectAll}
                                         disabled={maxSelections && selectedContentProfiles.length >= maxSelections}
@@ -377,71 +371,95 @@ const LibrarySelectMultiple = ({
                             </TableRow>
                         </TableHead>
                         <TableBody>
-                            {filteredContent.map((content) => (
-                                <TableRow 
-                                    key={content.id}
-                                    hover
-                                    onClick={() => handleContentToggle(content)}
-                                    sx={{ cursor: 'pointer' }}
-                                >
-                                    <TableCell padding="checkbox">
-                                        <Checkbox
-                                            checked={selectedContentProfiles.some(p => p.id === content.id)}
-                                            disabled={maxSelections && selectedContentProfiles.length >= maxSelections && !selectedContentProfiles.some(p => p.id === content.id)}
-                                        />
-                                    </TableCell>
-                                    <TableCell>{content.title || 'Sin título'}</TableCell>
-                                    <TableCell>
-                                        <Chip 
-                                            label={content.content?.media_type || '-'} 
-                                            size="small"
-                                            color="primary"
-                                            variant="outlined"
-                                        />
-                                    </TableCell>
-                                    <TableCell>{content.author || 'Desconocido'}</TableCell>
-                                    <TableCell>
-                                        {content.created_at ? formatDate(content.created_at) : '—'}
-                                    </TableCell>
-                                    <TableCell 
-                                        onClick={(e) => e.stopPropagation()} // Prevent row click from triggering
-                                    >
-                                        <MuiLink
-                                            href={`/content/${content.content?.id}`}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            sx={{ 
-                                                display: 'flex', 
-                                                alignItems: 'center',
-                                                gap: 0.5,
-                                                color: 'primary.main',
-                                                textDecoration: 'none',
-                                                '&:hover': {
-                                                    textDecoration: 'underline'
-                                                }
-                                            }}
-                                        >
-                                            Ver
-                                            <OpenInNewIcon fontSize="small" />
-                                        </MuiLink>
-                                    </TableCell>
-                                </TableRow>
-                            ))}
-                            {filteredContent.length === 0 && (
+                            {loading && userContent.length === 0 ? (
                                 <TableRow>
                                     <TableCell colSpan={6} align="center">
-                                        {searchQuery || selectedCollectionId !== null 
-                                            ? 'No se encontró contenido con los filtros aplicados' 
-                                            : 'No hay contenido disponible'}
+                                        Cargando tu contenido...
                                     </TableCell>
                                 </TableRow>
+                            ) : (
+                                <>
+                                    {userContent.map((content) => (
+                                        <TableRow
+                                            key={content.id}
+                                            hover
+                                            onClick={() => handleContentToggle(content)}
+                                            sx={{ cursor: 'pointer', opacity: loading ? 0.6 : 1 }}
+                                        >
+                                            <TableCell padding="checkbox">
+                                                <Checkbox
+                                                    checked={selectedContentProfiles.some((p) => p.id === content.id)}
+                                                    disabled={maxSelections && selectedContentProfiles.length >= maxSelections && !selectedContentProfiles.some((p) => p.id === content.id)}
+                                                />
+                                            </TableCell>
+                                            <TableCell>{content.title || 'Sin título'}</TableCell>
+                                            <TableCell>
+                                                <Chip
+                                                    label={content.content?.media_type || '-'}
+                                                    size="small"
+                                                    color="primary"
+                                                    variant="outlined"
+                                                />
+                                            </TableCell>
+                                            <TableCell>{content.author || 'Desconocido'}</TableCell>
+                                            <TableCell>
+                                                {content.created_at ? formatDate(content.created_at) : '—'}
+                                            </TableCell>
+                                            <TableCell
+                                                onClick={(e) => e.stopPropagation()}
+                                            >
+                                                <MuiLink
+                                                    href={`/content/${content.content?.id}`}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    sx={{
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        gap: 0.5,
+                                                        color: 'primary.main',
+                                                        textDecoration: 'none',
+                                                        '&:hover': {
+                                                            textDecoration: 'underline'
+                                                        }
+                                                    }}
+                                                >
+                                                    Ver
+                                                    <OpenInNewIcon fontSize="small" />
+                                                </MuiLink>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                    {userContent.length === 0 && (
+                                        <TableRow>
+                                            <TableCell colSpan={6} align="center">
+                                                {searchDebounced || selectedCollectionId !== null
+                                                    ? 'No se encontró contenido con los filtros aplicados'
+                                                    : 'No hay contenido disponible'}
+                                            </TableCell>
+                                        </TableRow>
+                                    )}
+                                </>
                             )}
                         </TableBody>
                     </Table>
                 </TableContainer>
+
+                <TablePagination
+                    component="div"
+                    count={totalCount}
+                    page={page}
+                    onPageChange={handleChangePage}
+                    rowsPerPage={rowsPerPage}
+                    onRowsPerPageChange={handleChangeRowsPerPage}
+                    rowsPerPageOptions={[12, 25, 50, 100]}
+                    labelRowsPerPage="Por página"
+                    labelDisplayedRows={({ from, to, count }) =>
+                        `${from}–${to} de ${count !== -1 ? count : `más de ${to}`}`
+                    }
+                />
             </Paper>
         </Box>
     );
 };
 
-export default LibrarySelectMultiple; 
+export default LibrarySelectMultiple;

--- a/frontend/src/content/LibrarySelectSingle.jsx
+++ b/frontend/src/content/LibrarySelectSingle.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Typography,
@@ -24,12 +24,16 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  TablePagination,
+  CircularProgress,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SearchIcon from '@mui/icons-material/Search';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import contentApi from '../api/contentApi';
+
+const DEFAULT_PAGE_SIZE = 25;
 
 const LibrarySelectSingle = ({
   isOpen,
@@ -38,54 +42,48 @@ const LibrarySelectSingle = ({
   title = 'Seleccionar contenido de tu biblioteca',
   description,
   filterFunction,
+  excludeTopicId = null,
+  excludeCollectionId = null,
   compact = false,
   isLoading = false,
 }) => {
-  const getCollectionId = (item) => {
-    const rawCollection = item?.collection;
-    if (rawCollection && typeof rawCollection === 'object') {
-      return rawCollection.id ?? null;
-    }
-    return rawCollection ?? null;
-  };
-
   const [userContent, setUserContent] = useState([]);
   const [selectedContentProfile, setSelectedContentProfile] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   const [searchQuery, setSearchQuery] = useState('');
+  const [searchDebounced, setSearchDebounced] = useState('');
   const [selectedCollectionId, setSelectedCollectionId] = useState(null);
   const [sortField, setSortField] = useState(null);
   const [sortDirection, setSortDirection] = useState('asc');
   const [collections, setCollections] = useState([]);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_PAGE_SIZE);
+  const [totalCount, setTotalCount] = useState(0);
 
   useEffect(() => {
-    const fetchUserContent = async () => {
-      try {
-        const data = await contentApi.getUserContent();
-        if (filterFunction) {
-          setUserContent(data.filter(filterFunction));
-        } else {
-          setUserContent(data);
-        }
-      } catch (err) {
-        console.error('LibrarySelectSingle: Error fetching content:', err);
-        setError('Error al obtener tu contenido');
-      } finally {
-        setLoading(false);
-      }
-    };
+    const t = setTimeout(() => {
+      setSearchDebounced(searchQuery.trim());
+    }, 400);
+    return () => clearTimeout(t);
+  }, [searchQuery]);
 
-    if (isOpen) {
-      setSelectedContentProfile(null);
-      setSearchQuery('');
-      setSelectedCollectionId(null);
-      setLoading(true);
-      setError(null);
-      fetchUserContent();
-    }
-  }, [isOpen, filterFunction]);
+  useEffect(() => {
+    setPage(0);
+  }, [searchDebounced, selectedCollectionId, sortField, sortDirection, excludeTopicId, excludeCollectionId]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setSelectedContentProfile(null);
+    setSearchQuery('');
+    setSearchDebounced('');
+    setSelectedCollectionId(null);
+    setSortField(null);
+    setSortDirection('asc');
+    setPage(0);
+    setError(null);
+  }, [isOpen]);
 
   useEffect(() => {
     const fetchCollections = async () => {
@@ -96,65 +94,59 @@ const LibrarySelectSingle = ({
         console.error('LibrarySelectSingle: Error fetching collections:', err);
       }
     };
-
     if (isOpen) {
       fetchCollections();
     }
   }, [isOpen]);
 
-  const filteredContent = useMemo(() => {
-    let filtered = [...userContent];
+  const ordering = (() => {
+    if (!sortField) return '-created_at';
+    return sortDirection === 'desc' ? `-${sortField}` : sortField;
+  })();
 
-    if (selectedCollectionId !== null) {
-      const collectionIdNum =
-        typeof selectedCollectionId === 'string'
-          ? parseInt(selectedCollectionId, 10)
-          : selectedCollectionId;
-      filtered = filtered.filter(
-        (item) => {
-          const itemCollectionId = getCollectionId(item);
-          return (
-            itemCollectionId === collectionIdNum ||
-            itemCollectionId === selectedCollectionId
-          );
-        }
-      );
-    }
-
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase().trim();
-      filtered = filtered.filter((item) => {
-        const titleText = (item.title || '').toLowerCase();
-        const author = (item.author || '').toLowerCase();
-        const mediaType = (item.content?.media_type || '').toLowerCase();
-        return (
-          titleText.includes(query) ||
-          author.includes(query) ||
-          mediaType.includes(query)
-        );
+  const loadLibraryPage = useCallback(async () => {
+    if (!isOpen) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await contentApi.getUserContentWithDetails({
+        page: page + 1,
+        page_size: rowsPerPage,
+        search: searchDebounced,
+        collection: selectedCollectionId || undefined,
+        exclude_topic: excludeTopicId || undefined,
+        exclude_collection: excludeCollectionId || undefined,
+        ordering,
       });
+      let results = Array.isArray(data?.results) ? data.results : [];
+      if (filterFunction) {
+        results = results.filter(filterFunction);
+      }
+      setUserContent(results);
+      setTotalCount(typeof data?.count === 'number' ? data.count : 0);
+    } catch (err) {
+      console.error('LibrarySelectSingle: Error fetching content:', err);
+      setError('Error al obtener tu contenido');
+      setUserContent([]);
+      setTotalCount(0);
+    } finally {
+      setLoading(false);
     }
+  }, [
+    isOpen,
+    page,
+    rowsPerPage,
+    searchDebounced,
+    selectedCollectionId,
+    excludeTopicId,
+    excludeCollectionId,
+    ordering,
+    filterFunction,
+  ]);
 
-    if (sortField) {
-      filtered = [...filtered].sort((a, b) => {
-        let aValue, bValue;
-        if (sortField === 'title') {
-          aValue = (a.title || 'Sin título').toLowerCase();
-          bValue = (b.title || 'Sin título').toLowerCase();
-        } else if (sortField === 'author') {
-          aValue = (a.author || 'Desconocido').toLowerCase();
-          bValue = (b.author || 'Desconocido').toLowerCase();
-        } else {
-          return 0;
-        }
-        if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
-        if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
-        return 0;
-      });
-    }
-
-    return filtered;
-  }, [userContent, selectedCollectionId, searchQuery, sortField, sortDirection]);
+  useEffect(() => {
+    loadLibraryPage();
+  }, [loadLibraryPage]);
 
   const handleRowClick = (contentProfile) => {
     setSelectedContentProfile(contentProfile);
@@ -162,6 +154,15 @@ const LibrarySelectSingle = ({
 
   const handleSortDirectionToggle = () => {
     setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+  };
+
+  const handleChangePage = (_event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
   };
 
   const handleConfirm = () => {
@@ -188,7 +189,7 @@ const LibrarySelectSingle = ({
       elevation={0}
     >
       <Box sx={{ mb: compact ? 1.5 : 2 }}>
-        <Typography variant={compact ? 'h6' : 'h6'} sx={{ mb: 1 }}>
+        <Typography variant="h6" sx={{ mb: 1 }}>
           {title}
         </Typography>
         {description && (
@@ -253,6 +254,7 @@ const LibrarySelectSingle = ({
             </MenuItem>
             <MenuItem value="title">Título</MenuItem>
             <MenuItem value="author">Autor</MenuItem>
+            <MenuItem value="created_at">Fecha de subida</MenuItem>
           </Select>
         </FormControl>
         {sortField && (
@@ -274,8 +276,20 @@ const LibrarySelectSingle = ({
       </Box>
 
       <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-        Contenido disponible ({filteredContent.length})
+        Contenido disponible ({totalCount})
+        {loading && (
+          <CircularProgress size={14} sx={{ ml: 1, verticalAlign: 'middle' }} />
+        )}
       </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+          <Button size="small" onClick={loadLibraryPage} sx={{ ml: 1 }}>
+            Reintentar
+          </Button>
+        </Alert>
+      )}
 
       <TableContainer
         sx={{
@@ -294,92 +308,92 @@ const LibrarySelectSingle = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {filteredContent.map((content) => (
-              <TableRow
-                key={content.id}
-                hover
-                onClick={() => handleRowClick(content)}
-                selected={selectedContentProfile?.id === content.id}
-                sx={{
-                  cursor: 'pointer',
-                  '&.Mui-selected': {
-                    backgroundColor: 'action.selected',
-                  },
-                  '&.Mui-selected:hover': {
-                    backgroundColor: 'action.selected',
-                  },
-                }}
-              >
-                <TableCell>{content.title || 'Sin título'}</TableCell>
-                <TableCell>
-                  <Chip
-                    label={content.content?.media_type || '-'}
-                    size="small"
-                    color="primary"
-                    variant="outlined"
-                  />
-                </TableCell>
-                <TableCell>{content.author || 'Desconocido'}</TableCell>
-                <TableCell onClick={(e) => e.stopPropagation()}>
-                  <MuiLink
-                    href={`/content/${content.content?.id}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      color: 'primary.main',
-                      textDecoration: 'none',
-                      '&:hover': { textDecoration: 'underline' },
-                    }}
-                  >
-                    Ver
-                    <OpenInNewIcon fontSize="small" />
-                  </MuiLink>
-                </TableCell>
-              </TableRow>
-            ))}
-            {filteredContent.length === 0 && (
+            {loading && userContent.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
-                  {searchQuery || selectedCollectionId !== null
-                    ? 'No se encontró contenido con los filtros aplicados'
-                    : 'No hay contenido disponible'}
+                  Cargando tu contenido...
                 </TableCell>
               </TableRow>
+            ) : (
+              <>
+                {userContent.map((content) => (
+                  <TableRow
+                    key={content.id}
+                    hover
+                    onClick={() => handleRowClick(content)}
+                    selected={selectedContentProfile?.id === content.id}
+                    sx={{
+                      cursor: 'pointer',
+                      opacity: loading ? 0.6 : 1,
+                      '&.Mui-selected': {
+                        backgroundColor: 'action.selected',
+                      },
+                      '&.Mui-selected:hover': {
+                        backgroundColor: 'action.selected',
+                      },
+                    }}
+                  >
+                    <TableCell>{content.title || 'Sin título'}</TableCell>
+                    <TableCell>
+                      <Chip
+                        label={content.content?.media_type || '-'}
+                        size="small"
+                        color="primary"
+                        variant="outlined"
+                      />
+                    </TableCell>
+                    <TableCell>{content.author || 'Desconocido'}</TableCell>
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <MuiLink
+                        href={`/content/${content.content?.id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 0.5,
+                          color: 'primary.main',
+                          textDecoration: 'none',
+                          '&:hover': { textDecoration: 'underline' },
+                        }}
+                      >
+                        Ver
+                        <OpenInNewIcon fontSize="small" />
+                      </MuiLink>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {userContent.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
+                      {searchDebounced || selectedCollectionId !== null
+                        ? 'No se encontró contenido con los filtros aplicados'
+                        : 'No hay contenido disponible'}
+                    </TableCell>
+                  </TableRow>
+                )}
+              </>
             )}
           </TableBody>
         </Table>
       </TableContainer>
+
+      <TablePagination
+        component="div"
+        count={totalCount}
+        page={page}
+        onPageChange={handleChangePage}
+        rowsPerPage={rowsPerPage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+        rowsPerPageOptions={[12, 25, 50, 100]}
+        labelRowsPerPage="Por página"
+        labelDisplayedRows={({ from, to, count }) =>
+          `${from}–${to} de ${count !== -1 ? count : `más de ${to}`}`
+        }
+        sx={{ flexShrink: 0 }}
+      />
     </Paper>
   );
-
-  if (loading) {
-    return (
-      <Dialog open={isOpen} onClose={handleClose} maxWidth="md" fullWidth>
-        <DialogTitle>{title}</DialogTitle>
-        <DialogContent>
-          <Box sx={{ py: 6, textAlign: 'center' }}>
-            <Typography color="text.secondary">
-              Cargando tu contenido...
-            </Typography>
-          </Box>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
-  if (error) {
-    return (
-      <Dialog open={isOpen} onClose={handleClose} maxWidth="md" fullWidth>
-        <DialogTitle>{title}</DialogTitle>
-        <DialogContent>
-          <Alert severity="error">{error}</Alert>
-        </DialogContent>
-      </Dialog>
-    );
-  }
 
   return (
     <Dialog
@@ -395,6 +409,7 @@ const LibrarySelectSingle = ({
         },
       }}
     >
+      <DialogTitle sx={{ display: 'none' }}>{title}</DialogTitle>
       <DialogContent
         sx={{
           p: compact ? 2 : 3,

--- a/frontend/src/topics/TopicAddContent.jsx
+++ b/frontend/src/topics/TopicAddContent.jsx
@@ -86,13 +86,6 @@ const TopicAddContent = () => {
         setSelectedContentProfileIds(selectedContentProfiles.map((p) => p.id));
     };
 
-    const filterContent = (content) => {
-        const isInTopic = content?.content?.topics?.some(
-            (tid) => tid === parseInt(topicId, 10)
-        );
-        return !isInTopic;
-    };
-
     if (loading) {
         return <Typography>Cargando...</Typography>;
     }
@@ -127,7 +120,7 @@ const TopicAddContent = () => {
                     onCancel={handleBackToSourceChoice}
                     onSave={handleSave}
                     onSelectionChange={handleSelectionChange}
-                    filterFunction={filterContent}
+                    excludeTopicId={topicId}
                     contextName={topicTitle || topicId}
                     selectedIds={selectedContentProfileIds}
                 />

--- a/frontend/src/topics/TopicContentManager.jsx
+++ b/frontend/src/topics/TopicContentManager.jsx
@@ -104,13 +104,6 @@ const TopicContentManager = ({ topicId, topicTitle: topicTitleProp = '' }) => {
     }
   };
 
-  const filterContent = (content) => {
-    const isInTopic = content?.content?.topics?.some(
-      (id) => id === parseInt(topicId, 10),
-    );
-    return !isInTopic;
-  };
-
   if (loading) {
     return <Typography color="text.secondary">Cargando contenido...</Typography>;
   }
@@ -139,7 +132,7 @@ const TopicContentManager = ({ topicId, topicTitle: topicTitleProp = '' }) => {
             description="Selecciona contenido de tu biblioteca para agregar a este tema"
             onCancel={() => setAddSourceMode(null)}
             onSave={handleSaveAdd}
-            filterFunction={filterContent}
+            excludeTopicId={topicId}
             contextName={topicTitle}
           />
         </Box>

--- a/frontend/src/topics/timeline/TopicTimelineContentSelector.jsx
+++ b/frontend/src/topics/timeline/TopicTimelineContentSelector.jsx
@@ -1,8 +1,9 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Checkbox,
   Chip,
+  CircularProgress,
   FormControl,
   IconButton,
   InputLabel,
@@ -16,6 +17,7 @@ import {
   TableCell,
   TableContainer,
   TableHead,
+  TablePagination,
   TableRow,
   TextField,
   Tooltip,
@@ -25,7 +27,10 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SearchIcon from '@mui/icons-material/Search';
+import contentApi from '../../api/contentApi';
 import { formatDate } from '../../utils/dateUtils';
+
+const DEFAULT_PAGE_SIZE = 25;
 
 const MEDIA_TYPE_LABELS = {
   VIDEO: 'Video',
@@ -41,122 +46,163 @@ const getItemId = (item) => {
   return content?.id != null ? String(content.id) : null;
 };
 
-const getItemTitle = (item) => {
+const normalizeItem = (item) => {
   const content = getContentData(item);
-  return (
-    item?.title ||
-    item?.selected_profile?.title ||
-    content?.original_title ||
-    'Contenido sin titulo'
-  );
+  const id = getItemId(item);
+  if (!id) return null;
+  return {
+    id,
+    title:
+      item?.title ||
+      item?.selected_profile?.title ||
+      content?.selected_profile?.title ||
+      content?.original_title ||
+      'Contenido sin titulo',
+    author:
+      item?.author ||
+      item?.selected_profile?.author ||
+      content?.selected_profile?.author ||
+      content?.original_author ||
+      'Desconocido',
+    mediaType: (content?.media_type || item?.media_type || 'TEXT').toUpperCase(),
+    createdAt:
+      item?.created_at ||
+      content?.created_at ||
+      item?.selected_profile?.created_at ||
+      null,
+    contentId: id,
+  };
 };
 
-const getItemAuthor = (item) => {
-  const content = getContentData(item);
-  return item?.author || item?.selected_profile?.author || content?.original_author || 'Desconocido';
+const buildInitialCache = (initialSelectedItems = []) => {
+  const map = {};
+  initialSelectedItems.forEach((raw) => {
+    const item = normalizeItem(raw);
+    if (item) map[item.id] = item;
+  });
+  return map;
 };
-
-const getItemMediaType = (item) => {
-  const content = getContentData(item);
-  return (content?.media_type || item?.media_type || 'TEXT').toUpperCase();
-};
-
-const getItemCreatedAt = (item) => {
-  const content = getContentData(item);
-  return item?.created_at || content?.created_at || item?.selected_profile?.created_at || null;
-};
-
-const normalizeItems = (items = []) => (
-  items
-    .map((item) => ({
-      id: getItemId(item),
-      title: getItemTitle(item),
-      author: getItemAuthor(item),
-      mediaType: getItemMediaType(item),
-      createdAt: getItemCreatedAt(item),
-      contentId: getItemId(item),
-    }))
-    .filter((item) => item.id)
-);
 
 const TopicTimelineContentSelector = ({
-  items = [],
+  topicId,
   selectedIds = [],
-  loading = false,
+  initialSelectedItems = [],
   onSelectionChange,
 }) => {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(Boolean(topicId));
+  const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
+  const [searchDebounced, setSearchDebounced] = useState('');
   const [mediaTypeFilter, setMediaTypeFilter] = useState('');
   const [sortField, setSortField] = useState('title');
   const [sortDirection, setSortDirection] = useState('asc');
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(DEFAULT_PAGE_SIZE);
+  const [totalCount, setTotalCount] = useState(0);
+  const [itemCache, setItemCache] = useState(() => buildInitialCache(initialSelectedItems));
 
-  const normalizedItems = useMemo(() => normalizeItems(items), [items]);
-  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const selectedSet = useMemo(() => new Set(selectedIds.map(String)), [selectedIds]);
 
-  const filteredItems = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    let result = normalizedItems.filter((item) => {
-      const matchesMedia = !mediaTypeFilter || item.mediaType === mediaTypeFilter;
-      const matchesSearch = !query ||
-        item.title.toLowerCase().includes(query) ||
-        item.author.toLowerCase().includes(query) ||
-        (MEDIA_TYPE_LABELS[item.mediaType] || item.mediaType).toLowerCase().includes(query);
-      return matchesMedia && matchesSearch;
-    });
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setSearchDebounced(searchQuery.trim());
+    }, 400);
+    return () => clearTimeout(t);
+  }, [searchQuery]);
 
-    result = [...result].sort((a, b) => {
-      let aValue = '';
-      let bValue = '';
-      if (sortField === 'author') {
-        aValue = a.author.toLowerCase();
-        bValue = b.author.toLowerCase();
-      } else if (sortField === 'mediaType') {
-        aValue = MEDIA_TYPE_LABELS[a.mediaType] || a.mediaType;
-        bValue = MEDIA_TYPE_LABELS[b.mediaType] || b.mediaType;
-      } else if (sortField === 'createdAt') {
-        aValue = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-        bValue = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-      } else {
-        aValue = a.title.toLowerCase();
-        bValue = b.title.toLowerCase();
-      }
+  useEffect(() => {
+    setPage(0);
+  }, [searchDebounced, mediaTypeFilter, sortField, sortDirection, topicId]);
 
-      if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
-      if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
-      return 0;
-    });
+  const ordering = sortDirection === 'desc' ? `-${sortField}` : sortField;
 
-    return result;
-  }, [mediaTypeFilter, normalizedItems, searchQuery, sortDirection, sortField]);
+  const loadPage = useCallback(async () => {
+    if (!topicId) {
+      setItems([]);
+      setTotalCount(0);
+      setLoading(false);
+      return;
+    }
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await contentApi.getTopicDetailsSimple(topicId, {
+        page: page + 1,
+        page_size: rowsPerPage,
+        search: searchDebounced,
+        media_type: mediaTypeFilter || undefined,
+        ordering,
+      });
+      const rows = Array.isArray(data?.results)
+        ? data.results
+        : Array.isArray(data?.contents)
+          ? data.contents
+          : [];
+      const normalized = rows.map(normalizeItem).filter(Boolean);
+      setItems(normalized);
+      setTotalCount(typeof data?.count === 'number' ? data.count : normalized.length);
+      setItemCache((prev) => {
+        const next = { ...prev };
+        normalized.forEach((item) => {
+          next[item.id] = item;
+        });
+        return next;
+      });
+    } catch (err) {
+      console.error('TopicTimelineContentSelector: Error fetching contents:', err);
+      setError('Error al cargar los contenidos del tema');
+      setItems([]);
+      setTotalCount(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [topicId, page, rowsPerPage, searchDebounced, mediaTypeFilter, ordering]);
+
+  useEffect(() => {
+    loadPage();
+  }, [loadPage]);
 
   const selectedItems = useMemo(
-    () => normalizedItems.filter((item) => selectedSet.has(item.id)),
-    [normalizedItems, selectedSet],
+    () => selectedIds.map((id) => {
+      const key = String(id);
+      return itemCache[key] || { id: key, title: `Contenido #${key}`, contentId: key };
+    }),
+    [selectedIds, itemCache],
   );
 
   const setSelectedIds = (nextIds) => {
-    onSelectionChange([...new Set(nextIds)]);
+    onSelectionChange([...new Set(nextIds.map(String))]);
   };
 
-  const handleToggle = (itemId) => {
+  const handleToggle = (item) => {
+    const itemId = item.id;
     if (selectedSet.has(itemId)) {
-      setSelectedIds(selectedIds.filter((id) => id !== itemId));
+      setSelectedIds(selectedIds.filter((id) => String(id) !== itemId));
     } else {
+      setItemCache((prev) => ({ ...prev, [itemId]: item }));
       setSelectedIds([...selectedIds, itemId]);
     }
   };
 
   const handleSelectVisible = (event) => {
-    const visibleIds = filteredItems.map((item) => item.id);
+    const visibleIds = items.map((item) => item.id);
     if (event.target.checked) {
+      setItemCache((prev) => {
+        const next = { ...prev };
+        items.forEach((item) => {
+          next[item.id] = item;
+        });
+        return next;
+      });
       setSelectedIds([...selectedIds, ...visibleIds]);
     } else {
-      setSelectedIds(selectedIds.filter((id) => !visibleIds.includes(id)));
+      setSelectedIds(selectedIds.filter((id) => !visibleIds.includes(String(id))));
     }
   };
 
-  const visibleSelectedCount = filteredItems.filter((item) => selectedSet.has(item.id)).length;
-  const allVisibleSelected = filteredItems.length > 0 && visibleSelectedCount === filteredItems.length;
+  const visibleSelectedCount = items.filter((item) => selectedSet.has(item.id)).length;
+  const allVisibleSelected = items.length > 0 && visibleSelectedCount === items.length;
   const someVisibleSelected = visibleSelectedCount > 0 && !allVisibleSelected;
 
   return (
@@ -177,14 +223,14 @@ const TopicTimelineContentSelector = ({
             value={searchQuery}
             onChange={(event) => setSearchQuery(event.target.value)}
             size="small"
-            disabled={loading}
+            disabled={!topicId}
             InputProps={{
               startAdornment: <SearchIcon sx={{ mr: 1, color: 'text.secondary' }} />,
             }}
             sx={{ flexGrow: 1, minWidth: { md: 240 } }}
           />
 
-          <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 160 } }} disabled={loading}>
+          <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 160 } }} disabled={!topicId}>
             <InputLabel>Tipo</InputLabel>
             <Select
               value={mediaTypeFilter}
@@ -200,7 +246,7 @@ const TopicTimelineContentSelector = ({
             </Select>
           </FormControl>
 
-          <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 160 } }} disabled={loading}>
+          <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 160 } }} disabled={!topicId}>
             <InputLabel>Ordenar por</InputLabel>
             <Select
               value={sortField}
@@ -209,8 +255,8 @@ const TopicTimelineContentSelector = ({
             >
               <MenuItem value="title">Titulo</MenuItem>
               <MenuItem value="author">Autor</MenuItem>
-              <MenuItem value="mediaType">Tipo</MenuItem>
-              <MenuItem value="createdAt">Fecha de subida</MenuItem>
+              <MenuItem value="media_type">Tipo</MenuItem>
+              <MenuItem value="created_at">Fecha de subida</MenuItem>
             </Select>
           </FormControl>
 
@@ -218,7 +264,7 @@ const TopicTimelineContentSelector = ({
             <IconButton
               onClick={() => setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'))}
               size="small"
-              disabled={loading}
+              disabled={!topicId}
               sx={{ border: 1, borderColor: 'divider', alignSelf: { xs: 'flex-start', md: 'center' } }}
             >
               {sortDirection === 'asc' ? <ArrowUpwardIcon /> : <ArrowDownwardIcon />}
@@ -230,12 +276,15 @@ const TopicTimelineContentSelector = ({
           <Typography variant="body2" color="text.secondary">
             {loading
               ? 'Cargando contenidos...'
-              : `${filteredItems.length} contenido(s) disponible(s) - ${selectedIds.length} seleccionado(s)`}
+              : `${totalCount} contenido(s) disponible(s) - ${selectedIds.length} seleccionado(s)`}
+            {loading && (
+              <CircularProgress size={14} sx={{ ml: 1, verticalAlign: 'middle' }} />
+            )}
           </Typography>
           {selectedItems.length > 0 && (
             <Stack direction="row" spacing={0.75} sx={{ flexWrap: 'wrap', gap: 0.75 }}>
               {selectedItems.slice(0, 4).map((item) => (
-                <Chip key={item.id} size="small" label={item.title} onDelete={() => handleToggle(item.id)} />
+                <Chip key={item.id} size="small" label={item.title} onDelete={() => handleToggle(item)} />
               ))}
               {selectedItems.length > 4 && (
                 <Chip size="small" label={`+${selectedItems.length - 4} mas`} variant="outlined" />
@@ -243,6 +292,15 @@ const TopicTimelineContentSelector = ({
             </Stack>
           )}
         </Stack>
+
+        {error && (
+          <Typography color="error" variant="body2">
+            {error}{' '}
+            <MuiLink component="button" type="button" onClick={loadPage} underline="hover">
+              Reintentar
+            </MuiLink>
+          </Typography>
+        )}
 
         <TableContainer sx={{ maxHeight: 360, border: 1, borderColor: 'divider' }}>
           <Table stickyHeader size="small">
@@ -253,7 +311,7 @@ const TopicTimelineContentSelector = ({
                     checked={allVisibleSelected}
                     indeterminate={someVisibleSelected}
                     onChange={handleSelectVisible}
-                    disabled={loading || filteredItems.length === 0}
+                    disabled={loading || items.length === 0}
                   />
                 </TableCell>
                 <TableCell>Titulo</TableCell>
@@ -264,60 +322,87 @@ const TopicTimelineContentSelector = ({
               </TableRow>
             </TableHead>
             <TableBody>
-              {filteredItems.map((item) => {
-                const selected = selectedSet.has(item.id);
-                return (
-                  <TableRow
-                    key={item.id}
-                    hover
-                    onClick={() => handleToggle(item.id)}
-                    selected={selected}
-                    sx={{ cursor: 'pointer' }}
-                  >
-                    <TableCell padding="checkbox">
-                      <Checkbox checked={selected} />
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2" fontWeight={selected ? 700 : 400}>
-                        {item.title}
-                      </Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Chip
-                        size="small"
-                        color="primary"
-                        variant="outlined"
-                        label={MEDIA_TYPE_LABELS[item.mediaType] || item.mediaType}
-                      />
-                    </TableCell>
-                    <TableCell>{item.author}</TableCell>
-                    <TableCell>{item.createdAt ? formatDate(item.createdAt) : '-'}</TableCell>
-                    <TableCell onClick={(event) => event.stopPropagation()}>
-                      <MuiLink
-                        href={`/content/${item.contentId}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, textDecoration: 'none' }}
-                      >
-                        Ver
-                        <OpenInNewIcon fontSize="small" />
-                      </MuiLink>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-              {!loading && filteredItems.length === 0 && (
+              {loading && items.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={6} align="center" sx={{ py: 3 }}>
-                    {normalizedItems.length === 0
-                      ? 'Este tema todavia no tiene contenidos para adjuntar.'
-                      : 'No se encontro contenido con los filtros aplicados.'}
+                    Cargando contenidos...
                   </TableCell>
                 </TableRow>
+              ) : (
+                <>
+                  {items.map((item) => {
+                    const selected = selectedSet.has(item.id);
+                    return (
+                      <TableRow
+                        key={item.id}
+                        hover
+                        onClick={() => handleToggle(item)}
+                        selected={selected}
+                        sx={{ cursor: 'pointer', opacity: loading ? 0.6 : 1 }}
+                      >
+                        <TableCell padding="checkbox">
+                          <Checkbox checked={selected} />
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" fontWeight={selected ? 700 : 400}>
+                            {item.title}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                            label={MEDIA_TYPE_LABELS[item.mediaType] || item.mediaType}
+                          />
+                        </TableCell>
+                        <TableCell>{item.author}</TableCell>
+                        <TableCell>{item.createdAt ? formatDate(item.createdAt) : '-'}</TableCell>
+                        <TableCell onClick={(event) => event.stopPropagation()}>
+                          <MuiLink
+                            href={`/content/${item.contentId}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, textDecoration: 'none' }}
+                          >
+                            Ver
+                            <OpenInNewIcon fontSize="small" />
+                          </MuiLink>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                  {!loading && items.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={6} align="center" sx={{ py: 3 }}>
+                        {searchDebounced || mediaTypeFilter
+                          ? 'No se encontro contenido con los filtros aplicados.'
+                          : 'Este tema todavia no tiene contenidos para adjuntar.'}
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </>
               )}
             </TableBody>
           </Table>
         </TableContainer>
+
+        <TablePagination
+          component="div"
+          count={totalCount}
+          page={page}
+          onPageChange={(_event, newPage) => setPage(newPage)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={(event) => {
+            setRowsPerPage(parseInt(event.target.value, 10));
+            setPage(0);
+          }}
+          rowsPerPageOptions={[12, 25, 50, 100]}
+          labelRowsPerPage="Por página"
+          labelDisplayedRows={({ from, to, count }) =>
+            `${from}–${to} de ${count !== -1 ? count : `más de ${to}`}`
+          }
+        />
       </Stack>
     </Paper>
   );

--- a/frontend/src/topics/timeline/TopicTimelineEntryForm.jsx
+++ b/frontend/src/topics/timeline/TopicTimelineEntryForm.jsx
@@ -51,8 +51,7 @@ const schema = yup.object({
 
 const TopicTimelineEntryForm = ({
   entry,
-  availableContents,
-  loadingContents,
+  topicId,
   saving,
   error,
   onCancel,
@@ -144,9 +143,9 @@ const TopicTimelineEntryForm = ({
           control={control}
           render={({ field }) => (
             <TopicTimelineContentSelector
-              items={availableContents}
+              topicId={topicId}
               selectedIds={field.value}
-              loading={loadingContents}
+              initialSelectedItems={entry?.contents || []}
               onSelectionChange={field.onChange}
             />
           )}

--- a/frontend/src/topics/timeline/TopicTimelineEntryPage.jsx
+++ b/frontend/src/topics/timeline/TopicTimelineEntryPage.jsx
@@ -37,7 +37,6 @@ const TopicTimelineEntryPage = () => {
 
   const [topicTitle, setTopicTitle] = useState('');
   const [entry, setEntry] = useState(null);
-  const [availableContents, setAvailableContents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
@@ -55,14 +54,12 @@ const TopicTimelineEntryPage = () => {
     setLoading(true);
     setError(null);
     try {
-      const [topicData, timelineData, contentsData] = await Promise.all([
+      const [topicData, timelineData] = await Promise.all([
         contentApi.getTopicDetails(topicId, { include_contents: false }),
         contentApi.getTopicTimeline(topicId),
-        contentApi.getTopicDetailsSimple(topicId),
       ]);
 
       setTopicTitle(topicData?.title || '');
-      setAvailableContents(contentsData?.contents || []);
 
       const creatorId = typeof topicData?.creator === 'object'
         ? topicData.creator?.id
@@ -183,8 +180,7 @@ const TopicTimelineEntryPage = () => {
       {canEdit && !error && (
         <TopicTimelineEntryForm
           entry={entry}
-          availableContents={availableContents}
-          loadingContents={loading}
+          topicId={topicId}
           saving={saving}
           error={formError}
           onCancel={handleCancel}

--- a/frontend/src/topics/timeline/__tests__/TopicTimelineEntryForm.test.jsx
+++ b/frontend/src/topics/timeline/__tests__/TopicTimelineEntryForm.test.jsx
@@ -1,12 +1,21 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TopicTimelineEntryForm from '../TopicTimelineEntryForm';
 
+vi.mock('../../../api/contentApi', () => ({
+  default: {
+    getTopicDetailsSimple: vi.fn().mockResolvedValue({
+      count: 0,
+      results: [],
+      contents: [],
+    }),
+  },
+}));
+
 const baseProps = {
   entry: null,
-  availableContents: [],
-  loadingContents: false,
+  topicId: '42',
   saving: false,
   error: null,
   onCancel: vi.fn(),
@@ -14,6 +23,10 @@ const baseProps = {
 };
 
 describe('TopicTimelineEntryForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('shows a title validation error and disables submit', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Al editar un tema → Contenido → Agregar contenido, el selector de biblioteca (`LibrarySelectMultiple`) pedía `GET /content/user-content/` sin paginación y cargaba **toda** la biblioteca en el cliente (miles de ítems). La búsqueda y el filtro por colección eran solo client-side sobre ese array completo.

## Solution
- El picker ahora usa `GET /content/user-content-with-details/` (el mismo endpoint paginado de la biblioteca principal) con:
  - búsqueda con debounce
  - filtro por colección
  - ordenamiento
  - paginación (`TablePagination`)
- Extensiones al endpoint: `collection`, `exclude_collection`, `exclude_topic`, `ordering`
- Al agregar a un tema se usa `exclude_topic`; al agregar a una colección, `exclude_collection`
- También actualizado `LibrarySelectSingle` (mismo problema)

## Test plan
- [ ] Editar tema → Contenido → Elegir de la biblioteca: la página carga rápido (solo ~25 ítems)
- [ ] Buscar por título/autor filtra vía API
- [ ] Filtro por colección y ordenar funcionan
- [ ] Paginar y seleccionar ítems en distintas páginas; “Elegir (N)” conserva la selección
- [ ] Ítems ya en el tema no aparecen en el listado
- [ ] Misma experiencia al agregar contenido a una colección

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81494943-e15d-4a8d-a7da-7eb5ba67f45d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81494943-e15d-4a8d-a7da-7eb5ba67f45d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

