### PR TITLE
Fix missing certificate approval notifications for students

### DIFF
--- a/acbc_app/certificates/views.py
+++ b/acbc_app/certificates/views.py
@@ -329,7 +329,7 @@ class CertificateRequestActionView(APIView):
                 
                 # Send notification
                 try:
-                    notify_certificate_approval(certificate_request)
+                    notify_certificate_approval(certificate_request, actor=request.user)
                     logger.debug(f"Approval notification sent for certificate request {request_id}")
                 except Exception as e:
                     logger.error(f"Failed to send approval notification for certificate request {request_id}: {str(e)}", exc_info=True)
@@ -373,7 +373,7 @@ class CertificateRequestActionView(APIView):
                 
                 # Send notification
                 try:
-                    notify_certificate_rejection(certificate_request)
+                    notify_certificate_rejection(certificate_request, actor=request.user)
                     logger.debug(f"Rejection notification sent for certificate request {request_id}")
                 except Exception as e:
                     logger.error(f"Failed to send rejection notification for certificate request {request_id}: {str(e)}", exc_info=True)

--- a/acbc_app/profiles/serializers.py
+++ b/acbc_app/profiles/serializers.py
@@ -58,11 +58,17 @@ EVENT_TARGET_VERBS = (
     'se registró en tu evento',
     'aceptó tu pago para',
     'te envió un certificado para',
+    'solicitó un certificado para tu evento',
 )
 
 CERTIFICATE_DECISION_VERBS = (
     'aprobó tu solicitud de certificado para',
     'rechazó tu solicitud de certificado para',
+)
+
+CERTIFICATE_REQUEST_VERBS = (
+    'solicitó un certificado para tu camino de conocimiento',
+    'solicitó un certificado para tu evento',
 )
 
 TOPIC_REQUEST_DECISION_VERBS = (
@@ -77,6 +83,7 @@ KNOWLEDGE_PATH_VERB_KEYS = frozenset(verb_key(v) for v in KNOWLEDGE_PATH_VERBS)
 MODERATOR_ACTION_VERB_KEYS = frozenset(verb_key(v) for v in MODERATOR_ACTION_VERBS)
 EVENT_TARGET_VERB_KEYS = frozenset(verb_key(v) for v in EVENT_TARGET_VERBS)
 CERTIFICATE_DECISION_VERB_KEYS = frozenset(verb_key(v) for v in CERTIFICATE_DECISION_VERBS)
+CERTIFICATE_REQUEST_VERB_KEYS = frozenset(verb_key(v) for v in CERTIFICATE_REQUEST_VERBS)
 TOPIC_REQUEST_DECISION_VERB_KEYS = frozenset(verb_key(v) for v in TOPIC_REQUEST_DECISION_VERBS)
 
 # Get logger for profiles serializers
@@ -390,7 +397,7 @@ class NotificationSerializer(serializers.ModelSerializer):
             verb = obj.verb
 
             # Certificate request notifications link to the certificates section
-            if self._verb_is(verb, 'solicitó un certificado para tu camino de conocimiento'):
+            if self._verb_in(verb, CERTIFICATE_REQUEST_VERB_KEYS):
                 request = self.context.get('request')
                 recipient = obj.recipient
                 if request and request.user.is_authenticated and request.user.id == recipient.id:

--- a/acbc_app/profiles/tests.py
+++ b/acbc_app/profiles/tests.py
@@ -1129,6 +1129,94 @@ class NotificationTests(APITestCase):
             '/profiles/my_profile?section=certificates'
         )
 
+    def test_certificate_approval_notifies_after_rerequest(self):
+        """A prior approval notification for the same path must not block a new request."""
+        from utils.db_encoding import to_ascii_safe
+
+        student = User.objects.create_user(
+            username='student_rerequest',
+            email='student_rerequest@example.com',
+            password='testpass123'
+        )
+        knowledge_path = KnowledgePath.objects.create(
+            title='Rerequest Path',
+            description='Test',
+            author=self.user,
+            certificates_enabled=True,
+        )
+        ensure_path_completed(student, knowledge_path)
+
+        # Legacy path-level approval notification (old dedup key) still in DB
+        kp_ct = ContentType.objects.get_for_model(KnowledgePath)
+        user_ct = ContentType.objects.get_for_model(User)
+        Notification.objects.create(
+            recipient=student,
+            actor_content_type=user_ct,
+            actor_object_id=self.user.id,
+            verb=to_ascii_safe('aprobó tu solicitud de certificado para'),
+            target_content_type=kp_ct,
+            target_object_id=knowledge_path.id,
+            description=f'{self.user.username} aprobo tu solicitud de certificado para "Rerequest Path"',
+        )
+
+        self.client.force_authenticate(user=student)
+        request_url = reverse('certificates:certificate-request', args=[knowledge_path.id])
+        response = self.client.post(request_url, {'notes': 'Please review'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        request_id = response.data['id']
+
+        self.client.force_authenticate(user=self.user)
+        approve_url = reverse(
+            'certificates:certificate-request-action',
+            args=[request_id, 'approve'],
+        )
+        response = self.client.post(approve_url, {'note': 'OK'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.client.force_authenticate(user=student)
+        notifications = self.client.get(reverse('profiles:notifications')).data['notifications']
+        approval_notifications = [
+            n for n in notifications
+            if to_ascii_safe(n['verb']) == to_ascii_safe('aprobó tu solicitud de certificado para')
+        ]
+        # Legacy leftover + new approval for this request
+        self.assertGreaterEqual(len(approval_notifications), 1)
+        self.assertTrue(
+            any('Rerequest Path' in (n.get('description') or '') and n['unread']
+                for n in approval_notifications)
+        )
+
+    def test_certificate_approval_notification_once_per_request(self):
+        """Approving the same CertificateRequest twice must not duplicate notifications."""
+        from utils.notification_utils import notify_certificate_approval
+        from utils.db_encoding import to_ascii_safe
+
+        student = User.objects.create_user(
+            username='student_once',
+            email='student_once@example.com',
+            password='testpass123'
+        )
+        knowledge_path = KnowledgePath.objects.create(
+            title='Once Path',
+            description='Test',
+            author=self.user,
+            certificates_enabled=True,
+        )
+        certificate_request = CertificateRequest.objects.create(
+            requester=student,
+            knowledge_path=knowledge_path,
+            status='APPROVED',
+        )
+
+        notify_certificate_approval(certificate_request, actor=self.user)
+        notify_certificate_approval(certificate_request, actor=self.user)
+
+        approval_notifications = [
+            n for n in Notification.objects.filter(recipient=student)
+            if to_ascii_safe(n.verb) == to_ascii_safe('aprobó tu solicitud de certificado para')
+        ]
+        self.assertEqual(len(approval_notifications), 1)
+
     def test_certificate_rejection_notification(self):
         """Test notification when a teacher rejects a certificate request"""
         # Create a student

--- a/acbc_app/utils/notification_utils.py
+++ b/acbc_app/utils/notification_utils.py
@@ -453,248 +453,256 @@ def notify_knowledge_path_completion(user, knowledge_path):
             'knowledge_path_id': knowledge_path.id,
         })
 
+def _certificate_request_context(certificate_request, actor=None):
+    """
+    Resolve recipient-facing target + deciding user for a certificate request.
+
+    Supports knowledge-path and event requests. Returns None when the request
+    has no usable target/owner (caller should skip notifying).
+    """
+    knowledge_path = certificate_request.knowledge_path
+    event = certificate_request.event
+
+    if knowledge_path is not None:
+        owner = knowledge_path.author
+        if owner is None:
+            logger.warning(
+                "Certificate request knowledge path has no author - skipping notification",
+                extra={'certificate_request_id': certificate_request.id, 'knowledge_path_id': knowledge_path.id},
+            )
+            return None
+        title = knowledge_path.title
+        target = knowledge_path
+        target_kind = 'camino de conocimiento'
+    elif event is not None:
+        owner = event.owner
+        if owner is None:
+            logger.warning(
+                "Certificate request event has no owner - skipping notification",
+                extra={'certificate_request_id': certificate_request.id, 'event_id': event.id},
+            )
+            return None
+        title = event.title
+        target = event
+        target_kind = 'evento'
+    else:
+        logger.warning(
+            "Certificate request has neither knowledge_path nor event - skipping notification",
+            extra={'certificate_request_id': certificate_request.id},
+        )
+        return None
+
+    deciding_user = actor or owner
+    return {
+        'owner': owner,
+        'deciding_user': deciding_user,
+        'title': title,
+        'target': target,
+        'target_kind': target_kind,
+        'target_ct': ContentType.objects.get_for_model(target),
+        'request_ct': ContentType.objects.get_for_model(certificate_request),
+        'requester_ct': ContentType.objects.get_for_model(certificate_request.requester),
+        'decider_ct': ContentType.objects.get_for_model(deciding_user),
+    }
+
+
 def notify_certificate_request(certificate_request):
     """
-    Create a notification when someone requests a certificate for a knowledge path.
-    Notifies the knowledge path author.
-    
-    Args:
-        certificate_request: The CertificateRequest instance that was created
+    Create a notification when someone requests a certificate.
+    Notifies the knowledge path author or event owner.
     """
+    context = _certificate_request_context(certificate_request)
+    if context is None:
+        return
+
+    owner = context['owner']
+    title = context['title']
+    target_kind = context['target_kind']
+    requester = certificate_request.requester
+
     logger.info("Creating certificate request notification", extra={
-        'requester_id': certificate_request.requester.id,
-        'requester_username': certificate_request.requester.username,
-        'knowledge_path_id': certificate_request.knowledge_path.id,
-        'knowledge_path_title': certificate_request.knowledge_path.title,
-        'knowledge_path_author_id': certificate_request.knowledge_path.author.id,
-        'knowledge_path_author_username': certificate_request.knowledge_path.author.username,
+        'requester_id': requester.id,
+        'requester_username': requester.username,
+        'target_id': context['target'].id,
+        'target_title': title,
+        'owner_id': owner.id,
+        'owner_username': owner.username,
+        'target_kind': target_kind,
     })
-    
-    # Don't notify if requester is the author
-    if certificate_request.requester == certificate_request.knowledge_path.author:
-        logger.info("Requester is the author - skipping notification", extra={
-            'requester_id': certificate_request.requester.id,
-            'knowledge_path_id': certificate_request.knowledge_path.id,
+
+    if requester == owner:
+        logger.info("Requester is the owner - skipping notification", extra={
+            'requester_id': requester.id,
+            'target_id': context['target'].id,
         })
         return
-        
-    # Get content types
-    requester_ct = ContentType.objects.get_for_model(certificate_request.requester)
-    knowledge_path_ct = ContentType.objects.get_for_model(certificate_request.knowledge_path)
-    logger.debug(f"Content types - Requester: {requester_ct}, Knowledge Path: {knowledge_path_ct}")
-    
-    # Check if notification already exists for this specific request
-    # We'll check for recent notifications (within the last hour) to avoid spam
+
     from django.utils import timezone
     from datetime import timedelta
-    
-    request_verb = 'solicitó un certificado para tu camino de conocimiento'
+
+    if target_kind == 'evento':
+        request_verb = 'solicitó un certificado para tu evento'
+    else:
+        request_verb = 'solicitó un certificado para tu camino de conocimiento'
+
     recent_cutoff = timezone.now() - timedelta(hours=1)
     existing_notifications = Notification.objects.filter(
         matching_verb_q(request_verb),
-        recipient=certificate_request.knowledge_path.author,
-        actor_content_type=requester_ct,
-        actor_object_id=certificate_request.requester.id,
-        target_content_type=knowledge_path_ct,
-        target_object_id=certificate_request.knowledge_path.id,
-        timestamp__gte=recent_cutoff
+        recipient=owner,
+        actor_content_type=context['requester_ct'],
+        actor_object_id=requester.id,
+        target_content_type=context['target_ct'],
+        target_object_id=context['target'].id,
+        timestamp__gte=recent_cutoff,
     )
-    logger.debug(f"Recent existing notifications count: {existing_notifications.count()}")
-    
+
     if existing_notifications.exists():
-        logger.info("Recent notification already exists - skipping creation", extra={
-            'requester_id': certificate_request.requester.id,
-            'knowledge_path_id': certificate_request.knowledge_path.id,
+        logger.info("Recent certificate request notification already exists - skipping", extra={
+            'requester_id': requester.id,
+            'target_id': context['target'].id,
         })
         return
-    
-    # Create the notification
+
     notification = create_notification(
-        recipient=certificate_request.knowledge_path.author,
-        actor_content_type=requester_ct,
-        actor_object_id=certificate_request.requester.id,
+        recipient=owner,
+        actor_content_type=context['requester_ct'],
+        actor_object_id=requester.id,
         verb=request_verb,
-        target_content_type=knowledge_path_ct,
-        target_object_id=certificate_request.knowledge_path.id,
-        description=f'{certificate_request.requester.username} solicitó un certificado para tu camino de conocimiento "{certificate_request.knowledge_path.title}"'
+        action_object_content_type=context['request_ct'],
+        action_object_object_id=certificate_request.id,
+        target_content_type=context['target_ct'],
+        target_object_id=context['target'].id,
+        description=f'{requester.username} solicitó un certificado para tu {target_kind} "{title}"',
     )
     logger.info("Certificate request notification created successfully", extra={
         'notification_id': notification.id,
-        'requester_id': certificate_request.requester.id,
-        'knowledge_path_id': certificate_request.knowledge_path.id,
-        'recipient_id': notification.recipient.id,
-        'actor_id': notification.actor.id,
+        'requester_id': requester.id,
+        'recipient_id': owner.id,
+        'target_id': context['target'].id,
     })
-    
-    # Verify the notification was created
-    if notification:
-        logger.debug("Notification verification successful", extra={
-            'notification_id': notification.id,
-            'recipient': notification.recipient.username,
-            'actor': notification.actor.username,
-            'verb': notification.verb,
-            'timestamp': notification.timestamp.isoformat(),
-            'unread': notification.unread,
-            'target_content_type': str(notification.target_content_type),
-            'target_object_id': notification.target_object_id,
-        })
-    else:
-        logger.warning("Notification not found in database after creation", extra={
-            'requester_id': certificate_request.requester.id,
-            'knowledge_path_id': certificate_request.knowledge_path.id,
-        })
 
-def notify_certificate_approval(certificate_request):
+
+def notify_certificate_approval(certificate_request, actor=None):
     """
     Create a notification when a certificate request is approved.
     Notifies the student who requested the certificate.
-    
-    Args:
-        certificate_request: The CertificateRequest instance that was approved
+
+    Dedup is per CertificateRequest (action_object), not per path/event, so a
+    later re-request after cancel/reject still notifies the student.
     """
+    context = _certificate_request_context(certificate_request, actor=actor)
+    if context is None:
+        return
+
+    deciding_user = context['deciding_user']
+    title = context['title']
+    student = certificate_request.requester
+
     logger.info("Creating certificate approval notification", extra={
-        'student_id': certificate_request.requester.id,
-        'student_username': certificate_request.requester.username,
-        'knowledge_path_id': certificate_request.knowledge_path.id,
-        'knowledge_path_title': certificate_request.knowledge_path.title,
-        'approver_id': certificate_request.knowledge_path.author.id,
-        'approver_username': certificate_request.knowledge_path.author.username,
+        'student_id': student.id,
+        'student_username': student.username,
+        'target_id': context['target'].id,
+        'target_title': title,
+        'approver_id': deciding_user.id,
+        'approver_username': deciding_user.username,
+        'certificate_request_id': certificate_request.id,
+        'target_kind': context['target_kind'],
     })
-    
-    # Get content types
-    approver_ct = ContentType.objects.get_for_model(certificate_request.knowledge_path.author)
-    knowledge_path_ct = ContentType.objects.get_for_model(certificate_request.knowledge_path)
-    logger.debug(f"Content types - Approver: {approver_ct}, Knowledge Path: {knowledge_path_ct}")
-    
-    # Check if notification already exists
+
+    approval_verb = 'aprobó tu solicitud de certificado para'
+
     existing_notifications = Notification.objects.filter(
-        recipient=certificate_request.requester,
-        actor_content_type=approver_ct,
-        actor_object_id=certificate_request.knowledge_path.author.id,
-        verb='aprobó tu solicitud de certificado para',
-        target_content_type=knowledge_path_ct,
-        target_object_id=certificate_request.knowledge_path.id
+        matching_verb_q(approval_verb),
+        recipient=student,
+        action_object_content_type=context['request_ct'],
+        action_object_object_id=certificate_request.id,
     )
-    logger.debug(f"Existing notifications count: {existing_notifications.count()}")
-    
+
     if existing_notifications.exists():
-        logger.info("Notification already exists - skipping creation", extra={
-            'student_id': certificate_request.requester.id,
-            'knowledge_path_id': certificate_request.knowledge_path.id,
+        logger.info("Approval notification already exists for this request - skipping", extra={
+            'student_id': student.id,
+            'certificate_request_id': certificate_request.id,
         })
         return
-    
-    # Create the notification
+
     notification = create_notification(
-        recipient=certificate_request.requester,
-        actor_content_type=approver_ct,
-        actor_object_id=certificate_request.knowledge_path.author.id,
-        verb='aprobó tu solicitud de certificado para',
-        target_content_type=knowledge_path_ct,
-        target_object_id=certificate_request.knowledge_path.id,
-        description=f'{certificate_request.knowledge_path.author.username} aprobó tu solicitud de certificado para "{certificate_request.knowledge_path.title}"'
+        recipient=student,
+        actor_content_type=context['decider_ct'],
+        actor_object_id=deciding_user.id,
+        verb=approval_verb,
+        action_object_content_type=context['request_ct'],
+        action_object_object_id=certificate_request.id,
+        target_content_type=context['target_ct'],
+        target_object_id=context['target'].id,
+        description=f'{deciding_user.username} aprobó tu solicitud de certificado para "{title}"',
     )
     logger.info("Certificate approval notification created successfully", extra={
         'notification_id': notification.id,
-        'student_id': certificate_request.requester.id,
-        'knowledge_path_id': certificate_request.knowledge_path.id,
-        'recipient_id': notification.recipient.id,
-        'actor_id': notification.actor.id,
+        'student_id': student.id,
+        'certificate_request_id': certificate_request.id,
+        'recipient_id': student.id,
+        'actor_id': deciding_user.id,
     })
-    
-    # Verify the notification was created
-    if notification:
-        logger.debug("Notification verification successful", extra={
-            'notification_id': notification.id,
-            'recipient': notification.recipient.username,
-            'actor': notification.actor.username,
-            'verb': notification.verb,
-            'timestamp': notification.timestamp.isoformat(),
-            'unread': notification.unread,
-            'target_content_type': str(notification.target_content_type),
-            'target_object_id': notification.target_object_id,
-        })
-    else:
-        logger.warning("Notification not found in database after creation", extra={
-            'student_id': certificate_request.requester.id,
-            'knowledge_path_id': certificate_request.knowledge_path.id,
-        })
 
-def notify_certificate_rejection(certificate_request):
+
+def notify_certificate_rejection(certificate_request, actor=None):
     """
     Create a notification when a certificate request is rejected.
     Notifies the student who requested the certificate.
-    
-    Args:
-        certificate_request: The CertificateRequest instance that was rejected
     """
+    context = _certificate_request_context(certificate_request, actor=actor)
+    if context is None:
+        return
+
+    deciding_user = context['deciding_user']
+    title = context['title']
+    student = certificate_request.requester
+
     logger.info("Creating certificate rejection notification", extra={
-        'student_id': certificate_request.requester.id,
-        'student_username': certificate_request.requester.username,
-        'knowledge_path_id': certificate_request.knowledge_path.id,
-        'knowledge_path_title': certificate_request.knowledge_path.title,
-        'rejector_id': certificate_request.knowledge_path.author.id,
-        'rejector_username': certificate_request.knowledge_path.author.username,
+        'student_id': student.id,
+        'student_username': student.username,
+        'target_id': context['target'].id,
+        'target_title': title,
+        'rejector_id': deciding_user.id,
+        'rejector_username': deciding_user.username,
+        'certificate_request_id': certificate_request.id,
     })
-    
-    # Get content types
-    rejector_ct = ContentType.objects.get_for_model(certificate_request.knowledge_path.author)
-    knowledge_path_ct = ContentType.objects.get_for_model(certificate_request.knowledge_path)
-    logger.debug(f"Content types - Rejector: {rejector_ct}, Knowledge Path: {knowledge_path_ct}")
-    
-    # Check if notification already exists
+
+    rejection_verb = 'rechazó tu solicitud de certificado para'
+
     existing_notifications = Notification.objects.filter(
-        recipient=certificate_request.requester,
-        actor_content_type=rejector_ct,
-        actor_object_id=certificate_request.knowledge_path.author.id,
-        verb='rechazó tu solicitud de certificado para',
-        target_content_type=knowledge_path_ct,
-        target_object_id=certificate_request.knowledge_path.id
+        matching_verb_q(rejection_verb),
+        recipient=student,
+        action_object_content_type=context['request_ct'],
+        action_object_object_id=certificate_request.id,
     )
-    logger.debug(f"Existing notifications count: {existing_notifications.count()}")
-    
+
     if existing_notifications.exists():
-        logger.info("Notification already exists - skipping creation", extra={
-            'student_id': certificate_request.requester.id,
-            'knowledge_path_id': certificate_request.knowledge_path.id,
+        logger.info("Rejection notification already exists for this request - skipping", extra={
+            'student_id': student.id,
+            'certificate_request_id': certificate_request.id,
         })
         return
-    
-    # Create the notification
+
     notification = create_notification(
-        recipient=certificate_request.requester,
-        actor_content_type=rejector_ct,
-        actor_object_id=certificate_request.knowledge_path.author.id,
-        verb='rechazó tu solicitud de certificado para',
-        target_content_type=knowledge_path_ct,
-        target_object_id=certificate_request.knowledge_path.id,
-        description=f'{certificate_request.knowledge_path.author.username} rechazó tu solicitud de certificado para "{certificate_request.knowledge_path.title}"'
+        recipient=student,
+        actor_content_type=context['decider_ct'],
+        actor_object_id=deciding_user.id,
+        verb=rejection_verb,
+        action_object_content_type=context['request_ct'],
+        action_object_object_id=certificate_request.id,
+        target_content_type=context['target_ct'],
+        target_object_id=context['target'].id,
+        description=f'{deciding_user.username} rechazó tu solicitud de certificado para "{title}"',
     )
     logger.info("Certificate rejection notification created successfully", extra={
         'notification_id': notification.id,
-        'student_id': certificate_request.requester.id,
-        'knowledge_path_id': certificate_request.knowledge_path.id,
-        'recipient_id': notification.recipient.id,
-        'actor_id': notification.actor.id,
+        'student_id': student.id,
+        'certificate_request_id': certificate_request.id,
+        'recipient_id': student.id,
+        'actor_id': deciding_user.id,
     })
-    
-    # Verify the notification was created
-    if notification:
-        logger.debug("Notification verification successful", extra={
-            'notification_id': notification.id,
-            'recipient': notification.recipient.username,
-            'actor': notification.actor.username,
-            'verb': notification.verb,
-            'timestamp': notification.timestamp.isoformat(),
-            'unread': notification.unread,
-            'target_content_type': str(notification.target_content_type),
-            'target_object_id': notification.target_object_id,
-        })
-    else:
-        logger.warning("Notification not found in database after creation", extra={
-            'student_id': certificate_request.requester.id,
-            'knowledge_path_id': certificate_request.knowledge_path.id,
-        })
+
 
 def notify_content_upvote(vote):
     """

--- a/docs/backend/notifications.md
+++ b/docs/backend/notifications.md
@@ -53,6 +53,7 @@ All endpoints require authentication (`IsAuthenticated`).
 | `comentó en tu contenido` | Content profile owner | Top-level content comment |
 | `completó tu camino de conocimiento` | Knowledge path author | Path completed |
 | `solicitó un certificado para tu camino de conocimiento` | Knowledge path author | Certificate request |
+| `solicitó un certificado para tu evento` | Event owner | Event certificate request |
 | `aprobó tu solicitud de certificado para` | Student | Certificate approved |
 | `rechazó tu solicitud de certificado para` | Student | Certificate rejected |
 | `votó positivamente tu contenido` | Content uploader | Upvote on content |
@@ -97,6 +98,8 @@ Learners may request a certificate for a knowledge path only when:
 3. The learner has **completed** the path (`is_knowledge_path_completed`)
 
 The frontend hides the request CTA until completion; the backend enforces the same rule.
+
+Approval and rejection notify the **student** (`notify_certificate_approval` / `notify_certificate_rejection`). Dedup is per `CertificateRequest` (via `action_object`), so a new request after cancel/reject still produces a new decision notification. Helpers support both knowledge-path and event requests and use accent-safe verb matching.
 
 ### Deduplication
 

--- a/frontend/src/profiles/CertificateRequests.jsx
+++ b/frontend/src/profiles/CertificateRequests.jsx
@@ -217,7 +217,10 @@ const CertificateRequests = () => {
               </Box>
 
               <Stack direction="row" spacing={1.5} sx={{ flexWrap: 'wrap' }}>
-                {request.status === 'PENDING' && request.knowledge_path_author === authState.user?.username &&
+                {request.status === 'PENDING' && (
+                  request.knowledge_path_author === authState.user?.username ||
+                  request.event_owner === authState.user?.username
+                ) &&
                 <>
                     <Button
                     variant="contained"
@@ -235,7 +238,10 @@ const CertificateRequests = () => {
                     </Button>
                   </>
                 }
-                {request.status === 'REJECTED' && request.knowledge_path_author === authState.user?.username &&
+                {request.status === 'REJECTED' && (
+                  request.knowledge_path_author === authState.user?.username ||
+                  request.event_owner === authState.user?.username
+                ) &&
                 <Button
                   variant="contained"
                   color="success"

--- a/frontend/src/profiles/Certificates.jsx
+++ b/frontend/src/profiles/Certificates.jsx
@@ -419,7 +419,8 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
                 {/* Teacher View */}
                 {requests.filter(
               (req) =>
-              req.knowledge_path_author === authState.user?.username
+              req.knowledge_path_author === authState.user?.username ||
+              req.event_owner === authState.user?.username
             ).length > 0 &&
             <Box>
                     <Typography
@@ -433,7 +434,8 @@ const Certificates = ({ isOwnProfile = false, userId = null }) => {
                     {sortRequests(
                 requests.filter(
                   (req) =>
-                  req.knowledge_path_author === authState.user?.username
+                  req.knowledge_path_author === authState.user?.username ||
+                  req.event_owner === authState.user?.username
                 )
               ).map((request) =>
               <Card key={request.id} sx={{ mb: 2 }}>

--- a/frontend/src/profiles/Notifications.jsx
+++ b/frontend/src/profiles/Notifications.jsx
@@ -54,7 +54,8 @@ const Notifications = ({
       return notification.description || `${notification.actor} respondió a tu comentario`;
     } else if (verbIs(notification.verb, 'completó tu camino de conocimiento')) {
       return notification.description;
-    } else if (verbIs(notification.verb, 'solicitó un certificado para tu camino de conocimiento')) {
+    } else if (verbIs(notification.verb, 'solicitó un certificado para tu camino de conocimiento') ||
+               verbIs(notification.verb, 'solicitó un certificado para tu evento')) {
       return notification.description;
     } else if (verbIs(notification.verb, 'aprobó tu solicitud de certificado para')) {
       return notification.description;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Students were not receiving in-app notifications when an author approved their certificate request.

## Root cause

`notify_certificate_approval` deduplicated permanently by `(student, author, knowledge path)`. If an earlier approval notification already existed for that path (previous test approval, leftover after resetting a request, etc.), later real approvals were silently skipped. The approve API still returned 200 because notify errors/skips are non-fatal.

Related gaps:
- Helpers assumed `knowledge_path` always exists (event requests crashed with `AttributeError`, swallowed by the view).
- Approval/rejection dedup did not use accent-safe verb matching.
- Teacher UI only listed requests where `knowledge_path_author` matched (event owners could not approve from those screens).

## Fix

- Deduplicate approval/rejection **per `CertificateRequest`** (`action_object`), so a new request after cancel/reject still notifies.
- Support both knowledge-path and event targets; pass `actor=request.user` from the approve/reject view.
- Use `matching_verb_q` for decision/request verbs.
- Include event owners in Certificates / CertificateRequests teacher filters.
- Docs + tests for re-request after a leftover path-level notification, and once-per-request dedup.

## Verification

```bash
cd acbc_app && . .venv/bin/activate && ENVIRONMENT=DEVELOPMENT \
  python manage.py test profiles.tests.NotificationTests certificates.tests -v 1
```

21 NotificationTests + certificate tests: OK.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-827b523b-f845-4c7d-a7dd-dcd7b6792d54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-827b523b-f845-4c7d-a7dd-dcd7b6792d54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

